### PR TITLE
[main] Add more files and paths to provisioning test scopes

### DIFF
--- a/.github/scripts/provisioning-test-scopes.yaml
+++ b/.github/scripts/provisioning-test-scopes.yaml
@@ -178,6 +178,7 @@ full:
   - '^tests/v2prov/(clients|cluster|defaults|namespace|nodeconfig|objectstore|operations|registry|systemdnode|utils|wait)/' # framework (everything under tests/v2prov except 'tests/'. Individual tests are included in more specific scopes above)
   - '^scripts/provisioning-tests$'                    # the runner
   - '^\.github/workflows/provisioning-tests\.ya?ml$'
+  - '^trigger_ci$' # created by the 'Create CI Testing PR' workflow
 
 # Mainly here for documentation, these directories are provisioning related but don't
 # actually have any existing test coverage in the provv2 test suite. They're listed here

--- a/.github/scripts/provisioning-test-scopes.yaml
+++ b/.github/scripts/provisioning-test-scopes.yaml
@@ -97,6 +97,21 @@ scopes:
       - '^tests/v2prov/tests/fleet/'
       - '^tests/v2prov/tests/autoscaler/'
     file-paths:
+      - path: "^go.mod$"
+        substrings:
+          - 'github.com/rancher/wrangler'
+          - 'github.com/rancher/lasso'
+          - 'github.com/k3s'
+          - 'github.com/rancher/dynamiclistener'
+          - 'github.com/rancher/remotedialer'
+          - 'github.com/rancher/fleet'
+          - 'github.com/rancher/machine'
+          - 'github.com/rancher/remotedialer-proxy'
+          - 'github.com/rancher/steve'
+          - 'github.com/stretchr/testify'
+      - path: "^pkg/apis/go.mod$"
+        substrings:
+            - 'github.com/rancher/norman'
       - path: '^build.yaml'
         substrings:
           - 'turtlesVersion:'
@@ -163,6 +178,15 @@ scopes:
 #      - { dist: rke2,  regex: '^Test_Imported_Operation_(SetE_Imported|SetD_.*LifecycleHook).*$' }
 
 full:
+  - path: '^go.mod$'
+    substrings:
+      - 'github.com/rancher/cluster-api-provider-rke2'
+      - 'k8s.io/' # all kubernetes dependencies
+      - 'sigs.k8s.io/'
+  - path: '^pkg/apis/go.mod$'
+    substrings:
+      - 'k8s.io/'
+      - 'sigs.k8s.io/'
   - '^pkg/controllers/capr/controllers.go'
   - '^pkg/controllers/provisioningv2/controllers.go'
   - '^pkg/capr/planner/'

--- a/.github/scripts/resolve-provisioning-matrix.sh
+++ b/.github/scripts/resolve-provisioning-matrix.sh
@@ -63,7 +63,38 @@ scope_matches() {
     return 0
   fi
 
-  list_matches ".scopes.$scope.package-paths" "$scope" "$CHANGED"
+  # These files already had their chance to trigger the scope above and didn't, so they're
+  # removed from the pool before checking package-paths.
+  local claimed remaining
+  claimed="$(files_matching_file_paths ".scopes.$scope.file-paths" "$CHANGED")"
+  remaining="$(exclude_files "$CHANGED" "$claimed")"
+
+  list_matches ".scopes.$scope.package-paths" "$scope" "$remaining"
+}
+
+# files_matching_file_paths prints every changed file that matches the path regex of any entry in
+# the given file-paths list, regardless of whether its substring check passed.
+files_matching_file_paths() {
+  local yq_path="$1"
+  local files_pool="$2"
+  local n i path
+
+  n="$(yq "($yq_path // []) | length" "$CONFIG")"
+  for ((i = 0; i < n; i++)); do
+    path="$(yq "$yq_path[$i] | (.path // .)" "$CONFIG")"
+    test -n "$path" || continue
+    printf '%s\n' "$files_pool" | grep -E "$path" || true
+  done
+}
+
+# exclude_files prints every line of files_pool that isn't also a line in exclude_list.
+exclude_files() {
+  local files_pool="$1"
+  local exclude_list="$2"
+
+  test -n "$exclude_list" || { printf '%s\n' "$files_pool"; return; }
+
+  printf '%s\n' "$files_pool" | grep -vFxf <(printf '%s\n' "$exclude_list") || true
 }
 
 # list_matches iterates over the list of file-paths or package-paths for a given scope,


### PR DESCRIPTION
'Create CI Testing PR' workflow creates an empty `trigger_ci` file to simulate a real pull request. The recent changes to the provisioning tests CI don't watch that file, so they are skipped, making the workflow redundant. This PR adds back its special file so that all tests are run in response to that workflow 

This PR also adds rules for `go.mod` and `pkg/apis/go.mod`, to make sure we run provisioning tests when core dependencies are bumped. 

Finally, this PR adds a fix for changed files which are listed in file paths, but share a prefix with an entry in package paths. In this case, any substring rules of the file-path should be the exclusive trigger for that file, and it should not fall back to the package path definition. Doing so would always trigger that test scope, even if none of the lines we're interested in were changed 