### PR TITLE
[main] Reduce runtime of basic prov v2 tests

### DIFF
--- a/.github/scripts/provisioning-test-scopes.yaml
+++ b/.github/scripts/provisioning-test-scopes.yaml
@@ -132,8 +132,8 @@ scopes:
           - 'CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION'
           - 'CATTLE_K3S_VERSION'
     tests:
-      - { dist: k3s,  regex: '^Test_Provisioning_.*$' }
-      - { dist: rke2, regex: '^Test_(General|Provisioning|Fleet)_.*$' }
+      - { dist: k3s,  regex: '^Test_Provisioning_.*$', , parallelism: 10 }
+      - { dist: rke2, regex: '^Test_(General|Provisioning|Fleet)_.*$', parallelism: 10 }
 
   # day-2 ops (cert rotation, etcd snapshot, drain) on custom + machine provisioning
   operations:
@@ -145,10 +145,10 @@ scopes:
       - '^tests/v2prov/tests/custom/'                 # also basic
       - '^tests/v2prov/tests/machineprovisioning/'    # also basic
     tests:
-      - { dist: k3s,  regex: '^Test_Operation_.*$'}        # k3s runs all ops in one instance
-      - { dist: rke2, regex: '^Test_Operation_SetA_.*$'}
-      - { dist: rke2, regex: '^Test_Operation_SetB_.*EtcdSnapshotOperationsOnNew.*$'}
-      - { dist: rke2, regex: '^Test_Operation_SetB_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode$' }
+      - { dist: k3s,  regex: '^Test_Operation_.*$', , parallelism: 5 } # k3s runs all ops in one instance
+      - { dist: rke2, regex: '^Test_Operation_SetA_.*$', , parallelism: 5 }
+      - { dist: rke2, regex: '^Test_Operation_SetB_.*EtcdSnapshotOperationsOnNew.*$', , parallelism: 10 }
+      - { dist: rke2, regex: '^Test_Operation_SetB_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode$'}
 
   imported:
     package-paths:
@@ -160,8 +160,8 @@ scopes:
     tests:
       - { dist: k3s,  regex: '^Test_Imported_Operation_SetD_(ImportedETCDSnapshotSave|ImportedETCDSnapshotRestore)$', cpus: 8 }
       - { dist: k3s,  regex: '^Test_Imported_Operation_SetD_(ImportedDisableSingleNode|ImportedDisableMultiNode)$', cpus: 8 }
-      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedETCDSnapshotSave|ImportedETCDSnapshotRestore|ImportedDisableSingleNode|ImportedDisableMultiNode)$' }
-      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedEncryptionKeyRotation|ImportedEncryptionKeyRotation_MultiNodeMixedRoles)$' }
+      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedETCDSnapshotSave|ImportedETCDSnapshotRestore|ImportedDisableSingleNode|ImportedDisableMultiNode)$', , parallelism: 5 }
+      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedEncryptionKeyRotation|ImportedEncryptionKeyRotation_MultiNodeMixedRoles)$', , parallelism: 5 }
 
   prebootstrap:
     package-paths:

--- a/.github/scripts/provisioning-test-scopes.yaml
+++ b/.github/scripts/provisioning-test-scopes.yaml
@@ -146,8 +146,8 @@ scopes:
       - '^tests/v2prov/tests/custom/'                 # also basic
       - '^tests/v2prov/tests/machineprovisioning/'    # also basic
     tests:
-      - { dist: k3s,  regex: '^Test_Operation_.*$', parallelism: 3 } # k3s runs all ops in one instance
-      - { dist: rke2, regex: '^Test_Operation_SetA_.*$', parallelism: 3 }
+      - { dist: k3s,  regex: '^Test_Operation_.*$' } # k3s runs all ops in one instance. This shard is too heavily to parallelize at the moment.
+      - { dist: rke2, regex: '^Test_Operation_SetA_.*$' }
       - { dist: rke2, regex: '^Test_Operation_SetB_.*EtcdSnapshotOperationsOnNew.*$', parallelism: 3 }
       - { dist: rke2, regex: '^Test_Operation_SetB_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode$'}
 

--- a/.github/scripts/provisioning-test-scopes.yaml
+++ b/.github/scripts/provisioning-test-scopes.yaml
@@ -24,10 +24,11 @@
 #       keeps triggering unconditionally via package-paths.
 #
 #   scopes.<name>.tests : the matrix rows to run when this scope is selected. Each row:
-#       dist      (required) -> V2PROV_TEST_DIST        (k3s | rke2)
-#       regex     (required) -> V2PROV_TEST_RUN_REGEX   (go test -run regex)
-#       features  (optional) -> CATTLE_FEATURES         (omit when unused)
-#       cpus      (optional) -> V2PROV_TEST_CPUS        (16 by default)
+#       dist        (required) -> V2PROV_TEST_DIST        (k3s | rke2)
+#       regex       (required) -> V2PROV_TEST_RUN_REGEX   (go test -run regex)
+#       features    (optional) -> CATTLE_FEATURES         (omit when unused)
+#       cpus        (optional) -> V2PROV_TEST_CPUS        (16 by default)
+#       parallelism (optional) -> V2PROV_TEST_PARALLELISM (1 by default)
 #
 #   Tests within a specific scope can be sharded by adding additional test entries,
 #   however care must be taken to ensure that the regexes are mutually exclusive.
@@ -132,8 +133,8 @@ scopes:
           - 'CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION'
           - 'CATTLE_K3S_VERSION'
     tests:
-      - { dist: k3s,  regex: '^Test_Provisioning_.*$', , parallelism: 10 }
-      - { dist: rke2, regex: '^Test_(General|Provisioning|Fleet)_.*$', parallelism: 10 }
+      - { dist: k3s,  regex: '^Test_Provisioning_(SetA|Custom_SetA)_.*$', parallelism: 3 }
+      - { dist: rke2, regex: '^Test_(General|Provisioning_SetA|Provisioning_Custom_SetA|Fleet)_.*$', parallelism: 3 }
 
   # day-2 ops (cert rotation, etcd snapshot, drain) on custom + machine provisioning
   operations:
@@ -145,9 +146,9 @@ scopes:
       - '^tests/v2prov/tests/custom/'                 # also basic
       - '^tests/v2prov/tests/machineprovisioning/'    # also basic
     tests:
-      - { dist: k3s,  regex: '^Test_Operation_.*$', , parallelism: 5 } # k3s runs all ops in one instance
-      - { dist: rke2, regex: '^Test_Operation_SetA_.*$', , parallelism: 5 }
-      - { dist: rke2, regex: '^Test_Operation_SetB_.*EtcdSnapshotOperationsOnNew.*$', , parallelism: 10 }
+      - { dist: k3s,  regex: '^Test_Operation_.*$', parallelism: 3 } # k3s runs all ops in one instance
+      - { dist: rke2, regex: '^Test_Operation_SetA_.*$', parallelism: 3 }
+      - { dist: rke2, regex: '^Test_Operation_SetB_.*EtcdSnapshotOperationsOnNew.*$', parallelism: 3 }
       - { dist: rke2, regex: '^Test_Operation_SetB_MP_EtcdSnapshotOperationsWithThreeEtcdNodesOnNewNode$'}
 
   imported:
@@ -160,8 +161,8 @@ scopes:
     tests:
       - { dist: k3s,  regex: '^Test_Imported_Operation_SetD_(ImportedETCDSnapshotSave|ImportedETCDSnapshotRestore)$', cpus: 8 }
       - { dist: k3s,  regex: '^Test_Imported_Operation_SetD_(ImportedDisableSingleNode|ImportedDisableMultiNode)$', cpus: 8 }
-      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedETCDSnapshotSave|ImportedETCDSnapshotRestore|ImportedDisableSingleNode|ImportedDisableMultiNode)$', , parallelism: 5 }
-      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedEncryptionKeyRotation|ImportedEncryptionKeyRotation_MultiNodeMixedRoles)$', , parallelism: 5 }
+      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedETCDSnapshotSave|ImportedETCDSnapshotRestore|ImportedDisableSingleNode|ImportedDisableMultiNode)$', parallelism: 3 }
+      - { dist: rke2, regex: '^Test_Imported_Operation_SetD_(ImportedEncryptionKeyRotation|ImportedEncryptionKeyRotation_MultiNodeMixedRoles)$', parallelism: 3 }
 
   prebootstrap:
     package-paths:
@@ -171,11 +172,14 @@ scopes:
       - { dist: rke2, regex: '^Test_PreBootstrap_.*$', features: 'provisioningprebootstrap=true', cpus: 8 }
       - { dist: k3s,  regex: '^Test_PreBootstrap_.*$', features: 'provisioningprebootstrap=true', cpus: 8 }
 
-#  An example of a scope that should only run when ALL=1, or the 'full' scope is triggered
-#  nightly:
-#    tests:
+  # An example of a scope that should only run when ALL=1, or the 'full' scope is triggered.
+  # These tests run in addition to the other defined scopes.
+  nightly:
+    tests:
+      - { dist: k3s,  regex: '^Test_Provisioning_(SetB|Custom_SetB)_.*$' }
+      - { dist: rke2, regex: '^Test_Provisioning_(SetB|Custom_SetB)_.*$' }
 #      - { dist: k3s,  regex: '^Test_Imported_Operation_(SetE_Imported|SetD_.*LifecycleHook).*$' }
-#      - { dist: rke2,  regex: '^Test_Imported_Operation_(SetE_Imported|SetD_.*LifecycleHook).*$' }
+#      - { dist: rke2, regex: '^Test_Imported_Operation_(SetE_Imported|SetD_.*LifecycleHook).*$' }
 
 full:
   - path: '^go.mod$'

--- a/.github/scripts/resolve-provisioning-matrix.sh
+++ b/.github/scripts/resolve-provisioning-matrix.sh
@@ -204,6 +204,7 @@ yq -o=json '.' "$CONFIG" | jq -c --arg selected "$selected" '
       | { V2PROV_TEST_DIST: .dist, V2PROV_TEST_RUN_REGEX: .regex }
         + (if .features then { CATTLE_FEATURES: .features } else {} end)
         + (if .cpus then { V2PROV_TEST_CPUS: .cpus } else { V2PROV_TEST_CPUS: 16 } end)
+        + (if .parallelism then { V2PROV_TEST_PARALLELISM: .parallelism } else { V2PROV_TEST_PARALLELISM: 1 } end)
     ]
   }
 '

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -80,6 +80,7 @@ jobs:
       REGISTRY: "172.17.0.2:5000"
       DRONE_BUILD_EVENT: "${{ github.event_name }}"
       V2PROV_TEST_RUN_REGEX: "${{ matrix.V2PROV_TEST_RUN_REGEX }}"
+      V2PROV_TEST_PARALLELISM: "${{ matrix.V2PROV_TEST_PARALLELISM }}"
       V2PROV_TEST_DIST: "${{ matrix.V2PROV_TEST_DIST }}"
       CATTLE_FEATURES: "${{ matrix.CATTLE_FEATURES }}"
       TAG: ${{ github.sha }}-head

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -349,7 +349,7 @@ if [ -z "${V2PROV_TEST_PARALLELISM}" ]; then
 fi
 
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test -run "${V2PROV_TEST_RUN_REGEX}" -v -failfast -timeout 60m -p 3 -parallelism "${V2PROV_TEST_PARALLELISM}" ./tests/v2prov/tests/... 2>&1 | tee /tmp/out.txt || {
+go test -run "${V2PROV_TEST_RUN_REGEX}" -v -failfast -timeout 60m -p 3 -parallel "${V2PROV_TEST_PARALLELISM}" ./tests/v2prov/tests/... 2>&1 | tee /tmp/out.txt || {
      dump_rancher_logs
      exit 1
 }

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -344,8 +344,12 @@ if [ -n "${PRECOMPILE_PID:-}" ]; then
   wait "$PRECOMPILE_PID" || { echo "background test compilation reported an error:"; cat /tmp/precompile.log || true; }
 fi
 
+if [ -z "${V2PROV_TEST_PARALLELISM}" ]; then
+  V2PROV_TEST_PARALLELISM=1
+fi
+
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test -run "${V2PROV_TEST_RUN_REGEX}" -v -failfast -timeout 60m -p 3 ./tests/v2prov/tests/... 2>&1 | tee /tmp/out.txt || {
+go test -run "${V2PROV_TEST_RUN_REGEX}" -v -failfast -timeout 60m -p 3 -parallelism "${V2PROV_TEST_PARALLELISM}" ./tests/v2prov/tests/... 2>&1 | tee /tmp/out.txt || {
      dump_rancher_logs
      exit 1
 }

--- a/tests/v2prov/tests/custom/custom_test.go
+++ b/tests/v2prov/tests/custom/custom_test.go
@@ -16,7 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func Test_Provisioning_Custom_OneNodeWithDelete(t *testing.T) {
+func Test_Provisioning_Custom_SetA_OneNodeWithDelete(t *testing.T) {
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()
 	}
@@ -92,7 +92,7 @@ func Test_Provisioning_Custom_OneNodeWithDelete(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_Custom_ThreeNode(t *testing.T) {
+func Test_Provisioning_Custom_SetA_ThreeNode(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -156,7 +156,7 @@ func Test_Provisioning_Custom_ThreeNode(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_Custom_UniqueRoles(t *testing.T) {
+func Test_Provisioning_Custom_SetB_UniqueRoles(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -236,7 +236,7 @@ func Test_Provisioning_Custom_UniqueRoles(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_Custom_ThreeNodeWithTaints(t *testing.T) {
+func Test_Provisioning_Custom_SetB_ThreeNodeWithTaints(t *testing.T) {
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()
 	}

--- a/tests/v2prov/tests/machineprovisioning/machine_test.go
+++ b/tests/v2prov/tests/machineprovisioning/machine_test.go
@@ -33,7 +33,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/core/v1beta2"
 )
 
-func Test_Provisioning_MP_SingleNodeAllRolesWithDelete(t *testing.T) {
+func Test_Provisioning_SetA_MP_SingleNodeAllRolesWithDelete(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -124,139 +124,7 @@ func Test_Provisioning_MP_SingleNodeAllRolesWithDelete(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_MP_MachineTemplateClonedAnnotations(t *testing.T) {
-	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
-		t.Skip()
-	}
-	t.Parallel()
-
-	clients, err := clients.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer clients.Close()
-
-	c, err := cluster.New(clients, &provisioningv1api.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-machine-template-cloned-annotations",
-		},
-		Spec: provisioningv1api.ClusterSpec{
-			KubernetesVersion: defaults.SomeK8sVersion,
-			RKEConfig: &provisioningv1api.RKEConfig{
-				MachinePools: []provisioningv1api.RKEMachinePool{{
-					EtcdRole:         true,
-					ControlPlaneRole: true,
-					WorkerRole:       true,
-					Quantity:         &defaults.One,
-				}},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err = cluster.WaitForCreate(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	infraMachines, err := cluster.PodInfraMachines(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, infraMachine := range infraMachines.Items {
-		templateGroupKind := schema.ParseGroupKind(infraMachine.GetAnnotations()[capi.TemplateClonedFromGroupKindAnnotation])
-
-		machineTemplate, err := clients.Dynamic.
-			Resource(schema.GroupVersionResource{Group: templateGroupKind.Group, Version: "v1", Resource: strings.ToLower(templateGroupKind.Kind) + "s"}).
-			Namespace(infraMachine.GetNamespace()).
-			Get(clients.Ctx, infraMachine.GetAnnotations()[capi.TemplateClonedFromNameAnnotation], metav1.GetOptions{})
-		if err != nil {
-			t.Fatal(err)
-		}
-		gv, err := schema.ParseGroupVersion(machineTemplate.GetAnnotations()[capr.MachineTemplateClonedFromGroupVersionAnn])
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		assert.Equal(t, gv.String(), capr.DefaultMachineConfigAPIVersion)
-		assert.Equal(t, machineTemplate.GetAnnotations()[capr.MachineTemplateClonedFromKindAnn], c.Spec.RKEConfig.MachinePools[0].NodeConfig.Kind)
-		assert.Equal(t, machineTemplate.GetAnnotations()[capr.MachineTemplateClonedFromNameAnn], c.Spec.RKEConfig.MachinePools[0].NodeConfig.Name)
-	}
-	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
-	assert.NoError(t, err)
-}
-
-func Test_Provisioning_MP_MachineSetDeletePolicyOldestSet(t *testing.T) {
-	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
-		t.Skip()
-	}
-	t.Parallel()
-
-	clients, err := clients.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer clients.Close()
-
-	c, err := cluster.New(clients, &provisioningv1api.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-machine-set-delete-policy-oldest-set",
-		},
-		Spec: provisioningv1api.ClusterSpec{
-			KubernetesVersion: defaults.SomeK8sVersion,
-			RKEConfig: &provisioningv1api.RKEConfig{
-				MachinePools: []provisioningv1api.RKEMachinePool{
-					{
-						EtcdRole:         true,
-						ControlPlaneRole: true,
-						WorkerRole:       true,
-						Quantity:         &defaults.One,
-					},
-					{
-						EtcdRole:         true,
-						ControlPlaneRole: true,
-						WorkerRole:       true,
-						Quantity:         &defaults.One,
-						RollingUpdate: &provisioningv1api.RKEMachinePoolRollingUpdate{
-							MaxUnavailable: &intstr.IntOrString{
-								Type:   intstr.String,
-								StrVal: "10%",
-							},
-							MaxSurge: &intstr.IntOrString{
-								Type:   intstr.String,
-								StrVal: "10%",
-							},
-						},
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err = cluster.WaitForCreate(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	machineSets, err := cluster.MachineSets(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	for _, machineSet := range machineSets.Items {
-		assert.Equal(t, capi.OldestMachineSetDeletionOrder, machineSet.Spec.Deletion.Order)
-	}
-	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
-	assert.NoError(t, err)
-}
-
-func Test_Provisioning_MP_MultipleEtcdNodesScaledDownThenDelete(t *testing.T) {
+func Test_Provisioning_SetA_MP_MultipleEtcdNodesScaledDownThenDelete(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -363,7 +231,195 @@ func Test_Provisioning_MP_MultipleEtcdNodesScaledDownThenDelete(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_MP_FiveNodesUniqueRolesWithDelete(t *testing.T) {
+func Test_Provisioning_SetB_MP_DrainNoDelete(t *testing.T) {
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	c, err := cluster.New(clients, &provisioningv1api.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-drain-no-delete",
+		},
+		Spec: provisioningv1api.ClusterSpec{
+			KubernetesVersion: defaults.SomeK8sVersion,
+			RKEConfig: &provisioningv1api.RKEConfig{
+				MachinePools: []provisioningv1api.RKEMachinePool{
+					{
+						EtcdRole:          true,
+						ControlPlaneRole:  true,
+						Quantity:          &defaults.One,
+						DrainBeforeDelete: false,
+					},
+					{
+						WorkerRole:        true,
+						Quantity:          &defaults.One,
+						DrainBeforeDelete: true,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machines, err := cluster.Machines(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, len(machines.Items), 2)
+
+	excludeNodeDraining, ok := machines.Items[0].Annotations[capi.ExcludeNodeDrainingAnnotation]
+	assert.True(t, ok)
+	assert.Equal(t, excludeNodeDraining, "true")
+
+	_, ok = machines.Items[1].Annotations[capi.ExcludeNodeDrainingAnnotation]
+	assert.False(t, ok)
+	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
+	assert.NoError(t, err)
+}
+
+func Test_Provisioning_SetB_MP_MachineTemplateClonedAnnotations(t *testing.T) {
+	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
+		t.Skip()
+	}
+	t.Parallel()
+
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	c, err := cluster.New(clients, &provisioningv1api.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-machine-template-cloned-annotations",
+		},
+		Spec: provisioningv1api.ClusterSpec{
+			KubernetesVersion: defaults.SomeK8sVersion,
+			RKEConfig: &provisioningv1api.RKEConfig{
+				MachinePools: []provisioningv1api.RKEMachinePool{{
+					EtcdRole:         true,
+					ControlPlaneRole: true,
+					WorkerRole:       true,
+					Quantity:         &defaults.One,
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	infraMachines, err := cluster.PodInfraMachines(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, infraMachine := range infraMachines.Items {
+		templateGroupKind := schema.ParseGroupKind(infraMachine.GetAnnotations()[capi.TemplateClonedFromGroupKindAnnotation])
+
+		machineTemplate, err := clients.Dynamic.
+			Resource(schema.GroupVersionResource{Group: templateGroupKind.Group, Version: "v1", Resource: strings.ToLower(templateGroupKind.Kind) + "s"}).
+			Namespace(infraMachine.GetNamespace()).
+			Get(clients.Ctx, infraMachine.GetAnnotations()[capi.TemplateClonedFromNameAnnotation], metav1.GetOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		gv, err := schema.ParseGroupVersion(machineTemplate.GetAnnotations()[capr.MachineTemplateClonedFromGroupVersionAnn])
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		assert.Equal(t, gv.String(), capr.DefaultMachineConfigAPIVersion)
+		assert.Equal(t, machineTemplate.GetAnnotations()[capr.MachineTemplateClonedFromKindAnn], c.Spec.RKEConfig.MachinePools[0].NodeConfig.Kind)
+		assert.Equal(t, machineTemplate.GetAnnotations()[capr.MachineTemplateClonedFromNameAnn], c.Spec.RKEConfig.MachinePools[0].NodeConfig.Name)
+	}
+	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
+	assert.NoError(t, err)
+}
+
+func Test_Provisioning_SetB_MP_MachineSetDeletePolicyOldestSet(t *testing.T) {
+	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
+		t.Skip()
+	}
+	t.Parallel()
+
+	clients, err := clients.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clients.Close()
+
+	c, err := cluster.New(clients, &provisioningv1api.Cluster{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-machine-set-delete-policy-oldest-set",
+		},
+		Spec: provisioningv1api.ClusterSpec{
+			KubernetesVersion: defaults.SomeK8sVersion,
+			RKEConfig: &provisioningv1api.RKEConfig{
+				MachinePools: []provisioningv1api.RKEMachinePool{
+					{
+						EtcdRole:         true,
+						ControlPlaneRole: true,
+						WorkerRole:       true,
+						Quantity:         &defaults.One,
+					},
+					{
+						EtcdRole:         true,
+						ControlPlaneRole: true,
+						WorkerRole:       true,
+						Quantity:         &defaults.One,
+						RollingUpdate: &provisioningv1api.RKEMachinePoolRollingUpdate{
+							MaxUnavailable: &intstr.IntOrString{
+								Type:   intstr.String,
+								StrVal: "10%",
+							},
+							MaxSurge: &intstr.IntOrString{
+								Type:   intstr.String,
+								StrVal: "10%",
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c, err = cluster.WaitForCreate(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	machineSets, err := cluster.MachineSets(clients, c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, machineSet := range machineSets.Items {
+		assert.Equal(t, capi.OldestMachineSetDeletionOrder, machineSet.Spec.Deletion.Order)
+	}
+	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
+	assert.NoError(t, err)
+}
+
+func Test_Provisioning_SetB_MP_FiveNodesUniqueRolesWithDelete(t *testing.T) {
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()
 	}
@@ -420,7 +476,7 @@ func Test_Provisioning_MP_FiveNodesUniqueRolesWithDelete(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_MP_FourNodesServerAndWorkerRolesWithDelete(t *testing.T) {
+func Test_Provisioning_SetB_MP_FourNodesServerAndWorkerRolesWithDelete(t *testing.T) {
 	if strings.ToLower(os.Getenv("DIST")) == "rke2" {
 		t.Skip()
 	}
@@ -474,7 +530,7 @@ func Test_Provisioning_MP_FourNodesServerAndWorkerRolesWithDelete(t *testing.T) 
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_MP_Drain(t *testing.T) {
+func Test_Provisioning_SetB_MP_Drain(t *testing.T) {
 	clients, err := clients.New()
 	if err != nil {
 		t.Fatal(err)
@@ -617,63 +673,7 @@ func Test_Provisioning_MP_Drain(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func Test_Provisioning_MP_DrainNoDelete(t *testing.T) {
-	clients, err := clients.New()
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer clients.Close()
-
-	c, err := cluster.New(clients, &provisioningv1api.Cluster{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "test-drain-no-delete",
-		},
-		Spec: provisioningv1api.ClusterSpec{
-			KubernetesVersion: defaults.SomeK8sVersion,
-			RKEConfig: &provisioningv1api.RKEConfig{
-				MachinePools: []provisioningv1api.RKEMachinePool{
-					{
-						EtcdRole:          true,
-						ControlPlaneRole:  true,
-						Quantity:          &defaults.One,
-						DrainBeforeDelete: false,
-					},
-					{
-						WorkerRole:        true,
-						Quantity:          &defaults.One,
-						DrainBeforeDelete: true,
-					},
-				},
-			},
-		},
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	c, err = cluster.WaitForCreate(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	machines, err := cluster.Machines(clients, c)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, len(machines.Items), 2)
-
-	excludeNodeDraining, ok := machines.Items[0].Annotations[capi.ExcludeNodeDrainingAnnotation]
-	assert.True(t, ok)
-	assert.Equal(t, excludeNodeDraining, "true")
-
-	_, ok = machines.Items[1].Annotations[capi.ExcludeNodeDrainingAnnotation]
-	assert.False(t, ok)
-	err = cluster.EnsureMinimalConflictsWithThreshold(clients, c, cluster.SaneConflictMessageThreshold)
-	assert.NoError(t, err)
-}
-
-func Test_Provisioning_Single_Node_All_Roles_Drain(t *testing.T) {
+func Test_Provisioning_SetB_Single_Node_All_Roles_Drain(t *testing.T) {
 	clients, err := clients.New()
 	require.NoError(t, err)
 	defer clients.Close()


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55231

## Problem
Prior PRs have focused on making it easier to shard the provisioning tests, limited what tests run depending on the changes in a PR, and improved stability by reducing disk throughput issues. However, they did not directly impact the total runtime of the basic provisioning tests scenario (though they did result in a reduction of failed attempts, with helps with total runtime globally). Regardless, waiting ~50 minutes for CI to pass is still painful.

## Solution
This PR further shards the basic provisioning test cases so that the majority of PRs which trigger the `basic` scope do not have to wait 40-50 minutes for CI to pass. This is done by renaming the `machine_test.go` and `custom_test.go` test cases, and updating the test regexes used in the basic scope. This results in most PRs not running the bulkier tests, but still covering the basic provisioning flow. The tests which are no longer run in the basic scope have been added to the nightly scope, ensuring that they are still executed regularly. 

With this change, the following tests will run on a PR basis, when a relevant file or directory has been changed: 
+ Test_Provisioning_Custom_SetA_OneNodeWithDelete
+ Test_Provisioning_Custom_SetA_ThreeNode
+ Test_Provisioning_SetA_MP_SingleNodeAllRolesWithDelete
+ Test_Provisioning_SetA_MP_MultipleEtcdNodesScaledDownThenDelete

The following tests have been relegated to the nightly test suite:
+ Test_Provisioning_Custom_SetB_UniqueRoles
+ Test_Provisioning_Custom_SetB_ThreeNodeWithTaints
+ Test_Provisioning_SetB_MP_DrainNoDelete
+ Test_Provisioning_SetB_MP_MachineTemplateClonedAnnotations
+ Test_Provisioning_SetB_MP_MachineSetDeletePolicyOldestSet
+ Test_Provisioning_SetB_MP_FiveNodesUniqueRolesWithDelete
+ Test_Provisioning_SetB_MP_FourNodesServerAndWorkerRolesWithDelete
+ Test_Provisioning_SetB_MP_Drain
  + Putting this test into the nightly suite specifically results in the biggest speedup, as it alone takes ~15 mins on main
+ Test_Provisioning_SetB_Single_Node_All_Roles_Drain

**A core part of this PR review that I could use help with is determining if the new SetA regex sufficiently covers the basic provisioning functionality, or if we need to include more tests to properly catch regressions early.** Happy to shift some back into SetA if we feel that the extra time is worth it. 

Additionally, this PR exposes a new `parallelism` field to the scopes file and applicable scripts/workflows. This knob allows for further fine turning of `go test` execution on a per-shard basis. This should let us speed up tests even more once we fine tune the CI runners and can start to add more `t.parallel` calls without hitting resource bottle necks.

## Testing

The CI of this PR is its testing. Recent CI runs show that the reduced test regex used in the basic scope brings those test cases down to ~15 minutes. The other half of those tests are also still executed and are passing, after ~30 minutes.

The total runtime of the CI for this PR is misleading, as updating the provisioning-tests script runs all tests, most of which are not the focus of this PR. 