### PR TITLE
[backport v2.14] bypass new webhook validation for resource quota and limit range

### DIFF
--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -142,14 +142,9 @@ func Register(ctx context.Context, workload *config.UserContext) error {
 	management.Management.Clusters("").AddHandler(ctx, "global-admin-cluster-sync", newClusterHandler(workload))
 	management.Management.GlobalRoleBindings("").AddHandler(ctx, grbHandlerName, newGlobalRoleBindingHandler(workload))
 
-	sync := &resourcequota.SyncController{
-		Namespaces:          workload.Corew.Namespace(),
-		NsIndexer:           nsInformer.GetIndexer(),
-		ResourceQuotas:      workload.Corew.ResourceQuota(),
-		ResourceQuotaLister: workload.Corew.ResourceQuota().Cache(),
-		LimitRange:          workload.Corew.LimitRange(),
-		LimitRangeLister:    workload.Corew.LimitRange().Cache(),
-		ProjectCache:        management.Wrangler.Mgmt.Project().Cache(),
+	sync, err := resourcequota.NewSyncController(workload, nsInformer, management.Wrangler.Mgmt)
+	if err != nil {
+		return err
 	}
 
 	nsLifecycle := newNamespaceLifecycle(r, sync)

--- a/pkg/controllers/managementuser/resourcequota/register.go
+++ b/pkg/controllers/managementuser/resourcequota/register.go
@@ -41,15 +41,12 @@ func registerDeferred(ctx context.Context, cluster *config.UserContext) error {
 	if err := nsInformer.AddIndexers(nsIndexers); err != nil {
 		return err
 	}
-	sync := &SyncController{
-		Namespaces:          cluster.Corew.Namespace(),
-		NsIndexer:           nsInformer.GetIndexer(),
-		ResourceQuotas:      cluster.Corew.ResourceQuota(),
-		ResourceQuotaLister: cluster.Corew.ResourceQuota().Cache(),
-		LimitRange:          cluster.Corew.LimitRange(),
-		LimitRangeLister:    cluster.Corew.LimitRange().Cache(),
-		ProjectCache:        cluster.Management.Wrangler.Mgmt.Project().Cache(),
+
+	sync, err := NewSyncController(cluster, nsInformer, cluster.Management.Wrangler.Mgmt)
+	if err != nil {
+		return err
 	}
+
 	cluster.Corew.Namespace().OnChange(ctx, "resourceQuotaSyncController", sync.syncResourceQuota)
 
 	reconcile := &reconcileController{

--- a/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
+++ b/pkg/controllers/managementuser/resourcequota/resource_quota_sync.go
@@ -8,10 +8,12 @@ import (
 
 	"github.com/rancher/norman/types/convert"
 	v32 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/controllers"
 	wmgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	v1 "github.com/rancher/rancher/pkg/generated/norman/core/v1"
 	namespaceutil "github.com/rancher/rancher/pkg/namespace"
 	validate "github.com/rancher/rancher/pkg/resourcequota"
+	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/utils"
 	corew "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/sirupsen/logrus"
@@ -49,6 +51,36 @@ type SyncController struct {
 	LimitRange          corew.LimitRangeClient
 	LimitRangeLister    corew.LimitRangeCache
 	NsIndexer           clientcache.Indexer
+}
+
+func NewSyncController(
+	cluster *config.UserContext,
+	nsInformer clientcache.SharedIndexInformer,
+	mgmt wmgmtv3.Interface,
+) (*SyncController, error) {
+
+	rqClient := cluster.Corew.ResourceQuota()
+	resourceQuotaImpClient, err := rqClient.WithImpersonation(controllers.WebhookImpersonation())
+	if err != nil {
+		return nil, err
+	}
+
+	limitRangeImpClient, err := cluster.Corew.LimitRange().WithImpersonation(controllers.WebhookImpersonation())
+	if err != nil {
+		return nil, err
+	}
+
+	sync := &SyncController{
+		Namespaces:          cluster.Corew.Namespace(),
+		NsIndexer:           nsInformer.GetIndexer(),
+		ResourceQuotas:      resourceQuotaImpClient,
+		ResourceQuotaLister: cluster.Corew.ResourceQuota().Cache(),
+		LimitRange:          limitRangeImpClient,
+		LimitRangeLister:    cluster.Corew.LimitRange().Cache(),
+		ProjectCache:        mgmt.Project().Cache(),
+	}
+
+	return sync, nil
 }
 
 func (c *SyncController) syncResourceQuota(_ string, ns *corev1.Namespace) (*corev1.Namespace, error) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

#56774 

This PR is a backport of #56780
 
## Problem

Users are able to modify the rancher-managed resource quota resource in each namespace under rancher's control.
 
## Solution

On the rancher side, perform all quota and limit operations using an webhook by pass (sudo) client.
Extend the webhook with validators which recognize attempts to created, edit, delete, promote, demote the rancher-managed resource, and reject them. Due to the sudo client in r/r the validators will only see user-initiated ops, not rancher ops.

Companion: TDB r/webhook
 
## Testing

unit tests in r/webhook for the new validators

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_