### PR TITLE
Register the GlobalRoleBinding by GlobalRole index on all replicas

### DIFF
--- a/pkg/controllers/management/auth/globalroles/enqueue.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue.go
@@ -19,7 +19,6 @@ import (
 )
 
 const (
-	grbGrIndex                 = pkgrbac.GRBGlobalRoleIndex
 	grNsIndex                  = "mgmt-auth-gr-ns-index"
 	grSafeConcatIndex          = "mgmt-auth-gr-concat-index"
 	grbSafeConcatIndex         = "mgmt-auth-grb-concat-index"
@@ -74,7 +73,7 @@ func (g *globalRBACEnqueuer) enqueueGRBs(_, _ string, obj runtime.Object) ([]rel
 		logrus.Errorf("unable to convert object: %[1]v, type: %[1]T to a global role", obj)
 		return nil, nil
 	}
-	bindings, err := g.grbCache.GetByIndex(grbGrIndex, globalRole.Name)
+	bindings, err := g.grbCache.GetByIndex(pkgrbac.GRBGlobalRoleIndex, globalRole.Name)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get grbs for gr %s from indexer: %w", globalRole.Name, err)
 	}

--- a/pkg/controllers/management/auth/globalroles/enqueue.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue.go
@@ -6,6 +6,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/controllers/status"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	wrangler "github.com/rancher/wrangler/v3/pkg/name"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/sirupsen/logrus"
@@ -18,7 +19,7 @@ import (
 )
 
 const (
-	grbGrIndex                 = "mgmt-auth-grb-gr-idex"
+	grbGrIndex                 = pkgrbac.GRBGlobalRoleIndex
 	grNsIndex                  = "mgmt-auth-gr-ns-index"
 	grSafeConcatIndex          = "mgmt-auth-gr-concat-index"
 	grbSafeConcatIndex         = "mgmt-auth-grb-concat-index"

--- a/pkg/controllers/management/auth/globalroles/enqueue_test.go
+++ b/pkg/controllers/management/auth/globalroles/enqueue_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 	"github.com/stretchr/testify/assert"
@@ -128,7 +129,7 @@ func Test_enqueueGRBs(t *testing.T) {
 						UserName:       "u-123xyz",
 					},
 				}
-				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return(grbs, nil)
+				state.grbCacheMock.EXPECT().GetByIndex(pkgrbac.GRBGlobalRoleIndex, "test-gr").Return(grbs, nil)
 
 			},
 			wantKeys: []relatedresource.Key{{Name: "test-grb-1"}},
@@ -151,7 +152,7 @@ func Test_enqueueGRBs(t *testing.T) {
 						UserName:       "u-123xyz",
 					},
 				}
-				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return(grbs, nil)
+				state.grbCacheMock.EXPECT().GetByIndex(pkgrbac.GRBGlobalRoleIndex, "test-gr").Return(grbs, nil)
 
 			},
 			wantKeys: []relatedresource.Key{{Name: "test-grb-1"}},
@@ -182,7 +183,7 @@ func Test_enqueueGRBs(t *testing.T) {
 						UserName:       "u-123abc",
 					},
 				}
-				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return(grbs, nil)
+				state.grbCacheMock.EXPECT().GetByIndex(pkgrbac.GRBGlobalRoleIndex, "test-gr").Return(grbs, nil)
 			},
 			wantKeys: []relatedresource.Key{{Name: "test-grb-1"}, {Name: "test-grb-2"}},
 		},
@@ -195,7 +196,7 @@ func Test_enqueueGRBs(t *testing.T) {
 				InheritedClusterRoles: []string{"test-role"},
 			},
 			stateSetup: func(state testState) {
-				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return(nil, fmt.Errorf("server not available"))
+				state.grbCacheMock.EXPECT().GetByIndex(pkgrbac.GRBGlobalRoleIndex, "test-gr").Return(nil, fmt.Errorf("server not available"))
 			},
 			wantError: true,
 		},
@@ -208,7 +209,7 @@ func Test_enqueueGRBs(t *testing.T) {
 				InheritedClusterRoles: []string{"test-role"},
 			},
 			stateSetup: func(state testState) {
-				state.grbCacheMock.EXPECT().GetByIndex(grbGrIndex, "test-gr").Return([]*v3.GlobalRoleBinding{}, nil)
+				state.grbCacheMock.EXPECT().GetByIndex(pkgrbac.GRBGlobalRoleIndex, "test-gr").Return([]*v3.GlobalRoleBinding{}, nil)
 			},
 			wantKeys: nil,
 		},

--- a/pkg/controllers/management/auth/globalroles/register.go
+++ b/pkg/controllers/management/auth/globalroles/register.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/rancher/rancher/pkg/clustermanager"
+	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 )
@@ -13,8 +14,15 @@ const (
 	grbController = "mgmt-auth-grb-controller"
 )
 
+// RegisterWranglerIndexers registers the indexers that are also read outside of the leader
+// replica. The controllers for a downstream cluster run on the replica that owns the cluster,
+// which is not necessarily the leader, so indexers they depend on cannot be registered in
+// Register.
+func RegisterWranglerIndexers(grbCache mgmtv3.GlobalRoleBindingCache) {
+	grbCache.AddIndexer(grbGrIndex, grbGrIndexer)
+}
+
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
-	management.Wrangler.Mgmt.GlobalRoleBinding().Cache().AddIndexer(grbGrIndex, grbGrIndexer)
 	management.Wrangler.Mgmt.GlobalRoleBinding().Cache().AddIndexer(grbSafeConcatIndex, grbSafeConcatIndexer)
 	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grNsIndex, grNsIndexer)
 	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grSafeConcatIndex, grSafeConcatIndexer)

--- a/pkg/controllers/management/auth/globalroles/register.go
+++ b/pkg/controllers/management/auth/globalroles/register.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rancher/rancher/pkg/clustermanager"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/wrangler/v3/pkg/relatedresource"
 )
@@ -19,9 +20,12 @@ const (
 // which is not necessarily the leader, so indexers they depend on cannot be registered in
 // Register.
 func RegisterWranglerIndexers(grbCache mgmtv3.GlobalRoleBindingCache) {
-	grbCache.AddIndexer(grbGrIndex, grbGrIndexer)
+	grbCache.AddIndexer(pkgrbac.GRBGlobalRoleIndex, grbGrIndexer)
 }
 
+// Register wires the GlobalRole and GlobalRoleBinding controllers, which run on the leader replica.
+// RegisterWranglerIndexers has to be called first, since the enqueuers registered here read the
+// indexers it adds.
 func Register(ctx context.Context, management *config.ManagementContext, clusterManager *clustermanager.Manager) {
 	management.Wrangler.Mgmt.GlobalRoleBinding().Cache().AddIndexer(grbSafeConcatIndex, grbSafeConcatIndexer)
 	management.Wrangler.Mgmt.GlobalRole().Cache().AddIndexer(grNsIndex, grNsIndexer)

--- a/pkg/controllers/management/auth/globalroles/register_test.go
+++ b/pkg/controllers/management/auth/globalroles/register_test.go
@@ -1,0 +1,22 @@
+package globalroles
+
+import (
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
+	"go.uber.org/mock/gomock"
+)
+
+// TestRegisterWranglerIndexers verifies that the GlobalRoleBinding-by-GlobalRole indexer is
+// registered outside of the leader-only Register, since it is consumed by the downstream
+// enqueuers which run on the replica that owns the cluster.
+func TestRegisterWranglerIndexers(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	grbCache := fake.NewMockNonNamespacedCacheInterface[*v3.GlobalRoleBinding](ctrl)
+	grbCache.EXPECT().AddIndexer(pkgrbac.GRBGlobalRoleIndex, gomock.Any())
+
+	RegisterWranglerIndexers(grbCache)
+}

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rancher/rancher/pkg/controllers/management/auth/globalroles"
 	"github.com/rancher/rancher/pkg/controllers/management/auth/project_cluster"
 	"github.com/rancher/rancher/pkg/controllers/management/auth/roletemplates"
+	"github.com/rancher/rancher/pkg/features"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/types/config"
@@ -34,7 +35,12 @@ func RegisterWranglerIndexers(config *wrangler.Context) {
 		return indexByMembershipBindingOwner(obj)
 	})
 
-	globalroles.RegisterWranglerIndexers(config.Mgmt.GlobalRoleBinding().Cache())
+	// The GlobalRoleBinding CRD is only installed when MCM is enabled. Instantiating its cache in a
+	// non-MCM instance, such as the rancher embedded in the cluster agent, starts a watch for a
+	// resource that does not exist and takes the process down with it.
+	if features.MCM.Enabled() {
+		globalroles.RegisterWranglerIndexers(config.Mgmt.GlobalRoleBinding().Cache())
+	}
 }
 
 func RegisterIndexers(scaledContext *config.ScaledContext) error {

--- a/pkg/controllers/management/auth/register.go
+++ b/pkg/controllers/management/auth/register.go
@@ -33,6 +33,8 @@ func RegisterWranglerIndexers(config *wrangler.Context) {
 	config.RBAC.RoleBinding().Cache().AddIndexer(membershipBindingOwnerIndex, func(obj *rbacv1.RoleBinding) ([]string, error) {
 		return indexByMembershipBindingOwner(obj)
 	})
+
+	globalroles.RegisterWranglerIndexers(config.Mgmt.GlobalRoleBinding().Cache())
 }
 
 func RegisterIndexers(scaledContext *config.ScaledContext) error {

--- a/pkg/controllers/managementuser/rbac/handler_base.go
+++ b/pkg/controllers/managementuser/rbac/handler_base.go
@@ -675,7 +675,7 @@ func (g *globalRoleEnqueuer) namespaceEnqueueGRBs(_, name string, obj runtime.Ob
 	}
 	var keys []relatedresource.Key
 	for _, gr := range grs {
-		grbs, err := g.grbLister.GetByIndex("mgmt-auth-grb-gr-idex", gr.Name)
+		grbs, err := g.grbLister.GetByIndex(pkgrbac.GRBGlobalRoleIndex, gr.Name)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list GlobalRoleBindings for GlobalRole %s: %w", gr.Name, err)
 		}

--- a/pkg/controllers/managementuser/rbac/handler_base_test.go
+++ b/pkg/controllers/managementuser/rbac/handler_base_test.go
@@ -406,7 +406,7 @@ func TestNamespaceEnqueueGRBs(t *testing.T) {
 					grCache.EXPECT().GetByIndex(pkgrbac.GRDownstreamNSIndex, gomock.Any()).Return(test.grResults, test.grErr).AnyTimes()
 					for _, gr := range test.grResults {
 						grbs := test.grbResults[gr.Name]
-						grbCache.EXPECT().GetByIndex("mgmt-auth-grb-gr-idex", gr.Name).Return(grbs, test.grbErr).AnyTimes()
+						grbCache.EXPECT().GetByIndex(pkgrbac.GRBGlobalRoleIndex, gr.Name).Return(grbs, test.grbErr).AnyTimes()
 					}
 				}
 			}

--- a/pkg/rbac/common.go
+++ b/pkg/rbac/common.go
@@ -65,6 +65,8 @@ const (
 	AggregationFeatureLabel               = "management.cattle.io/roletemplate-aggregation"
 	// GRDownstreamNSIndex is the cache index name for looking up GlobalRoles by the namespaces in InheritedNamespacedRules.
 	GRDownstreamNSIndex = "mgmt-auth-gr-downstream-ns-index"
+	// GRBGlobalRoleIndex is the cache index name for looking up GlobalRoleBindings by the GlobalRole they reference.
+	GRBGlobalRoleIndex = "mgmt-auth-grb-gr-idex"
 )
 
 // BuildSubjectFromRTB This function will generate

--- a/tests/controllers/globalroles/globalrole_test.go
+++ b/tests/controllers/globalroles/globalrole_test.go
@@ -88,7 +88,9 @@ func (s *GlobalRoleTestSuite) SetupSuite() {
 	s.managementContext, err = scaledContext.NewManagementContext()
 	assert.NoError(s.T(), err)
 
-	// Register controller
+	// Register controller. The indexers shared with the downstream controllers are registered
+	// separately on every replica, and the enqueuers wired by Register depend on them.
+	globalroles.RegisterWranglerIndexers(s.managementContext.Wrangler.Mgmt.GlobalRoleBinding().Cache())
 	globalroles.Register(s.ctx, s.managementContext, clusterManager)
 
 	// Start controllers

--- a/tests/controllers/globalroles/indexers_test.go
+++ b/tests/controllers/globalroles/indexers_test.go
@@ -92,17 +92,16 @@ func (s *IndexerTestSuite) TestGRBByGlobalRoleIndex() {
 	_, err = s.wranglerContext.Mgmt.GlobalRoleBinding().Create(grb)
 	assert.NoError(t, err)
 
+	// The last result is kept so a missing indexer reports its own error rather than only a timeout.
 	grbCache := s.wranglerContext.Mgmt.GlobalRoleBinding().Cache()
+	var indexed []*v3.GlobalRoleBinding
 	assert.Eventually(t, func() bool {
-		grbs, err := grbCache.GetByIndex(pkgrbac.GRBGlobalRoleIndex, gr.Name)
-		return err == nil && len(grbs) == 1
+		indexed, err = grbCache.GetByIndex(pkgrbac.GRBGlobalRoleIndex, gr.Name)
+		return err == nil && len(indexed) == 1
 	}, duration, tick)
-
-	// Repeated outside Eventually so a missing indexer reports its own error instead of a timeout.
-	grbs, err := grbCache.GetByIndex(pkgrbac.GRBGlobalRoleIndex, gr.Name)
 	assert.NoError(t, err)
-	if assert.Len(t, grbs, 1) {
-		assert.Equal(t, grb.Name, grbs[0].Name)
+	if assert.Len(t, indexed, 1) {
+		assert.Equal(t, grb.Name, indexed[0].Name)
 	}
 
 	err = s.wranglerContext.Mgmt.GlobalRoleBinding().Delete(grb.Name, &metav1.DeleteOptions{})

--- a/tests/controllers/globalroles/indexers_test.go
+++ b/tests/controllers/globalroles/indexers_test.go
@@ -1,0 +1,116 @@
+package globalroles_integration_test
+
+import (
+	"context"
+	"testing"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	managementauth "github.com/rancher/rancher/pkg/controllers/management/auth"
+	pkgrbac "github.com/rancher/rancher/pkg/rbac"
+	"github.com/rancher/rancher/pkg/wrangler"
+	"github.com/rancher/rancher/tests/controllers/common"
+	"github.com/rancher/wrangler/v3/pkg/crd"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// IndexerTestSuite models a replica that owns a downstream cluster but is not the leader. Only the
+// registration path that every replica runs is exercised, so an indexer that moves back into the
+// leader-only globalroles.Register will fail here. See rancher/rancher#56890.
+type IndexerTestSuite struct {
+	suite.Suite
+	ctx             context.Context
+	cancel          context.CancelFunc
+	testEnv         *envtest.Environment
+	wranglerContext *wrangler.Context
+}
+
+func (s *IndexerTestSuite) SetupSuite() {
+	s.ctx, s.cancel = context.WithCancel(context.TODO())
+
+	s.testEnv = &envtest.Environment{}
+	restCfg, err := s.testEnv.Start()
+	assert.NoError(s.T(), err)
+	assert.NotNil(s.T(), restCfg)
+
+	common.RegisterCRDs(s.ctx, s.T(), restCfg,
+		crd.CRD{
+			SchemaObject: v3.GlobalRole{},
+			NonNamespace: true,
+			Status:       true,
+		},
+		crd.CRD{
+			SchemaObject: v3.GlobalRoleBinding{},
+			NonNamespace: true,
+		},
+	)
+
+	s.wranglerContext, err = wrangler.NewContext(s.ctx, nil, restCfg)
+	assert.NoError(s.T(), err)
+
+	// Deliberately without globalroles.Register, which only runs on the leader.
+	managementauth.RegisterWranglerIndexers(s.wranglerContext)
+
+	common.StartWranglerCaches(s.ctx, s.T(), s.wranglerContext,
+		schema.GroupVersionKind{
+			Group:   "management.cattle.io",
+			Version: "v3",
+			Kind:    "GlobalRoleBinding",
+		},
+	)
+}
+
+func (s *IndexerTestSuite) TearDownSuite() {
+	s.cancel()
+	err := s.testEnv.Stop()
+	assert.NoError(s.T(), err)
+}
+
+// TestGRBByGlobalRoleIndex covers the lookup the downstream enqueue-grbs-by-namespace handler performs
+// when a namespace referenced by inheritedNamespacedRules is created after the GlobalRole.
+func (s *IndexerTestSuite) TestGRBByGlobalRoleIndex() {
+	t := s.T()
+
+	gr := &v3.GlobalRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "indexed-gr",
+		},
+	}
+	_, err := s.wranglerContext.Mgmt.GlobalRole().Create(gr)
+	assert.NoError(t, err)
+
+	grb := &v3.GlobalRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "indexed-grb",
+		},
+		GlobalRoleName: gr.Name,
+		UserName:       "u-indexed",
+	}
+	_, err = s.wranglerContext.Mgmt.GlobalRoleBinding().Create(grb)
+	assert.NoError(t, err)
+
+	grbCache := s.wranglerContext.Mgmt.GlobalRoleBinding().Cache()
+	assert.Eventually(t, func() bool {
+		grbs, err := grbCache.GetByIndex(pkgrbac.GRBGlobalRoleIndex, gr.Name)
+		return err == nil && len(grbs) == 1
+	}, duration, tick)
+
+	// Repeated outside Eventually so a missing indexer reports its own error instead of a timeout.
+	grbs, err := grbCache.GetByIndex(pkgrbac.GRBGlobalRoleIndex, gr.Name)
+	assert.NoError(t, err)
+	if assert.Len(t, grbs, 1) {
+		assert.Equal(t, grb.Name, grbs[0].Name)
+	}
+
+	err = s.wranglerContext.Mgmt.GlobalRoleBinding().Delete(grb.Name, &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+	err = s.wranglerContext.Mgmt.GlobalRole().Delete(gr.Name, &metav1.DeleteOptions{})
+	assert.NoError(t, err)
+}
+
+func TestIndexerTestSuite(t *testing.T) {
+	suite.Run(t, new(IndexerTestSuite))
+}

--- a/tests/controllers/globalroles/indexers_test.go
+++ b/tests/controllers/globalroles/indexers_test.go
@@ -6,6 +6,7 @@ import (
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	managementauth "github.com/rancher/rancher/pkg/controllers/management/auth"
+	"github.com/rancher/rancher/pkg/features"
 	pkgrbac "github.com/rancher/rancher/pkg/rbac"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/rancher/tests/controllers/common"
@@ -14,6 +15,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
@@ -25,6 +27,7 @@ type IndexerTestSuite struct {
 	ctx             context.Context
 	cancel          context.CancelFunc
 	testEnv         *envtest.Environment
+	restCfg         *rest.Config
 	wranglerContext *wrangler.Context
 }
 
@@ -35,6 +38,7 @@ func (s *IndexerTestSuite) SetupSuite() {
 	restCfg, err := s.testEnv.Start()
 	assert.NoError(s.T(), err)
 	assert.NotNil(s.T(), restCfg)
+	s.restCfg = restCfg
 
 	common.RegisterCRDs(s.ctx, s.T(), restCfg,
 		crd.CRD{
@@ -108,6 +112,25 @@ func (s *IndexerTestSuite) TestGRBByGlobalRoleIndex() {
 	assert.NoError(t, err)
 	err = s.wranglerContext.Mgmt.GlobalRole().Delete(gr.Name, &metav1.DeleteOptions{})
 	assert.NoError(t, err)
+}
+
+// TestGRBByGlobalRoleIndexWithoutMCM covers the rancher instance embedded in the cluster agent, which
+// runs the same registration with MCM off. The GlobalRoleBinding CRD is not installed there, so the
+// cache must be left alone rather than started against a resource that does not exist.
+func (s *IndexerTestSuite) TestGRBByGlobalRoleIndexWithoutMCM() {
+	t := s.T()
+
+	features.MCM.Set(false)
+	defer features.MCM.Set(true)
+
+	// A separate context so the indexer registered by the suite is not visible here.
+	noMCMContext, err := wrangler.NewContext(s.ctx, nil, s.restCfg)
+	assert.NoError(t, err)
+
+	managementauth.RegisterWranglerIndexers(noMCMContext)
+
+	_, err = noMCMContext.Mgmt.GlobalRoleBinding().Cache().GetByIndex(pkgrbac.GRBGlobalRoleIndex, "indexed-gr")
+	assert.ErrorContains(t, err, pkgrbac.GRBGlobalRoleIndex)
 }
 
 func TestIndexerTestSuite(t *testing.T) {


### PR DESCRIPTION
## Issue: #56890 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
The index was added during GlobalRole controller registration, which only runs on the leader replica. The downstream namespace enqueuer that reads it runs on the replica owning the cluster, and in an HA install that is usually a different pod. A Role from inheritedNamespacedRules was not created when the namespace was added after the GlobalRole.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Registration moved to the indexer setup every replica performs at startup, and the index name is now a shared constant next to the other cross-plane RBAC index names. Added an envtest suite that runs only the all-replica registration path and asserts the lookup succeeds.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests
- envtest controller test