### PR TITLE
Make cluster agent reconnect backoff configurable (SURE-8745)

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -306,6 +306,19 @@ func run(ctx context.Context) error {
 	}
 }
 
+// retryDurationFromEnv parses a duration; unset or invalid values yield def.
+func retryDurationFromEnv(key string, def time.Duration) time.Duration {
+	v := os.Getenv(key)
+	d, err := time.ParseDuration(v)
+	if v != "" && err != nil {
+		logrus.Warnf("Ignoring %s=%q, want a duration like 30s or 5m", key, v)
+	}
+	if d <= 0 {
+		return def
+	}
+	return d
+}
+
 func exitCertWriter(ctx context.Context) {
 	// share-mnt process needs an always restart policy and to be killed so it can restart on startup
 	// this functionality is really only needed for OSes with ephemeral /etc like RancherOS

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -291,7 +291,7 @@ func run(ctx context.Context) error {
 		}
 
 		logrus.Infof("Connecting to %s with token starting with %s", wsURL, token[:len(token)/2])
-		remotedialer.ClientConnect(ctx, wsURL, headers, nil, func(proto, address string) bool {
+		remotedialer.ClientConnectWithOpts(ctx, wsURL, headers, nil, func(proto, address string) bool {
 			switch proto {
 			case "tcp":
 				return true
@@ -301,7 +301,11 @@ func run(ctx context.Context) error {
 				return address == "//./pipe/docker_engine"
 			}
 			return false
-		}, onConnect)
+		}, onConnect, &remotedialer.ConnectOpts{Backoff: remotedialer.Backoff{
+			Min: retryDurationFromEnv("CATTLE_CONNECT_RETRY_MIN", 10*time.Second),
+			Max: retryDurationFromEnv("CATTLE_CONNECT_RETRY_MAX", 0),
+		}})
+		// Only reached once the context is cancelled.
 		time.Sleep(5 * time.Second)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -434,3 +434,5 @@ require (
 	sigs.k8s.io/kustomize/api v0.21.1 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.21.1 // indirect
 )
+
+replace github.com/rancher/remotedialer => github.com/rohitsuse/remotedialer v0.4.2-0.20260820214538-cfab00138c5a

--- a/go.sum
+++ b/go.sum
@@ -653,8 +653,6 @@ github.com/rancher/muchang v0.1.1 h1:2UJ7FPn+DZKspmqioWQpGb/DvotKFJZdFrV961ZPHdU
 github.com/rancher/muchang v0.1.1/go.mod h1:dd9VsmzezLmgriZdgoWYqRmFPhfQlDE9+wABNYvLB0Y=
 github.com/rancher/norman v0.10.0 h1:vBIp5gNHelyS64IAs6FONPUfv0VTYWiMSrEbDS2l+hM=
 github.com/rancher/norman v0.10.0/go.mod h1:ExdLbr95m15PLbzQRrCVjGf8ah6kAVcttk484HSI9cM=
-github.com/rancher/remotedialer v0.6.1 h1:smq2sHKJn+NxxIeQ8To9CGGkz8l6Ir7EPzfAdjUTt2s=
-github.com/rancher/remotedialer v0.6.1/go.mod h1:0+dmsw9TPjcqNUPrgAVFZpvbxy1r/fRaGPpVa84OMjU=
 github.com/rancher/remotedialer-proxy v0.8.0 h1:PYKBT1i9HVu0AX7jKjUxNz3EuXVo0jkdWBcvS63RT4s=
 github.com/rancher/remotedialer-proxy v0.8.0/go.mod h1:VTxB4I+jt2dJBncXGtJ6Df5hK19XWS1Wr1AYR8p8y/o=
 github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHRkGaJ5v0=
@@ -687,6 +685,8 @@ github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzG
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/rohitsuse/remotedialer v0.4.2-0.20260820214538-cfab00138c5a h1:uvwpJMZXmkVk8mU8POP4Iir2/MHOHkCm6bhOzTkk/Ak=
+github.com/rohitsuse/remotedialer v0.4.2-0.20260820214538-cfab00138c5a/go.mod h1:GABgSIZBfWxeKuzXSz+XMHhYuRtC59TqfkjICIydGGA=
 github.com/rubenv/sql-migrate v1.8.1 h1:EPNwCvjAowHI3TnZ+4fQu3a915OpnQoPAjTXCGOy2U0=
 github.com/rubenv/sql-migrate v1.8.1/go.mod h1:BTIKBORjzyxZDS6dzoiw6eAFYJ1iNlGAtjn4LGeVjS8=
 github.com/russellhaering/goxmldsig v1.6.1 h1:SB7R5ttvrGIDB2juJAK/i7DQ2Ivr7agG+ohfNJjwyYU=


### PR DESCRIPTION
- Agent retried every 10s forever; a 2h outage burns ~720 doomed TLS handshakes.
- Adds `CATTLE_CONNECT_RETRY_MIN` and `CATTLE_CONNECT_RETRY_MAX`, settable per cluster via `agentEnvVars`.
- Setting only MIN keeps a fixed interval; adding MAX makes the delay double up to it.
- Unset or invalid values keep the existing 10s interval, so current clusters are unchanged.
- Blocked on rancher/remotedialer#281; the `go.mod` replace must be dropped before merge.

Refs: SURE-8745, #56746