### PR TITLE
Annotate pinned action versions

### DIFF
--- a/.github/actions/build-images/agent/action.yml
+++ b/.github/actions/build-images/agent/action.yml
@@ -16,20 +16,20 @@ runs:
       uses: ./.github/actions/setup-tag-env
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         images: ${{ github.repository_owner }}/rancher
         flavor: |
           latest=false
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       with:
         driver-opts: network=host
     - name: Build agent
       id: build
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         push: false
         build-args: |
@@ -45,7 +45,7 @@ runs:
         no-cache: true
         target: "agent"
     - name: Upload image
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "rancher-agent-${{ env.OS }}-${{ env.ARCH }}"
         path: /tmp/rancher-agent-${{ env.OS }}-${{ env.ARCH }}.tar

--- a/.github/actions/build-images/installer/action.yml
+++ b/.github/actions/build-images/installer/action.yml
@@ -13,24 +13,24 @@ runs:
       uses: ./.github/actions/setup-tag-env
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/system-agent-installer-rancher
         flavor: |
           latest=false
     - name: Login to Docker Registry
-      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ env.DOCKER_USERNAME }}
         password: ${{ env.DOCKER_PASSWORD }}
         registry: ${{ env.REGISTRY }}
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     - name: Build and export agent
       id: build
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         push:  true
         build-args: |

--- a/.github/actions/build-images/server/action.yml
+++ b/.github/actions/build-images/server/action.yml
@@ -16,18 +16,18 @@ runs:
       uses: ./.github/actions/setup-build-env
     - name: Docker meta
       id: meta
-      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+      uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
       with:
         images: ${{ github.repository_owner }}/rancher
         flavor: |
           latest=false
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
     - name: Build and export server
       id: build
-      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+      uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
       with:
         push: false
         build-args: |
@@ -43,7 +43,7 @@ runs:
         no-cache: true
         target: "server"
     - name: Upload image
-      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: "rancher-${{ env.OS }}-${{ env.ARCH }}"
         path: /tmp/rancher-${{ env.OS }}-${{ env.ARCH }}.tar

--- a/.github/actions/images-files/generate/action.yml
+++ b/.github/actions/images-files/generate/action.yml
@@ -11,7 +11,7 @@ runs:
     - id: env
       name: Setup Dependencies Env Variables
       uses: ./.github/actions/setup-build-env
-    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
+    - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
       with:
         go-version: '${{ steps.env.outputs.GO_VERSION }}'
         cache: false

--- a/.github/actions/push-images/action.yml
+++ b/.github/actions/push-images/action.yml
@@ -10,7 +10,7 @@ runs:
           echo "ARCH=amd64" >> $GITHUB_ENV
         fi
     - name: Download rancher image
-      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         pattern: "*-${{ env.OS }}-${{ env.ARCH }}"
         path: /tmp
@@ -18,7 +18,7 @@ runs:
     - name: Setup Environment Variables
       uses: ./.github/actions/setup-tag-env
     - name: Docker Registry Login
-      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
       with:
         username: ${{ env.DOCKER_USERNAME }}
         password: ${{ env.DOCKER_PASSWORD }}

--- a/.github/actions/rancher-chart/publish-gcp/action.yml
+++ b/.github/actions/rancher-chart/publish-gcp/action.yml
@@ -4,11 +4,11 @@ runs:
   using: "composite"
   steps:
     - name: Authenticate with Google Cloud
-      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
+      uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
       with:
         credentials_json: ${{ env.GOOGLE_AUTH }}
     - name: Upload
-      uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3
+      uses: google-github-actions/upload-cloud-storage@6397bd7208e18d13ba2619ee21b9873edc94427a # v3.0.0
       with:
         destination: releases.rancher.com/server-charts
         path: ./bin/chart

--- a/.github/workflows/nightly-provisioning-tests.yml
+++ b/.github/workflows/nightly-provisioning-tests.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Verify installer Dockerfile build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./package/Dockerfile.installer

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -111,7 +111,7 @@ jobs:
           path: "/tmp/report-${{ matrix.V2PROV_TEST_DIST }}-${{ steps.test_output.outputs.suite }}.*"
       - name: Upload logdump artifact if we had some tests failures
         if: failure()
-        uses: rancherlabs/cowboy@61de86d99456805424f9af0dadfcf362413cd745
+        uses: rancherlabs/cowboy@61de86d99456805424f9af0dadfcf362413cd745 # v0.0.2
         with:
           log-file-path: provtest_output.txt
           artifact-retention-days: 7

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Verify installer Dockerfile build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ./package/Dockerfile.installer


### PR DESCRIPTION
Record exact semver tags for immutable GitHub Action digests.

This helps among others Renovate to do better version matching for Github Action.