### PR TITLE
Optimize Renovate auto-approve action

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -12,6 +12,10 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: renovate-auto-approve-${{ github.repository }}
+  cancel-in-progress: true
+
 permissions: {}
 
 jobs:
@@ -41,15 +45,34 @@ jobs:
 
           today=$(date -u +%F)
           eligible_prs=()
+          if ! pr_list_json=$(gh pr list --repo "$REPO" --state open \
+            --author "$RENOVATE_BOT_USERNAME" \
+            --limit 100 \
+            --json number,state,body,autoMergeRequest,headRepository,headRefName,author,createdAt \
+            --jq 'sort_by(.createdAt)[] | @json'); then
+            echo "Failed to get open Renovate PRs from $REPO."
+            exit 1
+          fi
+
+          if [[ -z "$pr_list_json" ]]; then
+            echo "No open Renovate PRs to review."
+            printf 'eligible_prs=\n' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           while IFS= read -r pr_json; do
             pr_number=$(jq -r '.number' <<<"$pr_json")
             head_ref=$(jq -r '.headRefName' <<<"$pr_json")
+            pr_body=$(jq -r '.body // ""' <<<"$pr_json")
 
             if [[ $(jq -r '.state' <<<"$pr_json") != "OPEN" ||
                   $(jq -r '.autoMergeRequest' <<<"$pr_json") == "null" ||
                   $(jq -r '.headRepository.nameWithOwner' <<<"$pr_json") != "$REPO" ||
                   $(jq -r '.author.login' <<<"$pr_json") != "$RENOVATE_BOT_USERNAME" ||
                   "$head_ref" != renovate/* ]]; then
+              continue
+            fi
+            if ! [[ "$pr_body" =~ \*\*[[:space:]]*Automerge[[:space:]]*\*\*[[:space:]]*:[[:space:]]*Enabled[[:space:]]*\.? ]]; then
               continue
             fi
 
@@ -76,10 +99,7 @@ jobs:
             fi
 
             eligible_prs+=("$pr_number")
-          done < <(gh pr list --repo "$REPO" --state open \
-            --author "$RENOVATE_BOT_USERNAME" \
-            --json number,state,autoMergeRequest,headRepository,headRefName,author,createdAt \
-            --jq '.[] | @json')
+          done <<<"$pr_list_json"
 
           printf 'eligible_prs=%s\n' "${eligible_prs[*]}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Handle empty and failed Renovate PR lookups, process PRs oldest first, and require the explicit automerge marker before approval.

Incorporate Copilot feedback from #56303