### PR TITLE
[Backport v2.14] cluster assertion storage

### DIFF
--- a/pkg/auth/providers/providers.go
+++ b/pkg/auth/providers/providers.go
@@ -104,27 +104,27 @@ func Configure(ctx context.Context, mgmt *config.ScaledContext) {
 	ProviderNames[ldap.FreeIpaName] = true
 	Providers[ldap.FreeIpaName] = p
 
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.PingName)
+	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.PingName)
 	ProviderNames[saml.PingName] = true
 	UnrefreshableProviders[saml.PingName] = true
 	Providers[saml.PingName] = p
 
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.ADFSName)
+	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.ADFSName)
 	ProviderNames[saml.ADFSName] = true
 	UnrefreshableProviders[saml.ADFSName] = true
 	Providers[saml.ADFSName] = p
 
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.KeyCloakName)
+	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.KeyCloakName)
 	ProviderNames[saml.KeyCloakName] = true
 	UnrefreshableProviders[saml.KeyCloakName] = true
 	Providers[saml.KeyCloakName] = p
 
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.OKTAName)
+	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.OKTAName)
 	ProviderNames[saml.OKTAName] = true
 	UnrefreshableProviders[saml.OKTAName] = true
 	Providers[saml.OKTAName] = p
 
-	p = saml.Configure(mgmt, userMGR, tokenMGR, saml.ShibbolethName)
+	p = saml.Configure(ctx, mgmt, userMGR, tokenMGR, saml.ShibbolethName)
 	ProviderNames[saml.ShibbolethName] = true
 	UnrefreshableProviders[saml.ShibbolethName] = false
 	Providers[saml.ShibbolethName] = p

--- a/pkg/auth/providers/saml/saml_client.go
+++ b/pkg/auth/providers/saml/saml_client.go
@@ -407,7 +407,14 @@ func (s *Provider) HandleSamlAssertion(w http.ResponseWriter, r *http.Request, a
 	if assertion.Conditions != nil && !assertion.Conditions.NotOnOrAfter.IsZero() {
 		assertionExpiry = assertion.Conditions.NotOnOrAfter
 	}
-	if s.assertionCache.seen(assertion.ID, assertionExpiry) {
+	seen, err := s.assertionStore.seen(assertion.ID, assertionExpiry)
+	if err != nil {
+		log.Errorf("SAML: failed to lookup assertion ID %q: %v", assertion.ID, err)
+		http.Redirect(w, r, redirectURL+"errorCode=500", http.StatusFound)
+		return
+	}
+
+	if seen {
 		log.Errorf("SAML: Rejected previous assertion ID %q", assertion.ID)
 		http.Redirect(w, r, redirectURL+"errorCode=403", http.StatusFound)
 		return
@@ -686,41 +693,7 @@ func checkAssertionTimeConditions(now time.Time, conditions *saml.Conditions) er
 	return nil
 }
 
-// assertionCache tracks recently seen SAML assertion IDs to prevent replay attacks.
-type assertionCache struct {
-	mu      sync.Mutex
-	entries map[string]time.Time // assertion ID -> expiry time
-}
-
-func newAssertionCache() *assertionCache {
-	return &assertionCache{
-		entries: make(map[string]time.Time),
-	}
-}
-
-// seen returns true if the assertion ID was seen before.
-//
-// If not seen, it records the ID with its expiry time and returns false.
-// Expired entries are evicted lazily on each call.
-func (c *assertionCache) seen(id string, expiry time.Time) bool {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.evict()
-	if _, ok := c.entries[id]; ok {
-		return true
-	}
-	c.entries[id] = expiry
-	return false
-}
-
-// evict removes expired entries.
-//
-// Must be called with c.mu held.
-func (c *assertionCache) evict() {
-	now := time.Now()
-	for id, exp := range c.entries {
-		if now.After(exp) {
-			delete(c.entries, id)
-		}
-	}
+type assertionStore interface {
+	// seen returns true if the assertion ID was seen before.
+	seen(id string, expiry time.Time) (bool, error)
 }

--- a/pkg/auth/providers/saml/saml_client_test.go
+++ b/pkg/auth/providers/saml/saml_client_test.go
@@ -194,63 +194,6 @@ func TestValidateFinalRedirectURL(t *testing.T) {
 	}
 }
 
-func TestAssertionCache(t *testing.T) {
-	t.Parallel()
-
-	t.Run("new ID is not seen", func(t *testing.T) {
-		t.Parallel()
-		c := newAssertionCache()
-		expiry := time.Now().Add(time.Minute)
-		assert.False(t, c.seen("id-1", expiry))
-	})
-
-	t.Run("same ID seen twice", func(t *testing.T) {
-		t.Parallel()
-		c := newAssertionCache()
-		expiry := time.Now().Add(time.Minute)
-		assert.False(t, c.seen("id-replay", expiry))
-		assert.True(t, c.seen("id-replay", expiry))
-	})
-
-	t.Run("different IDs are tracked independently", func(t *testing.T) {
-		t.Parallel()
-		c := newAssertionCache()
-		expiry := time.Now().Add(time.Minute)
-		assert.False(t, c.seen("id-a", expiry))
-		assert.False(t, c.seen("id-b", expiry))
-		assert.True(t, c.seen("id-a", expiry))
-		assert.True(t, c.seen("id-b", expiry))
-	})
-
-	t.Run("expired ID is evicted and accepted again", func(t *testing.T) {
-		t.Parallel()
-		c := newAssertionCache()
-		// Insert with an already-expired time.
-		pastExpiry := time.Now().Add(-time.Second)
-		assert.False(t, c.seen("id-expired", pastExpiry))
-
-		// The entry is expired; the next call should evict it and accept a fresh one.
-		futureExpiry := time.Now().Add(time.Minute)
-		assert.False(t, c.seen("id-expired", futureExpiry))
-	})
-
-	t.Run("eviction does not remove live entries", func(t *testing.T) {
-		t.Parallel()
-		c := newAssertionCache()
-		liveExpiry := time.Now().Add(time.Minute)
-		pastExpiry := time.Now().Add(-time.Second)
-
-		assert.False(t, c.seen("id-live", liveExpiry))
-		assert.False(t, c.seen("id-stale", pastExpiry))
-
-		// Trigger eviction via any seen() call.
-		assert.False(t, c.seen("id-new", liveExpiry))
-
-		// The live entry must still be detected as a replay.
-		assert.True(t, c.seen("id-live", liveExpiry))
-	})
-}
-
 func TestCheckAssertionTimeConditions(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/auth/providers/saml/saml_id_store.go
+++ b/pkg/auth/providers/saml/saml_id_store.go
@@ -1,0 +1,126 @@
+package saml
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+)
+
+const (
+	samlClientCacheNamespace = "cattle-system"
+	samlClientCacheName      = "saml-client-ids"
+)
+
+var configMapLabels = map[string]string{
+	"authz.management.cattle.io/provider": "saml",
+}
+
+var _ assertionStore = (*configMapAssertionStore)(nil)
+
+type configMapInterface interface {
+	Create(*corev1.ConfigMap) (*corev1.ConfigMap, error)
+	Get(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error)
+	Delete(namespace, name string, options *metav1.DeleteOptions) error
+}
+
+type configMapCacheInterface interface {
+	List(namespace string, selector labels.Selector) ([]*corev1.ConfigMap, error)
+}
+
+type configMapAssertionStore struct {
+	mu             sync.Mutex
+	configMaps     configMapInterface
+	configMapCache configMapCacheInterface
+}
+
+// seen creates a per-assertion ConfigMap on first use and detects replays by its existence.
+// Expiry is stored in the ConfigMap so stale entries are cleaned up lazily after process restarts.
+func (s *configMapAssertionStore) seen(id string, expiry time.Time) (bool, error) {
+	name := assertionConfigMapName(id)
+	cm := &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "ConfigMap"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: samlClientCacheNamespace,
+			Labels:    configMapLabels,
+		},
+		Data: map[string]string{
+			"expiry": strconv.FormatInt(expiry.Unix(), 10),
+		},
+	}
+	const maxRetries = 3
+	for range maxRetries {
+		_, err := s.configMaps.Create(cm)
+		if err == nil {
+			return false, nil
+		}
+		if !apierrors.IsAlreadyExists(err) {
+			return true, err
+		}
+
+		// If the ConfigMap already exists, check if it's expired.
+		existing, err := s.configMaps.Get(samlClientCacheNamespace, name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			// Deleted between Create and Get; retry.
+			continue
+		}
+		if err != nil {
+			return true, err
+		}
+		if n, parseErr := strconv.ParseInt(existing.Data["expiry"], 10, 64); parseErr == nil && n <= time.Now().Unix() {
+			return false, nil
+		}
+		return true, nil
+	}
+
+	return true, fmt.Errorf("recording SAML assertion: too many retries")
+}
+
+func (s *configMapAssertionStore) cleanUpExpiredAssertionIDs(ctx context.Context, c <-chan time.Time) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-c:
+			s.mu.Lock()
+			configMaps, err := s.configMapCache.List(samlClientCacheNamespace, labels.SelectorFromSet(configMapLabels))
+			if err != nil {
+				logrus.Errorf("[SAML provider] error listing config maps: %v", err)
+				s.mu.Unlock()
+				continue
+			}
+
+			for _, configMap := range configMaps {
+				logrus.Debugf("[SAML provider] checking config map %s for expiry", configMap.Name)
+				if expiry, parseErr := strconv.ParseInt(configMap.Data["expiry"], 10, 64); parseErr == nil && expiry <= time.Now().Unix() {
+					logrus.Debugf("[SAML provider] deleting expired config map %s", configMap.Name)
+					err := s.configMaps.Delete(samlClientCacheNamespace, configMap.Name, &metav1.DeleteOptions{})
+					if err != nil {
+						logrus.Errorf("[SAML provider] error deleting config map: %v", err)
+					}
+				}
+			}
+			s.mu.Unlock()
+		}
+	}
+}
+
+// assertionConfigMapName returns a deterministic, DNS-safe ConfigMap name for an assertion ID.
+func assertionConfigMapName(id string) string {
+	h := sha256.Sum256([]byte(id))
+	return "saml-assertion-" + hex.EncodeToString(h[:16])
+}
+
+func newConfigMapIDStore(configMaps configMapInterface, cache configMapCacheInterface) *configMapAssertionStore {
+	return &configMapAssertionStore{configMaps: configMaps, configMapCache: cache}
+}

--- a/pkg/auth/providers/saml/saml_id_store_test.go
+++ b/pkg/auth/providers/saml/saml_id_store_test.go
@@ -1,0 +1,268 @@
+package saml
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestPerAssertionStorage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("new ID is not seen", func(t *testing.T) {
+		t.Parallel()
+		store := newConfigMapIDStore(newFakeConfigMapClient(), nil)
+
+		seen, err := store.seen("id-1", time.Now().Add(time.Minute))
+		require.NoError(t, err)
+		assert.False(t, seen)
+	})
+
+	t.Run("same ID seen twice is a replay", func(t *testing.T) {
+		t.Parallel()
+		store := newConfigMapIDStore(newFakeConfigMapClient(), nil)
+		expiry := time.Now().Add(time.Minute)
+
+		seen, err := store.seen("id-replay", expiry)
+		require.NoError(t, err)
+		assert.False(t, seen)
+
+		seen, err = store.seen("id-replay", expiry)
+		require.NoError(t, err)
+		assert.True(t, seen)
+	})
+
+	t.Run("different IDs are tracked independently", func(t *testing.T) {
+		t.Parallel()
+		store := newConfigMapIDStore(newFakeConfigMapClient(), nil)
+		expiry := time.Now().Add(time.Minute)
+
+		seen, err := store.seen("id-a", expiry)
+		require.NoError(t, err)
+		assert.False(t, seen)
+
+		seen, err = store.seen("id-b", expiry)
+		require.NoError(t, err)
+		assert.False(t, seen)
+
+		seen, err = store.seen("id-a", expiry)
+		require.NoError(t, err)
+		assert.True(t, seen)
+
+		seen, err = store.seen("id-b", expiry)
+		require.NoError(t, err)
+		assert.True(t, seen)
+	})
+
+	t.Run("each assertion gets its own ConfigMap", func(t *testing.T) {
+		t.Parallel()
+		fake := newFakeConfigMapClient()
+		store := newConfigMapIDStore(fake, nil)
+		expiry := time.Now().Add(time.Minute)
+
+		store.seen("id-x", expiry) //nolint:errcheck
+		store.seen("id-y", expiry) //nolint:errcheck
+
+		fake.mu.Lock()
+		count := len(fake.configMaps)
+		fake.mu.Unlock()
+		assert.Equal(t, 2, count)
+	})
+
+	t.Run("expired entry left by a previous process run is replaced, not a replay", func(t *testing.T) {
+		t.Parallel()
+		fake := newFakeConfigMapClient()
+		store := newConfigMapIDStore(fake, nil)
+
+		// Record an assertion with an already-past expiry.
+		seen, err := store.seen("id-stale", time.Now().Add(-time.Second))
+		require.NoError(t, err)
+		assert.False(t, seen)
+
+		// Simulate a restart: create a new store backed by the same storage.
+		store2 := newConfigMapIDStore(fake, nil)
+
+		// The expiry stored in the ConfigMap has passed; should clean up and treat as fresh.
+		seen, err = store2.seen("id-stale", time.Now().Add(time.Minute))
+		require.NoError(t, err)
+		assert.False(t, seen)
+	})
+
+	t.Run("non-expired assertion survives a process restart", func(t *testing.T) {
+		t.Parallel()
+		fake := newFakeConfigMapClient()
+		expiry := time.Now().Add(time.Minute)
+
+		seen, err := newConfigMapIDStore(fake, nil).seen("id-persistent", expiry)
+		require.NoError(t, err)
+		assert.False(t, seen)
+
+		// Simulate restart: new store instance, same backing storage.
+		seen, err = newConfigMapIDStore(fake, nil).seen("id-persistent", expiry)
+		require.NoError(t, err)
+		assert.True(t, seen)
+	})
+}
+
+func TestCleanUpExpiredAssertionIDs(t *testing.T) {
+	now := time.Now()
+
+	expiredConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "saml-assertion-expired", Namespace: "cattle-system",
+			Labels: configMapLabels,
+		},
+		Data: map[string]string{
+			"expiry": strconv.FormatInt(now.Add(-time.Minute).Unix(), 10),
+		},
+	}
+	liveConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "saml-assertion-live", Namespace: "cattle-system",
+			Labels: configMapLabels,
+		},
+		Data: map[string]string{
+			"expiry": strconv.FormatInt(now.Add(time.Minute).Unix(), 10),
+		},
+	}
+	nonAssertionConfigMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "saml-assertion-non-assertion", Namespace: "cattle-system",
+		},
+		Data: map[string]string{
+			"some": "value",
+		},
+	}
+
+	tests := map[string]struct {
+		configMaps     []*corev1.ConfigMap
+		wantConfigMaps map[string]*corev1.ConfigMap
+	}{
+		"remove expired sessions": {
+			configMaps:     []*corev1.ConfigMap{expiredConfigMap},
+			wantConfigMaps: map[string]*corev1.ConfigMap{},
+		},
+		"remove only expired session": {
+			configMaps: []*corev1.ConfigMap{expiredConfigMap, liveConfigMap},
+			wantConfigMaps: map[string]*corev1.ConfigMap{
+				"cattle-system/saml-assertion-live": liveConfigMap,
+			},
+		},
+		"ignores non-assertion config maps": {
+			configMaps: []*corev1.ConfigMap{expiredConfigMap, liveConfigMap, nonAssertionConfigMap},
+			wantConfigMaps: map[string]*corev1.ConfigMap{
+				"cattle-system/saml-assertion-live":          liveConfigMap,
+				"cattle-system/saml-assertion-non-assertion": nonAssertionConfigMap,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			fakeClient := newFakeConfigMapClient(tt.configMaps...)
+			storage := newConfigMapIDStore(fakeClient, &fakeConfigMapCache{configMaps: tt.configMaps})
+			ctx, cancel := context.WithCancel(t.Context())
+			c := make(chan time.Time)
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				storage.cleanUpExpiredAssertionIDs(ctx, c)
+			}()
+
+			c <- time.Unix(0, 0)
+			cancel()
+			wg.Wait()
+
+			assert.Equal(t, tt.wantConfigMaps, fakeClient.configMaps)
+		})
+	}
+}
+
+func newFakeConfigMapClient(configmaps ...*corev1.ConfigMap) *fakeConfigMapClient {
+	c := &fakeConfigMapClient{
+		configMaps: make(map[string]*corev1.ConfigMap),
+	}
+
+	for _, cm := range configmaps {
+		c.configMaps[cm.Namespace+"/"+cm.Name] = cm.DeepCopy()
+	}
+
+	return c
+}
+
+type fakeConfigMapClient struct {
+	mu         sync.Mutex
+	configMaps map[string]*corev1.ConfigMap
+	afterGet   func() // called after Get, outside mutex
+}
+
+func (f *fakeConfigMapClient) Create(cm *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.configMaps[cm.Namespace+"/"+cm.Name] != nil {
+		return nil, apierrors.NewAlreadyExists(schema.GroupResource{Resource: "configmaps"}, cm.Name)
+	}
+	cm = cm.DeepCopy()
+	cm.ResourceVersion = "1"
+	f.configMaps[cm.Namespace+"/"+cm.Name] = cm
+
+	return cm, nil
+}
+
+func (f *fakeConfigMapClient) Get(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
+	f.mu.Lock()
+	cm, ok := f.configMaps[namespace+"/"+name]
+	f.mu.Unlock()
+	if f.afterGet != nil {
+		f.afterGet()
+	}
+	if !ok {
+		return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, name)
+	}
+
+	return cm, nil
+}
+
+func (f *fakeConfigMapClient) Delete(namespace, name string, options *metav1.DeleteOptions) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := namespace + "/" + name
+	if _, ok := f.configMaps[key]; !ok {
+		return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, name)
+	}
+	delete(f.configMaps, key)
+
+	return nil
+}
+
+type fakeConfigMapCache struct {
+	mu         sync.Mutex
+	configMaps []*corev1.ConfigMap
+}
+
+func (f *fakeConfigMapCache) List(namespace string, selector labels.Selector) ([]*corev1.ConfigMap, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+
+	var result []*corev1.ConfigMap
+	for _, cm := range f.configMaps {
+		if cm.Namespace == namespace && selector.Matches(labels.Set(cm.Labels)) {
+			result = append(result, cm)
+		}
+	}
+
+	return result, nil
+}

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -1,10 +1,12 @@
 package saml
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/crewjam/saml"
 	"github.com/pkg/errors"
@@ -52,27 +54,31 @@ type Provider struct {
 	sloEnabled      bool
 	sloForced       bool
 
-	assertionCache *assertionCache
+	assertionStore assertionStore
 }
 
 var SamlProviders = make(map[string]*Provider)
 
-func Configure(mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager, name string) common.AuthProvider {
+func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager, name string) common.AuthProvider {
 	provider := &Provider{
-		authConfigs:    mgmtCtx.Management.AuthConfigs(""),
-		secrets:        mgmtCtx.Wrangler.Core.Secret(),
-		samlTokens:     mgmtCtx.Management.SamlTokens(""),
-		userMGR:        userMGR,
-		tokenMGR:       tokenMGR,
-		name:           name,
-		userType:       name + "_user",
-		groupType:      name + "_group",
-		assertionCache: newAssertionCache(),
+		authConfigs: mgmtCtx.Management.AuthConfigs(""),
+		secrets:     mgmtCtx.Wrangler.Core.Secret(),
+		samlTokens:  mgmtCtx.Management.SamlTokens(""),
+		userMGR:     userMGR,
+		tokenMGR:    tokenMGR,
+		name:        name,
+		userType:    name + "_user",
+		groupType:   name + "_group",
 	}
 
 	if provider.hasLdapGroupSearch() {
 		provider.ldapProvider = ldap.Configure(mgmtCtx, userMGR, tokenMGR, name)
 	}
+
+	logrus.Debugf("SAML: Using ConfigMap assertion store for %v", name)
+	store := newConfigMapIDStore(mgmtCtx.Wrangler.Core.ConfigMap(), mgmtCtx.Wrangler.Core.ConfigMap().Cache())
+	provider.assertionStore = store
+	go store.cleanUpExpiredAssertionIDs(ctx, time.Tick(time.Minute))
 
 	SamlProviders[name] = provider
 	return provider

--- a/pkg/auth/providers/saml/saml_provider_test.go
+++ b/pkg/auth/providers/saml/saml_provider_test.go
@@ -1,7 +1,6 @@
 package saml
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -23,8 +22,9 @@ import (
 func TestConfiguredOktaProviderContainsLdapProvider(t *testing.T) {
 	// saml.Configure runs some ldap specific logic based on the saml provider name, so we provide
 	// just enough scaffolding to run the Configure function.
-	ctx := context.Background()
+	ctx := t.Context()
 	mgmtCtx, err := config.NewScaledContext(rest.Config{}, nil)
+	mgmtCtx.RunContext = ctx
 	require.NoError(t, err, "Failed to create NewScaledContext")
 
 	// Create the dummy wrangler context
@@ -33,7 +33,7 @@ func TestConfiguredOktaProviderContainsLdapProvider(t *testing.T) {
 	mgmtCtx.Wrangler = wranglerContext
 
 	tokenMGR := tokens.NewManager(wranglerContext)
-	provider, ok := Configure(mgmtCtx, mgmtCtx.UserManager, tokenMGR, "okta").(*Provider)
+	provider, ok := Configure(t.Context(), mgmtCtx, mgmtCtx.UserManager, tokenMGR, "okta").(*Provider)
 	require.True(t, ok, "Failed to Configure a valid Provider")
 
 	assert.True(t, provider.hasLdapGroupSearch(), "Missing LDAP group search capability for okta provider")


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
We need to store assertion IDs in-cluster to survive restarts etc.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This allows sharing the seen assertion IDs in-cluster rather than the in-memory store.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_