### PR TITLE
Avoid duplicate Renovate presets

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>rancher/renovate-config//rancher-main#main"
-  ],
   "baseBranchPatterns": [
     "main",
     "release/v2.15",
@@ -17,6 +14,14 @@
   "prHourlyLimit": 6,
   "prConcurrentLimit": 20,
   "packageRules": [
+    {
+      "matchBaseBranches": [
+        "main"
+      ],
+      "extends": [
+        "github>rancher/renovate-config//rancher-main#main"
+      ]
+    },
     {
       "matchBaseBranches": [
         "release/v2.15"


### PR DESCRIPTION
Load rancher-main only for main so release branches do not inherit shared managers twice through both rancher-main and rancher-2.x.