### PR TITLE
[v2.15] Read the ext.Token hash from its backing Secret when syncing downstream

### DIFF
--- a/pkg/controllers/managementuser/clusterauthtoken/register.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/register.go
@@ -152,15 +152,20 @@ func Register(ctx context.Context, cluster *config.UserContext, secretsCache cor
 	}).Sync)
 
 	cluster.Management.Wrangler.DeferredEXTAPIRegistration.DeferFunc(func(w *wrangler.EXTAPIContext) {
+		extTokenStore := extstore.NewSystemFromWrangler(cluster.Management.Wrangler)
+
 		extToken := w.Client.Token()
 		handler.extTokenIndexer.Store(extToken.Informer().GetIndexer())
+		// Only the ext handlers registered just below read extTokenStore, so
+		// setting it here happens before any of them can run.
+		handler.extTokenStore = extTokenStore
 		extTokenLifecycle(ctx, extToken, extTokenController, clusterName, handler)
 
 		catHandler := &clusterAuthTokenHandler{
 			tokenCache:    tokenCache,
 			tokenClient:   tokenClient,
 			extTokenCache: extToken.Cache(),
-			extTokenStore: extstore.NewSystemFromWrangler(cluster.Management.Wrangler),
+			extTokenStore: extTokenStore,
 		}
 		cluster.Cluster.ClusterAuthTokens(namespace).AddHandler(ctx, clusterAuthTokenController, catHandler.sync)
 	})

--- a/pkg/controllers/managementuser/clusterauthtoken/token.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/auth/tokens/hashers"
 	"github.com/rancher/rancher/pkg/controllers/managementuser/clusterauthtoken/common"
+	extstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	"github.com/rancher/rancher/pkg/features"
 	clusterv3 "github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3"
 	managementv3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
@@ -40,6 +41,7 @@ type tokenHandler struct {
 	clusterUserAttributeLister clusterv3.ClusterUserAttributeLister
 	tokenIndexer               cache.Indexer
 	extTokenIndexer            atomic.Value // holds cache.Indexer; written once by the EXT API DeferFunc, read by v3 remove handlers
+	extTokenStore              *extstore.SystemStore
 	userLister                 managementv3.UserLister
 	userAttributeLister        managementv3.UserAttributeLister
 	clusterSecret              wcore.SecretClient
@@ -57,6 +59,24 @@ func validateToken(name, userID string) error {
 	return nil
 }
 
+// extTokenHash returns the hash of the named ext token. The ext.cattle.io API
+// strips Status.Hash from everything it serves, including the list and watch
+// calls backing this controller's informer, so the hash has to be read from the
+// token's backing secret instead.
+func (h *tokenHandler) extTokenHash(name string) (string, error) {
+	secret, err := h.extTokenStore.GetSecret(name, nil, true)
+	if err != nil {
+		return "", fmt.Errorf("unable to retrieve backing secret of token [%s]: %w", name, err)
+	}
+
+	hash := string(secret.Data[extstore.FieldHash])
+	if hash == "" {
+		return "", fmt.Errorf("backing secret of token [%s] carries no hash", name)
+	}
+
+	return hash, nil
+}
+
 // extCreate is called when a given ext token is created, and is responsible for
 // updating/creating the ClusterAuthToken in the downstream cluster.
 func (h *tokenHandler) extCreate(token *extv1.Token) (*extv1.Token, error) {
@@ -71,8 +91,13 @@ func (h *tokenHandler) extCreate(token *extv1.Token) (*extv1.Token, error) {
 	}
 
 	// we can sync tokens which are hashed by copying the hash downstream
+	hash, err := h.extTokenHash(token.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	// token is hashed, we can safely attempt to sync downstream
-	hashVersion, err := hashers.GetHashVersion(token.Status.Hash)
+	hashVersion, err := hashers.GetHashVersion(hash)
 	if err != nil {
 		// the token hash is unlikely to change, re-enqueing would just produce a flood of errors
 		logrus.Errorf("unable to determine hash version of token [%s], will not sync token: %s", token.Name, err.Error())
@@ -80,7 +105,7 @@ func (h *tokenHandler) extCreate(token *extv1.Token) (*extv1.Token, error) {
 	}
 	// we only sync tokens downstream that were created with SHA3
 	if hashVersion == hashers.SHA3Version {
-		return nil, h.createClusterAuthToken(token, token.Status.Hash)
+		return nil, h.createClusterAuthToken(token, hash)
 	}
 
 	// token is hashed, but we can't sync it since we don't have the raw value
@@ -106,6 +131,11 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 	}
 	clusterAuthToken = clusterAuthToken.DeepCopy()
 
+	hash, err := h.extTokenHash(token.Name)
+	if err != nil {
+		return nil, err
+	}
+
 	forced := false
 	clusterAuthTokenSecret, err := h.clusterSecretLister.Get(h.namespace, common.ClusterAuthTokenSecretName(token.Name))
 	if err != nil {
@@ -117,8 +147,7 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 		// missing. Make it now, and force an update later.
 
 		forced = true
-		hashedValue := token.Status.Hash
-		clusterAuthTokenSecret = common.NewClusterAuthTokenSecret(h.namespace, token, hashedValue)
+		clusterAuthTokenSecret = common.NewClusterAuthTokenSecret(h.namespace, token, hash)
 	} else {
 		clusterAuthTokenSecret = clusterAuthTokenSecret.DeepCopy()
 	}
@@ -141,7 +170,7 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 	}
 
 	// note: ext tokens are always hashed (contrary to v3 Tokens)
-	hashVersion, err := hashers.GetHashVersion(token.Status.Hash)
+	hashVersion, err := hashers.GetHashVersion(hash)
 	if err != nil {
 		logrus.Errorf("unable to determine hash version of token [%s], will not sync token: %s", token.Name, err.Error())
 		return token, generic.ErrSkip
@@ -149,7 +178,7 @@ func (h *tokenHandler) ExtUpdated(token *extv1.Token) (*extv1.Token, error) {
 	// we only sync tokens downstream that were created with SHA3
 	if hashVersion == hashers.SHA3Version {
 		// trigger the compare to compare the values of the tokens
-		current.value = token.Status.Hash
+		current.value = hash
 		old.value = common.ClusterAuthTokenSecretValue(clusterAuthTokenSecret)
 	}
 

--- a/pkg/controllers/managementuser/clusterauthtoken/token_test.go
+++ b/pkg/controllers/managementuser/clusterauthtoken/token_test.go
@@ -10,6 +10,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/tokens"
 	"github.com/rancher/rancher/pkg/auth/tokens/hashers"
+	etoken "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/generated/norman/cluster.cattle.io/v3/fakes"
 	mgmtFakes "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
@@ -82,6 +83,8 @@ func TestExtCreate(t *testing.T) {
 		tokenHashingEnabled       bool
 		updateAuthTokenErr        error
 		createAuthTokenErr        error
+		extTokenHash              string
+		extTokenSecretErr         error
 
 		wantClusterAuthToken bool
 		wantAuthTokenUpdate  bool
@@ -98,6 +101,33 @@ func TestExtCreate(t *testing.T) {
 
 			wantClusterAuthToken: true,
 			wantAuthTokenEnabled: true,
+		},
+		{
+			name:                "hash absent from status, create token from backing secret hash",
+			token:               stripExtTokenHash(testToken),
+			extTokenHash:        hashedTokenKey,
+			existingTokenError:  authTokenNotFoundError,
+			tokenHashingEnabled: true,
+
+			wantClusterAuthToken: true,
+			wantAuthTokenEnabled: true,
+		},
+		{
+			name:                "backing secret missing, retry",
+			token:               stripExtTokenHash(testToken),
+			extTokenSecretErr:   apierrors.NewNotFound(schema.GroupResource{Group: "ext.cattle.io", Resource: "tokens"}, testToken.Name),
+			existingTokenError:  authTokenNotFoundError,
+			tokenHashingEnabled: true,
+
+			wantError: true,
+		},
+		{
+			name:                "backing secret carries no hash, retry",
+			token:               stripExtTokenHash(testToken),
+			existingTokenError:  authTokenNotFoundError,
+			tokenHashingEnabled: true,
+
+			wantError: true,
 		},
 		{
 			name:                "legacy token hash, don't create token",
@@ -204,6 +234,8 @@ func TestExtCreate(t *testing.T) {
 				TokenHashingEnabled:       test.tokenHashingEnabled,
 				UpdateAuthTokenErr:        test.updateAuthTokenErr,
 				CreateAuthTokenErr:        test.createAuthTokenErr,
+				ExtTokenHash:              test.extTokenHash,
+				ExtTokenSecretErr:         test.extTokenSecretErr,
 				CallCreate:                true,
 			})
 			if test.wantError {
@@ -234,7 +266,7 @@ func TestExtCreate(t *testing.T) {
 					// tokenHashing is enabled, hash should
 					// be the same on token and cluster auth
 					// token
-					require.Equal(t, test.token.Status.Hash, hashedToken)
+					require.Equal(t, wantHash(test.extTokenHash, test.token), hashedToken)
 				}
 			} else {
 				require.Nil(t, output.ModifiedClusterAuthToken)
@@ -525,6 +557,8 @@ func TestExtUpdate(t *testing.T) {
 		tokenHashingEnabled       bool
 		updateAuthTokenErr        error
 		createAuthTokenErr        error
+		extTokenHash              string
+		extTokenSecretErr         error
 
 		wantClusterAuthToken bool
 		wantAuthTokenUpdate  bool
@@ -541,6 +575,37 @@ func TestExtUpdate(t *testing.T) {
 			wantClusterAuthToken: true,
 			wantAuthTokenEnabled: false,
 			wantAuthTokenUpdate:  true,
+		},
+		{
+			name:                      "hash absent from status, update token from backing secret hash",
+			token:                     stripExtTokenHash(testToken),
+			extTokenHash:              hashedTokenKey,
+			existingClusterAuthToken:  oldAuthToken,
+			existingClusterAuthSecret: oldAuthSecret,
+			tokenHashingEnabled:       true,
+
+			wantClusterAuthToken: true,
+			wantAuthTokenUpdate:  true,
+			wantAuthTokenEnabled: true,
+		},
+		{
+			name:                      "backing secret missing, retry",
+			token:                     stripExtTokenHash(testToken),
+			extTokenSecretErr:         apierrors.NewNotFound(schema.GroupResource{Group: "ext.cattle.io", Resource: "tokens"}, testToken.Name),
+			existingClusterAuthToken:  testAuthToken,
+			existingClusterAuthSecret: testAuthSecret,
+			tokenHashingEnabled:       true,
+
+			wantError: true,
+		},
+		{
+			name:                      "backing secret carries no hash, retry",
+			token:                     stripExtTokenHash(testToken),
+			existingClusterAuthToken:  testAuthToken,
+			existingClusterAuthSecret: testAuthSecret,
+			tokenHashingEnabled:       true,
+
+			wantError: true,
 		},
 		{
 			name:                      "token enabled missing, no token update",
@@ -695,6 +760,8 @@ func TestExtUpdate(t *testing.T) {
 				TokenHashingEnabled:       test.tokenHashingEnabled,
 				UpdateAuthTokenErr:        test.updateAuthTokenErr,
 				CreateAuthTokenErr:        test.createAuthTokenErr,
+				ExtTokenHash:              test.extTokenHash,
+				ExtTokenSecretErr:         test.extTokenSecretErr,
 				CallCreate:                false,
 			})
 			if test.wantError {
@@ -721,7 +788,7 @@ func TestExtUpdate(t *testing.T) {
 
 				if modifiedSecret != nil {
 					hashedToken := string(modifiedSecret.Data["hash"])
-					require.Equal(t, test.token.Status.Hash, hashedToken)
+					require.Equal(t, wantHash(test.extTokenHash, test.token), hashedToken)
 				}
 			} else {
 				require.Nil(t, output.ModifiedClusterAuthToken)
@@ -1155,6 +1222,23 @@ func hashExtToken(token *extv1.Token, hashedToken string) *extv1.Token {
 	return newToken
 }
 
+// wantHash mirrors the harness default for the hash held by a token's backing
+// secret: the hash the test case asks for, or the one in the token status.
+func wantHash(extTokenHash string, token *extv1.Token) string {
+	if extTokenHash != "" {
+		return extTokenHash
+	}
+	return token.Status.Hash
+}
+
+// stripExtTokenHash models how the ext.cattle.io API serves tokens: the hash
+// lives in the backing secret and is never part of the status the informer sees.
+func stripExtTokenHash(token *extv1.Token) *extv1.Token {
+	newToken := token.DeepCopy()
+	newToken.Status.Hash = ""
+	return newToken
+}
+
 func setExtTokenEnabled(token *extv1.Token, enabled *bool) *extv1.Token {
 	newToken := token.DeepCopy()
 	newToken.Spec.Enabled = enabled
@@ -1182,6 +1266,12 @@ type testExtInput struct {
 	UpdateAuthTokenErr        error
 	CreateAuthTokenErr        error
 	CallCreate                bool
+
+	// ExtTokenHash is the hash held by the token's backing secret. It defaults
+	// to the hash in the token status, for the cases which do not care about
+	// the difference between the two.
+	ExtTokenHash      string
+	ExtTokenSecretErr error
 }
 
 type testOutput struct {
@@ -1272,6 +1362,36 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 		}, nil
 	}
 
+	// The ext token store the handler reads the token hash from, backed by the
+	// token's secret in the local cluster.
+	extTokenHash := testInput.ExtTokenHash
+	if extTokenHash == "" {
+		extTokenHash = testInput.Token.Status.Hash
+	}
+	mockExtSecretCache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	mockExtSecretCache.EXPECT().Get(etoken.TokenNamespace, gomock.Any()).DoAndReturn(
+		func(namespace, name string) (*corev1.Secret, error) {
+			if testInput.ExtTokenSecretErr != nil {
+				return nil, testInput.ExtTokenSecretErr
+			}
+			return &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
+					Name:      name,
+					Labels: map[string]string{
+						etoken.SecretKindLabel: etoken.SecretKindLabelValue,
+					},
+				},
+				Data: map[string][]byte{
+					etoken.FieldHash: []byte(extTokenHash),
+				},
+			}, nil
+		}).AnyTimes()
+	mockExtSecrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	mockExtSecrets.EXPECT().Cache().Return(mockExtSecretCache)
+	mockUsers := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+	mockUsers.EXPECT().Cache().Return(nil)
+
 	features.TokenHashing.Set(testInput.TokenHashingEnabled)
 	h := tokenHandler{
 		clusterAuthTokenLister:     &mockLister,
@@ -1282,6 +1402,7 @@ func runExtCreateUpdateTest(t *testing.T, testInput *testExtInput) *testOutput {
 		clusterUserAttribute:       &fakes.ClusterUserAttributeInterfaceMock{},
 		clusterSecret:              mockSecrets,
 		clusterSecretLister:        mockSecretLister,
+		extTokenStore:              etoken.NewSystem(nil, nil, mockExtSecrets, mockUsers, nil, nil, nil, nil, nil),
 	}
 	var err error
 	if testInput.CallCreate {


### PR DESCRIPTION
## Issue: #56900 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The ext.cattle.io API strips the hash out of every response it serves, including the list and watch calls backing the downstream sync controller's informer. Every ext.Token reaching the controller has an empty hash, and the sync is abandoned with a hash format error. Clusters are left without the matching ClusterAuthToken. Authentication through an ACE endpoint fails for those clusters.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

The hash is now read from the token's backing Secret in the local cluster instead of from the token status. A missing Secret, or one carrying no hash, is a retryable error. That covers the secret cache lagging behind the ext.Token informer.


**Trade-off**
The hash now comes from a second object — the Secret behind the token — instead of from the token itself. Rancher keeps an in-memory copy of both, and the two are not guaranteed to update at the same instant. For a brand-new token the controller can see the token before it sees the Secret. When that happens the first sync attempt fails and is retried, so the downstream ClusterAuthToken may appear a moment later than it did before. Only the first attempt is delayed; nothing is dropped.
The lookup itself is cheap: reading the Secret is an in-memory lookup, not a call to the API server, and it uses a copy Rancher already keeps for token authentication. No new watches and no extra memory.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests