### PR TITLE
Use main branch for Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>rancher/renovate-config//rancher-main#release"
+    "github>rancher/renovate-config//rancher-main#main"
   ],
   "baseBranchPatterns": [
     "main",
@@ -22,7 +22,7 @@
         "release/v2.15"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.15#release"
+        "github>rancher/renovate-config//rancher-2.15#main"
       ]
     },
     {
@@ -30,7 +30,7 @@
         "release/v2.14"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.14#release"
+        "github>rancher/renovate-config//rancher-2.14#main"
       ]
     },
     {
@@ -38,7 +38,7 @@
         "release/v2.13"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.13#release"
+        "github>rancher/renovate-config//rancher-2.13#main"
       ]
     },
     {
@@ -46,7 +46,7 @@
         "release/v2.12"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.12#release"
+        "github>rancher/renovate-config//rancher-2.12#main"
       ]
     },
     {
@@ -54,7 +54,7 @@
         "release/v2.11"
       ],
       "extends": [
-        "github>rancher/renovate-config//rancher-2.11#release"
+        "github>rancher/renovate-config//rancher-2.11#main"
       ]
     },
     {


### PR DESCRIPTION
Early adopt renovate-config changes before they move from main to release.