### PR TITLE
Bind config.ClusterRegistry to CLI flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -179,6 +179,12 @@ func main() {
 			Usage:       "Configuration for rancher namespace labels and annotations",
 			Destination: &config.RancherNamespaceOptions,
 		},
+		cli.StringFlag{
+			Name:        "registry-override",
+			EnvVar:      "RANCHER_REGISTRY_OVERRIDE",
+			Usage:       "Override the default registry used for system chart installs.",
+			Destination: &config.ClusterRegistry,
+		},
 	}
 
 	app.Action = func(c *cli.Context) error {


### PR DESCRIPTION
Binds the existing `ClusterRegistry` property on the config struct to a cli flag / env var.  In rancher server isnt bound or set, and therefore has no effect. In agent mode it is set to the value of `CATTLE_SYSTEM_DEFAULT_REGISTRY`..

This change means the system-chart installs can utilise a pull through cache registry. Setting `CATTLE_SYSTEM_DEFAULT_REGISTRY` on the server achieves the same result, however it causes downstream clusters to inherit the setting which can cause issues if set to a registry the downstream cannot access.