### PR TITLE
Migrate integration-tests off docker mode

### DIFF
--- a/.github/actions/rancher-chart/build/action.yml
+++ b/.github/actions/rancher-chart/build/action.yml
@@ -47,3 +47,17 @@ runs:
     - name: Package
       shell: bash
       run: ./scripts/chart/package
+    - name: Prepare for upload
+      shell: bash
+      run: |
+        set -e
+        source scripts/version
+        cp bin/chart/${CHART_REPO}/rancher-${CHART_VERSION}.tgz /tmp/rancher-chart.tgz
+    - name: Upload chart
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+      with:
+        name: "rancher-chart"
+        path: /tmp/rancher-chart.tgz
+        if-no-files-found: error
+        retention-days: 4
+        overwrite: false

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,6 +122,7 @@ jobs:
         env:
           INTEGRATION_TEST_PACKAGES: ${{ matrix.packages }}
           INTEGRATION_TEST_RUN: ${{ matrix.run }}
+          CATTLE_K3S_VERSION: ${{ steps.env.outputs.CATTLE_K3S_VERSION }}
           RANCHER_CHART: /tmp/rancher-chart.tgz
         run: ./scripts/gha/tests
       - name: Upload Rancher + K3s logs if tests failed

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -69,10 +69,6 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Configure Docker for cgroupfs
-        run: |
-          echo '{"exec-opts": ["native.cgroupdriver=cgroupfs"]}'| sudo tee /etc/docker/daemon.json
-          sudo systemctl restart docker
       - name: Setup Environment Variables
         uses: ./.github/actions/setup-tag-env
       - id: env
@@ -132,7 +128,7 @@ jobs:
         env:
           INTEGRATION_TEST_PACKAGES: ${{ matrix.packages }}
           INTEGRATION_TEST_RUN: ${{ matrix.run }}
-        run: sudo --preserve-env GOBIN=$(which go) ./scripts/gha/tests
+        run: ./scripts/gha/tests
       - name: Upload Rancher + K3s logs if tests failed
         if: failure()
         continue-on-error: true
@@ -140,8 +136,8 @@ jobs:
         with:
           name: "Rancher + K3s logs (${{ matrix.shard }})"
           path: |
-            /tmp/rancher.log
-            /tmp/k3s.log
+            build/logs/rancher.log
+            build/logs/tmp/k3s.log
           if-no-files-found: ignore
           retention-days: 7
   # Aggregates the shard matrix into the single stable check

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -74,7 +74,7 @@ jobs:
       - id: env
         name: Setup Dependencies Env Variables
         uses: ./.github/actions/setup-build-env
-      - name: Download Docker images artifact
+      - name: Download Docker images and chart artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: "/tmp"
@@ -128,6 +128,7 @@ jobs:
         env:
           INTEGRATION_TEST_PACKAGES: ${{ matrix.packages }}
           INTEGRATION_TEST_RUN: ${{ matrix.run }}
+          RANCHER_CHART: /tmp/rancher-chart.tgz
         run: ./scripts/gha/tests
       - name: Upload Rancher + K3s logs if tests failed
         if: failure()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -113,12 +113,6 @@ jobs:
           echo "${K3D_BIN_HASH_AMD64}  k3d" | shasum -a 256 --check
           sudo mv k3d /usr/local/bin
           sudo chmod +x /usr/local/bin/k3d
-      - name: KDM data
-        env:
-          CATTLE_KDM_BRANCH: ${{ steps.env.outputs.CATTLE_KDM_BRANCH }}
-        run: |
-          mkdir -p bin
-          curl -sLf "https://releases.rancher.com/kontainer-driver-metadata/${CATTLE_KDM_BRANCH}/data.json" > bin/data.json
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -124,7 +124,14 @@ jobs:
           INTEGRATION_TEST_RUN: ${{ matrix.run }}
           CATTLE_K3S_VERSION: ${{ steps.env.outputs.CATTLE_K3S_VERSION }}
           RANCHER_CHART: /tmp/rancher-chart.tgz
-        run: ./scripts/gha/tests
+        run: |
+          IP="$(ip route get 8.8.8.8 | awk '{print $7}')"
+
+          # Minimize external DNS resolutions to make test suite faster
+          echo "${IP} ${IP}.sslip.io" | sudo tee -a /etc/hosts
+
+          export CATTLE_RANCHER_HOST="${IP}.sslip.io:8443"
+          ./scripts/gha/tests
       - name: Upload Rancher + K3s logs if tests failed
         if: failure()
         continue-on-error: true

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -125,7 +125,7 @@ jobs:
   integration-tests:
     permissions:
       contents: read
-    needs: [build-server-amd64, build-agent-amd64]
+    needs: [build-chart, build-server-amd64, build-agent-amd64]
     uses: ./.github/workflows/integration-tests.yml
   provisioning-tests:
     permissions:

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -22,7 +22,7 @@ cd build/testdata
 # Setup environment variables
 export CATTLE_DEV_MODE=yes
 HOST_IP=$(ip route get 8.8.8.8 | awk '{print $7}')
-export CATTLE_SERVER_URL="https://${HOST_IP}.sslip.io"
+export CATTLE_SERVER_URL="https://${HOST_IP}.sslip.io:8443"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 if [ -n "$CATTLE_FEATURES" ]; then
   export CATTLE_FEATURES="$CATTLE_FEATURES,harvester=false"
@@ -38,7 +38,7 @@ fi
 k3d cluster create rancher-server \
   --api-port 6443 \
   -p "8080:80@loadbalancer" \
-  -p "443:443@loadbalancer" \
+  -p "8443:443@loadbalancer" \
   --wait
 
 # Import local development images into the k3d cluster

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -30,36 +30,28 @@ else
   export CATTLE_FEATURES="harvester=false"
 fi
 
-# Create k3d cluster. We expose:
-# - API Port: 6443
-# - 8080 host port -> 80 loadbalancer port
-# - 443 host port -> 443 loadbalancer port
-# This ensures tests communicating on these ports work seamlessly.
 k3d cluster create rancher-server \
   --api-port 6443 \
   -p "8080:80@loadbalancer" \
   -p "8443:443@loadbalancer" \
   --wait
 
-# Import local development images into the k3d cluster
-k3d image import $IMAGE $CATTLE_AGENT_IMAGE -c rancher-server
-
-# Deploy cert-manager using pinned/parameterized version
+# Deploy cert-manager and wait for its rollout
 CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-"v1.15.3"}
 kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
-
-# Wait for cert-manager deployments to roll out
 kubectl rollout status -n cert-manager deploy --timeout=150s
 
+# RANCHER_CHART is the path to the already packaged chart, recovered from a previous "build-chart" step
 if [ -z "${RANCHER_CHART:-}" ]; then
   # Build the local Rancher chart
   (cd ../.. && ./scripts/chart/build chart)
   RANCHER_CHART=../chart/rancher
 fi
 
-# Rancher server and agent images are set in the chart and server image respectively. There is no need to override them here
+# Rancher server and agent images are loaded from previous build steps and now imported directly into the cluster.
+# The chart and server image already references them, respectively, so there is no need to override them using helm values.
+k3d image import $IMAGE $CATTLE_AGENT_IMAGE -c rancher-server
 
-# Install Rancher via Helm
 helm upgrade --install rancher ${RANCHER_CHART} \
   --namespace cattle-system \
   --create-namespace \

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -57,14 +57,7 @@ if [ -z "${RANCHER_CHART:-}" ]; then
   RANCHER_CHART=../chart/rancher
 fi
 
-# Extract repository and tag from full $IMAGE string
-if [[ "$IMAGE" == *:* ]]; then
-  IMAGE_REPO=$(echo $IMAGE | rev | cut -d: -f2- | rev)
-  IMAGE_TAG=$(echo $IMAGE | rev | cut -d: -f1 | rev)
-else
-  IMAGE_REPO="$IMAGE"
-  IMAGE_TAG="latest"
-fi
+# Rancher server and agent images are set in the chart and server image respectively. There is no need to override them here
 
 # Install Rancher via Helm
 helm upgrade --install rancher ${RANCHER_CHART} \
@@ -78,9 +71,5 @@ helm upgrade --install rancher ${RANCHER_CHART} \
   --set extraEnv[1].value="$CATTLE_SERVER_URL" \
   --set extraEnv[2].name=CATTLE_FEATURES \
   --set extraEnv[2].value="$CATTLE_FEATURES" \
-  --set extraEnv[3].name=CATTLE_AGENT_IMAGE \
-  --set extraEnv[3].value="$CATTLE_AGENT_IMAGE" \
-  --set image.repository="${IMAGE_REPO}" \
-  --set image.tag="${IMAGE_TAG}" \
   --set replicas=1 \
   --wait

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -18,6 +18,7 @@ mkdir -p build/testdata
 cd build/testdata
 
 : ${KUBECONFIG?KUBECONFIG environment variable must be set}
+: ${CATTLE_K3S_VERSION?CATTLE_K3S_VERSION environment variable must be set}
 
 # Setup environment variables
 export CATTLE_DEV_MODE=yes
@@ -34,6 +35,7 @@ k3d cluster create rancher-server \
   --api-port 6443 \
   -p "8080:80@loadbalancer" \
   -p "8443:443@loadbalancer" \
+  --image "rancher/k3s:${CATTLE_K3S_VERSION//+/-}" \
   --wait
 
 # Deploy cert-manager and wait for its rollout

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -51,8 +51,11 @@ kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download
 # Wait for cert-manager deployments to roll out
 kubectl rollout status -n cert-manager deploy --timeout=150s
 
-# Build the local Rancher chart
-(cd ../.. && ./scripts/chart/build chart)
+if [ -z "${RANCHER_CHART:-}" ]; then
+  # Build the local Rancher chart
+  (cd ../.. && ./scripts/chart/build chart)
+  RANCHER_CHART=../chart/rancher
+fi
 
 # Extract repository and tag from full $IMAGE string
 if [[ "$IMAGE" == *:* ]]; then
@@ -64,7 +67,7 @@ else
 fi
 
 # Install Rancher via Helm
-helm upgrade --install rancher ../chart/rancher \
+helm upgrade --install rancher ${RANCHER_CHART} \
   --namespace cattle-system \
   --create-namespace \
   --set hostname="${HOST_IP}.sslip.io" \

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -1,15 +1,13 @@
 #!/bin/bash
 set -ex
 
-echo Starting rancher server in container
-
-source $(dirname $0)/../version
-cd scripts
-source ./package-env
-cd ..
-
+echo Starting rancher server in k3d cluster
 
 cd $(dirname $0)/../..
+
+source scripts/version
+source scripts/package-env
+
 
 if [ ! -z $1 ] && ( [ $1 = "--trace" ] || [ $1 = "--info" ] || [ $1 = "--debug" ] ); then
   LOGFLAG=$1
@@ -18,9 +16,13 @@ fi
 rm -rf build/testdata
 mkdir -p build/testdata
 cd build/testdata
-export KUBECONFIG=
+
+: ${KUBECONFIG?KUBECONFIG environment variable must be set}
+
+# Setup environment variables
 export CATTLE_DEV_MODE=yes
-export CATTLE_SERVER_URL="https://$(ip route get 8.8.8.8 | awk '{print $7}')"
+HOST_IP=$(ip route get 8.8.8.8 | awk '{print $7}')
+export CATTLE_SERVER_URL="https://${HOST_IP}.sslip.io"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 if [ -n "$CATTLE_FEATURES" ]; then
   export CATTLE_FEATURES="$CATTLE_FEATURES,harvester=false"
@@ -28,5 +30,54 @@ else
   export CATTLE_FEATURES="harvester=false"
 fi
 
-mkdir -p /etc/rancher/k3s/
-docker run -d --name rancher-server -v /etc/rancher/k3s:/etc/rancher/k3s --restart=unless-stopped --privileged -p 6443:6443 -p 8080:8080 -p 443:443 -e CATTLE_SERVER_URL=$CATTLE_SERVER_URL -e CATTLE_BOOTSTRAP_PASSWORD=$CATTLE_BOOTSTRAP_PASSWORD -e CATTLE_DEV_MODE=yes -e CATTLE_AGENT_IMAGE=$AGENT_IMAGE $IMAGE
+# Create k3d cluster. We expose:
+# - API Port: 6443
+# - 8080 host port -> 80 loadbalancer port
+# - 443 host port -> 443 loadbalancer port
+# This ensures tests communicating on these ports work seamlessly.
+k3d cluster create rancher-server \
+  --api-port 6443 \
+  -p "8080:80@loadbalancer" \
+  -p "443:443@loadbalancer" \
+  --wait
+
+# Import local development images into the k3d cluster
+k3d image import $IMAGE $CATTLE_AGENT_IMAGE -c rancher-server
+
+# Deploy cert-manager using pinned/parameterized version
+CERT_MANAGER_VERSION=${CERT_MANAGER_VERSION:-"v1.15.3"}
+kubectl apply -f "https://github.com/cert-manager/cert-manager/releases/download/${CERT_MANAGER_VERSION}/cert-manager.yaml"
+
+# Wait for cert-manager deployments to roll out
+kubectl rollout status -n cert-manager deploy --timeout=150s
+
+# Build the local Rancher chart
+(cd ../.. && ./scripts/chart/build chart)
+
+# Extract repository and tag from full $IMAGE string
+if [[ "$IMAGE" == *:* ]]; then
+  IMAGE_REPO=$(echo $IMAGE | rev | cut -d: -f2- | rev)
+  IMAGE_TAG=$(echo $IMAGE | rev | cut -d: -f1 | rev)
+else
+  IMAGE_REPO="$IMAGE"
+  IMAGE_TAG="latest"
+fi
+
+# Install Rancher via Helm
+helm upgrade --install rancher ../chart/rancher \
+  --namespace cattle-system \
+  --create-namespace \
+  --set hostname="${HOST_IP}.sslip.io" \
+  --set bootstrapPassword="$CATTLE_BOOTSTRAP_PASSWORD" \
+  --set extraEnv[0].name=CATTLE_DEV_MODE \
+  --set extraEnv[0].value="$CATTLE_DEV_MODE" \
+  --set extraEnv[1].name=CATTLE_SERVER_URL \
+  --set extraEnv[1].value="$CATTLE_SERVER_URL" \
+  --set extraEnv[2].name=CATTLE_FEATURES \
+  --set extraEnv[2].value="$CATTLE_FEATURES" \
+  --set extraEnv[3].name=CATTLE_AGENT_IMAGE \
+  --set extraEnv[3].value="$CATTLE_AGENT_IMAGE" \
+  --set image.repository="${IMAGE_REPO}" \
+  --set image.tag="${IMAGE_TAG}" \
+  --set replicas=1 \
+  --wait

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -19,11 +19,12 @@ cd build/testdata
 
 : ${KUBECONFIG?KUBECONFIG environment variable must be set}
 : ${CATTLE_K3S_VERSION?CATTLE_K3S_VERSION environment variable must be set}
+: ${CATTLE_RANCHER_HOST?CATTLE_RANCHER_HOST environment variable must be set}
 
 # Setup environment variables
 export CATTLE_DEV_MODE=yes
-HOST_IP=$(ip route get 8.8.8.8 | awk '{print $7}')
-export CATTLE_SERVER_URL="https://${HOST_IP}.sslip.io:8443"
+export CATTLE_SERVER_URL="https://${CATTLE_RANCHER_HOST}"
+export CATTLE_RANCHER_HOSTNAME="${CATTLE_RANCHER_HOST%:8443}"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 if [ -n "$CATTLE_FEATURES" ]; then
   export CATTLE_FEATURES="$CATTLE_FEATURES,harvester=false"
@@ -59,7 +60,7 @@ k3d image import $IMAGE $CATTLE_AGENT_IMAGE -c rancher-server
 helm upgrade --install rancher ${RANCHER_CHART} \
   --namespace cattle-system \
   --create-namespace \
-  --set hostname="${HOST_IP}.sslip.io" \
+  --set hostname="$CATTLE_RANCHER_HOSTNAME" \
   --set bootstrapPassword="$CATTLE_BOOTSTRAP_PASSWORD" \
   --set extraEnv[0].name=CATTLE_DEV_MODE \
   --set extraEnv[0].value="$CATTLE_DEV_MODE" \

--- a/scripts/gha/run
+++ b/scripts/gha/run
@@ -33,9 +33,11 @@ fi
 
 k3d cluster create rancher-server \
   --api-port 6443 \
-  -p "8080:80@loadbalancer" \
-  -p "8443:443@loadbalancer" \
+  --no-lb -p "8443:443@server:0:direct" \
   --image "rancher/k3s:${CATTLE_K3S_VERSION//+/-}" \
+  --k3s-arg "--disable=servicelb@server:*" \
+  --k3s-arg "--disable=metrics-server@server:*" \
+  --k3s-arg "--disable=local-storage@server:*" \
   --wait
 
 # Deploy cert-manager and wait for its rollout
@@ -67,3 +69,19 @@ helm upgrade --install rancher ${RANCHER_CHART} \
   --set extraEnv[2].value="$CATTLE_FEATURES" \
   --set replicas=1 \
   --wait
+
+# Force traefik to run on 443 inside the k3s container, exposing the ingress directly on that port
+cat <<EOF | kubectl apply -f -
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |-
+    ports:
+      web:
+        hostPort: 80
+      websecure:
+        hostPort: 443
+EOF

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -1,8 +1,6 @@
 #!/bin/bash
 set -e
 
-GOBIN=${GOBIN-"go"}
-
 cleanup()
 {
     EXIT=$?
@@ -65,27 +63,19 @@ export CATTLE_CHART_DEFAULT_URL=https://github.com/rancher/charts
 fi
 
 echo Starting rancher server for test
-touch /tmp/rancher.log
 
 export KUBECONFIG=$(pwd)/build/testdata/k3s.yaml
 
-mkdir -p /var/lib/rancher/$DIST/agent/images
-grep PodTestImage ./tests/v2prov/defaults/defaults.go | cut -f2 -d'"' > /var/lib/rancher/$DIST/agent/images/pull.txt
-grep MachineProvisionImage ./pkg/settings/setting.go | cut -f4 -d'"' >> /var/lib/rancher/$DIST/agent/images/pull.txt
-mkdir -p /usr/share/rancher/ui-dashboard/assets
-curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-amd64 -o /usr/share/rancher/ui-dashboard/assets/rancher-system-agent-amd64
-curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/rancher-system-agent-arm64 -o /usr/share/rancher/ui-dashboard/assets/rancher-system-agent-arm64
-curl -sLf https://github.com/rancher/system-agent/releases/download/${CATTLE_SYSTEM_AGENT_VERSION}/system-agent-uninstall.sh -o /usr/share/rancher/ui-dashboard/assets/system-agent-uninstall.sh
+LOGS_DIR=$PWD/build/logs
+mkdir -p "$LOGS_DIR"
 
 dump_rancher_logs()
 {
-  echo "Dumping Rancher + K3s container logs to /tmp/rancher.log and /tmp/k3s.log"
+  echo "Dumping Rancher + K3s container logs to rancher.log and k3s.log"
   # Best-effort: this runs under `set -e`, so don't let a missing container/log
   # abort the caller or leave the workflow's artifact upload step empty-handed.
-  kubectl --kubeconfig "$KUBECONFIG" logs -n cattle-system -l app=rancher --tail=-1 &> /tmp/rancher.log || echo "failed to fetch rancher logs" >> /tmp/rancher.log
-  docker logs k3d-rancher-server-server-0 &> /tmp/k3s.log || echo "failed to fetch k3s.log" > /tmp/k3s.log
-  # Written while running under sudo; make readable so the CI workflow can upload them as an artifact.
-  chmod 644 /tmp/rancher.log /tmp/k3s.log 2>/dev/null || true
+  kubectl --kubeconfig "$KUBECONFIG" logs -n cattle-system -l app=rancher --tail=-1 &> "${LOGS_DIR}/rancher.log" || echo "failed to fetch rancher logs" >> "${LOGS_DIR}/rancher.log"
+  docker logs k3d-rancher-server-server-0 &> "${LOGS_DIR}/k3s.log" || echo "failed to fetch k3s.log" > "${LOGS_DIR}/k3s.log"
 }
 
 export -f dump_rancher_logs
@@ -93,7 +83,7 @@ export -f dump_rancher_logs
 ./scripts/gha/run 2>&1
 trap cleanup exit
 
-CATTLE_RANCHER_HOST="$(kubectl -n cattle-system get ingress rancher -o jsonpath='{.spec.rules[0].host}')"
+CATTLE_RANCHER_HOST="$(kubectl -n cattle-system get ingress rancher -o jsonpath='{.spec.rules[0].host}'):8443"
 export CATTLE_RANCHER_HOST
 
 # Build integrationsetup and compile the integration test binaries in the
@@ -109,12 +99,12 @@ echo "Building integrationsetup + pre-compiling integration test binaries in the
 (
   set -e
   mkdir -p tests/v2/integration/bin
-  CGO_ENABLED=0 $GOBIN build -tags containers_image_openpgp,integrationsetup \
+  CGO_ENABLED=0 go build -tags containers_image_openpgp,integrationsetup \
     -o tests/v2/integration/bin/integrationsetup ./tests/v2/integration/setup
-  for pkg in $($GOBIN list $INTEGRATION_TEST_PACKAGES); do
-    $GOBIN test -c -o /dev/null "$pkg"
+  for pkg in $(go list $INTEGRATION_TEST_PACKAGES); do
+    go test -c -o /dev/null "$pkg"
   done
-) >/tmp/precompile.log 2>&1 &
+) > "${LOGS_DIR}/precompile.log" 2>&1 &
 PRECOMPILE_PID=$!
 
 echo "Waiting for K3s kubeconfig to be generated"
@@ -153,7 +143,7 @@ export CATTLE_TEST_CONFIG=$(pwd)/tests/v2/integration/config.yaml # used by inte
 # real error.
 if [ -n "${PRECOMPILE_PID:-}" ]; then
   echo "Waiting for background integrationsetup build + test compilation to finish"
-  wait "$PRECOMPILE_PID" || { echo "background build/compilation reported an error:"; cat /tmp/precompile.log || true; }
+  wait "$PRECOMPILE_PID" || { echo "background build/compilation reported an error:"; cat "${LOGS_DIR}/precompile.log" || true; }
 fi
 ./tests/v2/integration/bin/integrationsetup || {
   dump_rancher_logs
@@ -165,9 +155,8 @@ integration_test_args=(-v -failfast -timeout 30m -p 1)
 if [ -n "$INTEGRATION_TEST_RUN" ]; then
   integration_test_args+=(-run "$INTEGRATION_TEST_RUN")
 fi
-$GOBIN test "${integration_test_args[@]}" $INTEGRATION_TEST_PACKAGES || {
+
+go test "${integration_test_args[@]}" $INTEGRATION_TEST_PACKAGES || {
   dump_rancher_logs
   exit 1
 }
-
-tail -f /tmp/rancher-test.log &

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -42,11 +42,6 @@ export CATTLE_AGENT_IMAGE="${REGISTRY}rancher/rancher-agent:${AGENT_TAG}"
 export CATTLE_BOOTSTRAP_PASSWORD="admin"
 echo "Using Rancher agent image $CATTLE_AGENT_IMAGE"
 
-eval "$(grep '^ENV CATTLE_SYSTEM_AGENT' package/Dockerfile | awk '{print "export " $2}')"
-eval "$(grep '^ENV CATTLE_WINS_AGENT' package/Dockerfile | awk '{print "export " $2}')"
-eval "$(grep '^ENV CATTLE_CSI_PROXY_AGENT' package/Dockerfile | awk '{print "export " $2}')"
-eval "$(grep '^ENV CATTLE_KDM_BRANCH' package/Dockerfile | awk '{print "export " $2}')"
-
 if [ -z "${SOME_K8S_VERSION}" ]; then
 # Get the last release for $DIST, which is usually the latest version or an experimental version.
 # Previously this would use channels, but channels no longer reflect the latest version since

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -123,7 +123,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-webhook was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why webhook did not start` \
-  "kubectl --kubeconfig $KUBECONFIG rollout status -n cattle-system deploy/rancher-webhook &>/dev/null"
+  "kubectl rollout status -n cattle-system deploy/rancher-webhook &>/dev/null"
 
 echo "Waiting up to 5 minutes for rancher-turtles deployment"
 ./scripts/retry \
@@ -132,8 +132,8 @@ echo "Waiting up to 5 minutes for rancher-turtles deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-turtles was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why turtles did not start` \
-  "kubectl --kubeconfig $KUBECONFIG get ns cattle-turtles-system &>/dev/null \
-    && kubectl --kubeconfig $KUBECONFIG rollout status -w -n cattle-turtles-system deploy/rancher-turtles-controller-manager &>/dev/null"
+  "kubectl get ns cattle-turtles-system &>/dev/null \
+    && kubectl rollout status -w -n cattle-turtles-system deploy/rancher-turtles-controller-manager &>/dev/null"
 
 echo Running integrationsetup
 export CATTLE_TEST_CONFIG=$(pwd)/tests/v2/integration/config.yaml # used by integration tests and test setup

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -7,8 +7,8 @@ cleanup()
 {
     EXIT=$?
     set +ex
-    echo Stopping and removing rancher server container
-    docker rm -f rancher-server
+    echo Stopping and removing rancher server cluster
+    k3d cluster delete rancher-server
     return $EXIT
 }
 
@@ -67,7 +67,7 @@ fi
 echo Starting rancher server for test
 touch /tmp/rancher.log
 
-export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+export KUBECONFIG=$(pwd)/build/testdata/k3s.yaml
 
 mkdir -p /var/lib/rancher/$DIST/agent/images
 grep PodTestImage ./tests/v2prov/defaults/defaults.go | cut -f2 -d'"' > /var/lib/rancher/$DIST/agent/images/pull.txt
@@ -82,8 +82,8 @@ dump_rancher_logs()
   echo "Dumping Rancher + K3s container logs to /tmp/rancher.log and /tmp/k3s.log"
   # Best-effort: this runs under `set -e`, so don't let a missing container/log
   # abort the caller or leave the workflow's artifact upload step empty-handed.
-  docker logs rancher-server &> /tmp/rancher.log || echo "failed to fetch rancher-server logs" >> /tmp/rancher.log
-  docker cp rancher-server:/var/lib/rancher/k3s.log /tmp/k3s.log || echo "failed to fetch k3s.log from rancher-server" > /tmp/k3s.log
+  kubectl --kubeconfig "$KUBECONFIG" logs -n cattle-system -l app=rancher --tail=-1 &> /tmp/rancher.log || echo "failed to fetch rancher logs" >> /tmp/rancher.log
+  docker logs k3d-rancher-server-server-0 &> /tmp/k3s.log || echo "failed to fetch k3s.log" > /tmp/k3s.log
   # Written while running under sudo; make readable so the CI workflow can upload them as an artifact.
   chmod 644 /tmp/rancher.log /tmp/k3s.log 2>/dev/null || true
 }
@@ -92,6 +92,9 @@ export -f dump_rancher_logs
 
 ./scripts/gha/run 2>&1
 trap cleanup exit
+
+CATTLE_RANCHER_HOST="$(kubectl -n cattle-system get ingress rancher -o jsonpath='{.spec.rules[0].host}')"
+export CATTLE_RANCHER_HOST
 
 # Build integrationsetup and compile the integration test binaries in the
 # background while we wait for Rancher's deployments to roll out below, keeping
@@ -119,9 +122,9 @@ echo "Waiting for K3s kubeconfig to be generated"
   --timeout 300 `# Time out after 300 seconds (5 min)` \
   --sleep 5 `# Sleep for 2 seconds in between attempts` \
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
-  --message "/etc/rancher/k3s/k3s.yaml did not exist after {{elapsed}} seconds" `# Print this progress message` \
+  --message "$KUBECONFIG did not exist after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why K3s did not start` \
-  "stat /etc/rancher/k3s/k3s.yaml &>/dev/null"
+  "stat $KUBECONFIG &>/dev/null"
 
 echo "Waiting up to 5 minutes for the api-extension deployment"
 ./scripts/retry \
@@ -130,7 +133,7 @@ echo "Waiting up to 5 minutes for the api-extension deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "api-extension was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why api-extension did not start` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/api-extension &>/dev/null"
+  "kubectl --kubeconfig $KUBECONFIG rollout status -n cattle-system deploy/api-extension &>/dev/null"
 
 echo "Waiting up to 5 minutes for rancher-webhook deployment"
 ./scripts/retry \
@@ -139,7 +142,7 @@ echo "Waiting up to 5 minutes for rancher-webhook deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-webhook was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why webhook did not start` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -n cattle-system deploy/rancher-webhook &>/dev/null"
+  "kubectl --kubeconfig $KUBECONFIG rollout status -n cattle-system deploy/rancher-webhook &>/dev/null"
 
 echo "Waiting up to 5 minutes for rancher-turtles deployment"
 ./scripts/retry \
@@ -148,8 +151,8 @@ echo "Waiting up to 5 minutes for rancher-turtles deployment"
   --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
   --message "rancher-turtles was not available after {{elapsed}} seconds" `# Print this progress message` \
   --exit-command "dump_rancher_logs" `# Dump logs to find out why turtles did not start` \
-  "kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml get ns cattle-turtles-system &>/dev/null \
-    && kubectl --kubeconfig /etc/rancher/k3s/k3s.yaml rollout status -w -n cattle-turtles-system deploy/rancher-turtles-controller-manager &>/dev/null"
+  "kubectl --kubeconfig $KUBECONFIG get ns cattle-turtles-system &>/dev/null \
+    && kubectl --kubeconfig $KUBECONFIG rollout status -w -n cattle-turtles-system deploy/rancher-turtles-controller-manager &>/dev/null"
 
 echo Running integrationsetup
 export CATTLE_TEST_CONFIG=$(pwd)/tests/v2/integration/config.yaml # used by integration tests and test setup

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -126,15 +126,6 @@ echo "Waiting for K3s kubeconfig to be generated"
   --exit-command "dump_rancher_logs" `# Dump logs to find out why K3s did not start` \
   "stat $KUBECONFIG &>/dev/null"
 
-echo "Waiting up to 5 minutes for the api-extension deployment"
-./scripts/retry \
-  --timeout 300 `# Time out after 300 seconds (5 min)` \
-  --sleep 2 `# Sleep for 2 seconds in between attempts` \
-  --message-interval 30 `# Print the progress message below every 30 attempts (roughly every minute)` \
-  --message "api-extension was not available after {{elapsed}} seconds" `# Print this progress message` \
-  --exit-command "dump_rancher_logs" `# Dump logs to find out why api-extension did not start` \
-  "kubectl --kubeconfig $KUBECONFIG rollout status -n cattle-system deploy/api-extension &>/dev/null"
-
 echo "Waiting up to 5 minutes for rancher-webhook deployment"
 ./scripts/retry \
   --timeout 300 `# Time out after 300 seconds (5 min)` \

--- a/scripts/gha/tests
+++ b/scripts/gha/tests
@@ -35,6 +35,8 @@ export TB_ORG=${TB_ORG}
 export CATTLE_CHART_DEFAULT_URL=${CATTLE_CHART_DEFAULT_URL}
 REGISTRY=${REGISTRY/-""}
 
+: ${CATTLE_RANCHER_HOST?CATTLE_RANCHER_HOST environment variable must be set}
+
 # Tell Rancher to use the recently-built Rancher cluster agent image. This image is built as part of CI and will be
 # copied to the in-cluster registry during test setup below.
 source ./scripts/version
@@ -77,9 +79,6 @@ export -f dump_rancher_logs
 
 ./scripts/gha/run 2>&1
 trap cleanup exit
-
-CATTLE_RANCHER_HOST="$(kubectl -n cattle-system get ingress rancher -o jsonpath='{.spec.rules[0].host}'):8443"
-export CATTLE_RANCHER_HOST
 
 # Build integrationsetup and compile the integration test binaries in the
 # background while we wait for Rancher's deployments to roll out below, keeping


### PR DESCRIPTION
## Issue: #57022
 
## Problem

Docker mode is unsupported and should be migrated to a helm-based installation method.
 
## Solution

The following changes were performed in the files that form the integration test suite automation:
* `scripts/gha/run` used to start Rancher:
  * `docker run rancher/rancher` was replaced with `k3d`, `helm install` steps.
  * Use non-privileged TCP ports (>1024) to expose the cluster load balancer.
  * Use the artifact from a previous `build-chart` step to install Rancher.
* `scripts/gha/test` is used to run the integration test suite, including invoking the above `run` script:
  * Write logs to a relative path within the working directory
  * Remove `sudo` invocation.
  * Remove unnecessary download of additional files: KDM data, dashboard files, system agent binaries, etc.
  * Removed `api-extension` Deployment check, as this installation method does support API Aggregation and this component is not deployed.
* `build-chart` action job now archives the chart tgz as an artifact, so it can be retrieved by later steps.
* Removed unnecessary tweaks on the docker daemon. 
 
## Testing

No individual tests were changed due to this change, only the automation around it. The test suite continues to be executed correctly.

## Regressions

This change incurs into an increase during the execution time of `go test` suite. After multiple experiments and research, I concluded it's caused by test suite and shepherd making use of Rancher's k8s proxy functionality, instead of direct access to k3s (which is now possible as it's no longer embedded inside the Rancher docker container).
However, changing this would require multiple changes in the integration test setup and `rancher/shepherd`, so they are better addressed in separate PRs.