### PR TITLE
Handle concurrent ConfigMap updates when creating a Kubeconfig

### DIFF
--- a/pkg/ext/stores/kubeconfig/errors.go
+++ b/pkg/ext/stores/kubeconfig/errors.go
@@ -47,7 +47,7 @@ func mapBackingError(err error, resource string) error {
 		}
 		return rebuilt
 	case apierrors.IsInvalid(err):
-		logrus.Warnf("invalid backing object for kubeconfig %s: %v", resource, err)
+		logrus.Warnf("kubeconfig: invalid backing object for kubeconfig %s: %v", resource, err)
 		var errs field.ErrorList
 		if details := statusDetails(err); details != nil {
 			for _, c := range details.Causes {
@@ -60,20 +60,20 @@ func mapBackingError(err error, resource string) error {
 		}
 		return apierrors.NewInvalid(schema.GroupKind{Group: gvr.Group, Kind: Kind}, resource, errs)
 	case apierrors.IsBadRequest(err):
-		logrus.Warnf("bad request on backing object for kubeconfig %s: %v", resource, err)
+		logrus.Warnf("kubeconfig: bad request on backing object for kubeconfig %s: %v", resource, err)
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid request for kubeconfig %s", resource))
 	case apierrors.IsTooManyRequests(err):
 		var retryAfter int32
 		if details := statusDetails(err); details != nil {
 			retryAfter = details.RetryAfterSeconds
 		}
-		logrus.Warnf("backing store throttled for kubeconfig %s: %v", resource, err)
+		logrus.Warnf("kubeconfig: backing store throttled for kubeconfig %s: %v", resource, err)
 		return apierrors.NewTooManyRequests(fmt.Sprintf("too many requests for kubeconfig %s", resource), int(retryAfter))
 	case apierrors.IsServiceUnavailable(err):
-		logrus.Warnf("backing store unavailable for kubeconfig %s: %v", resource, err)
+		logrus.Warnf("kubeconfig: backing store unavailable for kubeconfig %s: %v", resource, err)
 		return apierrors.NewServiceUnavailable(fmt.Sprintf("backing store unavailable for kubeconfig %s", resource))
 	default:
-		logrus.Errorf("backing store error for kubeconfig %s: %v", resource, err)
+		logrus.Errorf("kubeconfig: backing store error for kubeconfig %s: %v", resource, err)
 		return apierrors.NewInternalError(errors.New("error accessing backing object for kubeconfig " + resource))
 	}
 }

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"net/url"
 	"reflect"
 	"strconv"
@@ -49,6 +50,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage/names"
 	"k8s.io/client-go/features"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/kubernetes/pkg/printers"
 	printerstorage "k8s.io/kubernetes/pkg/printers/storage"
 	"sigs.k8s.io/structured-merge-diff/v4/fieldpath"
@@ -505,12 +507,16 @@ func (s *Store) Create(
 			}
 
 			sharedTokenKey = sharedToken.Status.BearerToken
+			// Note the token down before anything else can go wrong. Both the
+			// stored record and the cleanup below work off tokenIDs, so a token
+			// that never gets added to it can no longer be deleted.
+			tokenIDs = append(tokenIDs, sharedToken.Name)
+
 			ownerRef, err := s.secretOwnerRef(sharedToken.Name)
 			if err != nil {
 				return apierrors.NewInternalError(fmt.Errorf("error getting owner reference for shared token: %v", err))
 			}
 			ownerRefs = append(ownerRefs, ownerRef)
-			tokenIDs = append(tokenIDs, sharedToken.Name)
 
 			conditions = append(conditions, metav1.Condition{
 				Type:               TokenCreatedCond,
@@ -596,12 +602,13 @@ func (s *Store) Create(
 				}
 
 				tokenKey = clusterToken.Status.BearerToken
+				tokenIDs = append(tokenIDs, clusterToken.Name) // See the shared token above.
+
 				ownerRef, err := s.secretOwnerRef(clusterToken.Name)
 				if err != nil {
 					return apierrors.NewInternalError(fmt.Errorf("error getting owner reference for token: %v", err))
 				}
 				ownerRefs = append(ownerRefs, ownerRef)
-				tokenIDs = append(tokenIDs, clusterToken.Name)
 
 				conditions = append(conditions, metav1.Condition{
 					Type:               TokenCreatedCond,
@@ -713,25 +720,41 @@ func (s *Store) Create(
 	kubeconfigToStore.Status.Tokens = tokenIDs
 	kubeconfigToStore.OwnerReferences = append(kubeconfigToStore.OwnerReferences, ownerRefs...)
 
-	var convertErr error
-	configMap, convertErr = s.toConfigMap(kubeconfigToStore)
-	if convertErr == nil {
-		if !dryRun {
-			var updateErr error
-			configMap, updateErr = s.configMapClient.Update(configMap)
-			if updateErr != nil {
-				if err == nil {
-					err = mapBackingError(updateErr, kubeConfigID)
-				} // else preserve the original error.
-			}
-		}
-	} else {
+	// What the kubeconfig ended up as, a failed attempt included, is saved back
+	// to the ConfigMap created above. Keeping a failed one is on purpose: it
+	// lists the tokens that were created, so the user can still delete the
+	// kubeconfig and have those tokens deleted with it. That only works if this
+	// last save succeeds, which is what recorded tracks.
+	recorded := dryRun
+
+	desiredConfigMap, convertErr := s.toConfigMap(kubeconfigToStore)
+	switch {
+	case convertErr != nil:
 		if err == nil {
 			err = apierrors.NewInternalError(fmt.Errorf("error converting kubeconfig %s to configmap: %v", kubeConfigID, convertErr))
 		} // else preserve the original error.
+	case dryRun:
+		configMap = desiredConfigMap
+	default:
+		finalized, finalizeErr := s.finalizeConfigMap(configMap, desiredConfigMap)
+		if finalizeErr != nil {
+			if err == nil {
+				err = mapBackingError(finalizeErr, kubeConfigID)
+			} // else preserve the original error.
+			break
+		}
+		configMap, recorded = finalized, true
 	}
 
 	if err != nil {
+		if !recorded {
+			// Nothing points at the tokens that were created: their IDs never
+			// reached the ConfigMap, so deleting the kubeconfig later won't
+			// delete them either. Remove them here along with the unfinished
+			// record, so that a create which reports a failure doesn't leave
+			// working credentials behind.
+			s.cleanupIncompleteKubeconfig(kubeConfigID, tokenIDs)
+		}
 		return nil, err
 	}
 
@@ -806,6 +829,153 @@ func (s *Store) toConfigMap(kubeconfig *ext.Kubeconfig) (*corev1.ConfigMap, erro
 	}
 
 	return configMap, nil
+}
+
+// finalizeConfigMap saves the finished kubeconfig into the ConfigMap that
+// [Store.Create] already made for it.
+//
+// Create is a two-phase write. The first phase stores an empty record and gets
+// back the generated name, which the tokens need. The second phase, done here,
+// saves the tokens and the rest of the finished kubeconfig. Only the store knows
+// about the first phase: the client never sees the resourceVersion it produced,
+// and retrying the request would make a whole new ConfigMap and a whole new set
+// of tokens rather than repeat this one write. So when something else changes
+// the ConfigMap in between - another controller adding a label to it, for
+// example - the request must not fail. Read the ConfigMap again instead and
+// write the fields the store owns onto the version that is now stored.
+func (s *Store) finalizeConfigMap(created, desired *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+	var (
+		latest    = created
+		finalized *corev1.ConfigMap
+	)
+
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		if latest == nil {
+			refreshed, err := s.configMapClient.Get(namespace, created.Name, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+			latest = refreshed
+		}
+
+		updated, err := s.configMapClient.Update(mergeConfigMap(latest, desired))
+		if err != nil {
+			latest = nil // Read the ConfigMap again before the next attempt.
+			return err
+		}
+
+		finalized = updated
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return finalized, nil
+}
+
+// mergeConfigMap copies the fields the store owns onto the ConfigMap as it is
+// currently stored, leaving whatever anything else wrote there in place. The
+// result has the current resourceVersion and can be sent as an update.
+//
+// Data and metadata are handled differently on purpose. Every key under data
+// belongs to the store, so the whole map is replaced and a key the store has
+// stopped writing goes away. Labels and annotations are shared with anything
+// else that touches the ConfigMap, so a key the store doesn't write is far more
+// likely to belong to someone else than to be one of the store's own left over
+// from an earlier version. Those are only added or overwritten, never removed,
+// which means dropping a label or an annotation the store used to set needs an
+// explicit delete here.
+func mergeConfigMap(latest, desired *corev1.ConfigMap) *corev1.ConfigMap {
+	merged := latest.DeepCopy()
+	// Cloned rather than shared: desired is built once and reused for every
+	// attempt, so it must not end up pointing at a map that was handed to the
+	// client.
+	merged.Data = maps.Clone(desired.Data)
+
+	if merged.Labels == nil && len(desired.Labels) > 0 {
+		merged.Labels = make(map[string]string, len(desired.Labels))
+	}
+	maps.Copy(merged.Labels, desired.Labels)
+
+	if merged.Annotations == nil && len(desired.Annotations) > 0 {
+		merged.Annotations = make(map[string]string, len(desired.Annotations))
+	}
+	maps.Copy(merged.Annotations, desired.Annotations)
+
+	merged.OwnerReferences = mergeOwnerReferences(merged.OwnerReferences, desired.OwnerReferences)
+
+	// ManagedFields are left as the API server reported them: it works them out
+	// again on every update and ignores whatever the request carries.
+
+	return merged
+}
+
+// mergeOwnerReferences returns the two lists of owner references combined,
+// matching entries up by UID. Where the same UID is in both lists, the entry
+// from desired is the one kept.
+//
+// Both lists have to survive, which is why this isn't a plain replace like
+// [mergeConfigMap] does for data. The references the store writes are what makes
+// Kubernetes delete the ConfigMap once the tokens it points at are gone, so
+// losing them would leave the record behind forever. A reference that only the
+// stored ConfigMap has was put there by something else between the two writes,
+// and dropping it would break whatever that something else is relying on.
+//
+// It isn't a plain concatenation either. The desired list is built from the
+// ConfigMap the first write returned, so the references that were already on it
+// are in both lists, and appending would list them twice.
+func mergeOwnerReferences(existing, desired []metav1.OwnerReference) []metav1.OwnerReference {
+	if len(desired) == 0 {
+		return existing
+	}
+
+	merged := make([]metav1.OwnerReference, 0, len(existing)+len(desired))
+	indexByUID := make(map[types.UID]int, len(existing)+len(desired))
+
+	for _, refs := range [][]metav1.OwnerReference{existing, desired} {
+		for _, ref := range refs {
+			if i, ok := indexByUID[ref.UID]; ok {
+				merged[i] = ref
+				continue
+			}
+			indexByUID[ref.UID] = len(merged)
+			merged = append(merged, ref)
+		}
+	}
+
+	return merged
+}
+
+// cleanupIncompleteKubeconfig removes what a failed [Store.Create] left behind:
+// the tokens it had already created and the ConfigMap still holding the
+// unfinished record. Create is already returning an error, so anything that
+// goes wrong here is logged rather than reported.
+func (s *Store) cleanupIncompleteKubeconfig(name string, tokenIDs []string) {
+	for _, tokenID := range tokenIDs {
+		if err := s.deleteToken(tokenID, &metav1.DeleteOptions{}); err != nil {
+			logrus.Errorf("kubeconfig: error deleting token %s of incomplete kubeconfig %s: %v", tokenID, name, err)
+		}
+	}
+
+	if err := s.configMapClient.Delete(namespace, name, &metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+		logrus.Errorf("kubeconfig: error deleting configmap of incomplete kubeconfig %s: %v", name, err)
+	}
+}
+
+// deleteToken removes one of a kubeconfig's tokens, falling back to the v3 token
+// client for tokens created before the ext token store existed. A token that is
+// already gone is not an error.
+func (s *Store) deleteToken(name string, options *metav1.DeleteOptions) error {
+	err := s.tokenStore.Delete(name, options)
+	if apierrors.IsNotFound(err) {
+		err = s.v3Tokens.Delete(name, options)
+	}
+	if apierrors.IsNotFound(err) {
+		return nil
+	}
+
+	return err
 }
 
 // fromConfigMap converts a ConfigMap object to a Kubeconfig object.
@@ -1500,11 +1670,7 @@ func (s *Store) delete(
 			PropagationPolicy:  options.PropagationPolicy,
 			DryRun:             options.DryRun,
 		}
-		err := s.tokenStore.Delete(tokenName, delOptions)
-		if apierrors.IsNotFound(err) {
-			err = s.v3Tokens.Delete(tokenName, delOptions)
-		}
-		if err != nil && !apierrors.IsNotFound(err) {
+		if err := s.deleteToken(tokenName, delOptions); err != nil {
 			return nil, false, mapBackingError(err, configMap.Name)
 		}
 	}

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -25,6 +25,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/accessor"
 	"github.com/rancher/rancher/pkg/auth/providers/common"
+	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/rancher/wrangler/v3/pkg/randomtoken"
 	"github.com/stretchr/testify/assert"
@@ -67,6 +68,23 @@ var commonAuthorizer = authorizer.AuthorizerFunc(func(ctx context.Context, a aut
 		return authorizer.DecisionDeny, "", nil
 	}
 })
+
+// allowAllAuthorizer lets every request through, for tests that are about
+// something other than authorization.
+var allowAllAuthorizer = authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+	return authorizer.DecisionAllow, "", nil
+})
+
+// userContext returns a request context for the named user. A non-empty tokenID
+// is attached as the token the request was authenticated with.
+func userContext(name, tokenID string) context.Context {
+	info := &k8suser.DefaultInfo{Name: name}
+	if tokenID != "" {
+		info.Extra = map[string][]string{common.ExtraRequestTokenID: {tokenID}}
+	}
+
+	return request.WithUser(context.Background(), info)
+}
 
 type fakeTokenManager struct {
 	sharedTokenKeys  []string
@@ -479,11 +497,34 @@ func TestStoreCreate(t *testing.T) {
 	options := &metav1.CreateOptions{}
 	tokenManager := &fakeTokenManager{}
 
-	t.Run("user creates a kubeconfig", func(t *testing.T) {
-		authorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
+	// newStore builds a store on the fixtures above, with authorization allowing
+	// everything. The three arguments are what the subtests below vary most; each
+	// opts function gets to change anything else.
+	newStore := func(configMapClient v1.ConfigMapClient, tokenStore tokenFetcher, tokenMgr tokenCreator, opts ...func(*Store)) *Store {
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAllAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenMgr,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getMaxTTL:           getMaxTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+		for _, opt := range opts {
+			opt(store)
+		}
 
+		return store
+	}
+
+	t.Run("user creates a kubeconfig", func(t *testing.T) {
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -508,29 +549,9 @@ func TestStoreCreate(t *testing.T) {
 			return tokenManager.generate(token)
 		}
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          authorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager)
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -667,12 +688,7 @@ func TestStoreCreate(t *testing.T) {
 			shouldGenerateToken: shouldGenerateToken,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Description: "Test Kubeconfig",
@@ -754,12 +770,7 @@ func TestStoreCreate(t *testing.T) {
 			shouldGenerateToken: shouldGenerateToken,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(adminID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -839,10 +850,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, "downstream1", config.CurrentContext)
 	})
 	t.Run("token generation disabled", func(t *testing.T) {
-		authorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -860,7 +867,7 @@ func TestStoreCreate(t *testing.T) {
 
 		store := &Store{
 			mcmEnabled:          true,
-			authorizer:          authorizer,
+			authorizer:          allowAllAuthorizer,
 			nsCache:             nsCache,
 			configMapClient:     configMapClient,
 			userCache:           userCache,
@@ -875,12 +882,7 @@ func TestStoreCreate(t *testing.T) {
 			shouldGenerateToken: func() bool { return false },
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -914,7 +916,7 @@ func TestStoreCreate(t *testing.T) {
 		assert.Contains(t, downstream2Exec.Args, "--cluster="+downstream2)
 	})
 	t.Run("all clusters specified", func(t *testing.T) {
-		authorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+		clusterAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 			switch a.GetResource() {
 			case v3.ClusterResourceName:
 				if a.GetName() == downstream1 {
@@ -947,7 +949,7 @@ func TestStoreCreate(t *testing.T) {
 
 		store := &Store{
 			mcmEnabled:          true,
-			authorizer:          authorizer,
+			authorizer:          clusterAuthorizer,
 			nsCache:             nsCache,
 			configMapClient:     configMapClient,
 			userCache:           userCache,
@@ -961,12 +963,7 @@ func TestStoreCreate(t *testing.T) {
 			shouldGenerateToken: shouldGenerateToken,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:    []string{"*"},
@@ -1035,10 +1032,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, "downstream1", config.CurrentContext)
 	})
 	t.Run("MCM disabled", func(t *testing.T) {
-		authorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -1057,7 +1050,7 @@ func TestStoreCreate(t *testing.T) {
 		tokenManager := &fakeTokenManager{} // Subtest specific instance.
 
 		store := &Store{
-			authorizer:          authorizer,
+			authorizer:          allowAllAuthorizer,
 			nsCache:             nsCache,
 			configMapClient:     configMapClient,
 			userCache:           userCache,
@@ -1071,12 +1064,7 @@ func TestStoreCreate(t *testing.T) {
 			shouldGenerateToken: shouldGenerateToken,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters: []string{"local"},
@@ -1150,9 +1138,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:   tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminSA,
-		})
+		ctx := userContext(adminSA, "")
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -1174,9 +1160,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:   tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -1198,12 +1182,7 @@ func TestStoreCreate(t *testing.T) {
 			tokenMgr:   tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {"non-existent"},
-			},
-			Name: userID,
-		})
+		ctx := userContext(userID, "non-existent")
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -1229,12 +1208,7 @@ func TestStoreCreate(t *testing.T) {
 			getMaxTTL: getMaxTTL,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 
 		obj, err := store.Create(ctx, &ext.Kubeconfig{}, nil, options)
 		require.Error(t, err)
@@ -1253,12 +1227,7 @@ func TestStoreCreate(t *testing.T) {
 			getMaxTTL:     getMaxTTL,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-			Name: userID,
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -1283,12 +1252,7 @@ func TestStoreCreate(t *testing.T) {
 			getMaxTTL:     getMaxTTL,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-			Name: userID,
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:       []string{downstream1, downstream2},
@@ -1313,12 +1277,7 @@ func TestStoreCreate(t *testing.T) {
 			getMaxTTL:     getMaxTTL,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				IncludeDefaultEntry: ptr.To(false),
@@ -1332,10 +1291,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.ErrorContains(t, err, "at least one cluster is required when includeDefaultEntry is false")
 	})
 	t.Run("exclude default entry with non-ACE clusters", func(t *testing.T) {
-		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -1351,29 +1306,9 @@ func TestStoreCreate(t *testing.T) {
 
 		tokenManager := &fakeTokenManager{}
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          allowAuthorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager)
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:            []string{downstream1},
@@ -1409,10 +1344,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, "downstream1", config.CurrentContext)
 	})
 	t.Run("exclude default entry with ACE-only clusters", func(t *testing.T) {
-		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -1428,29 +1359,9 @@ func TestStoreCreate(t *testing.T) {
 
 		tokenManager := &fakeTokenManager{}
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          allowAuthorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager)
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:            []string{downstream2},
@@ -1477,10 +1388,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, "downstream2-cp", config.CurrentContext)
 	})
 	t.Run("select first ready control plane node as current context", func(t *testing.T) {
-		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -1546,29 +1453,9 @@ func TestStoreCreate(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          allowAuthorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager, func(s *Store) { s.nodeCache = nodeCache })
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
@@ -1589,10 +1476,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, "downstream2-cp2", config.CurrentContext)
 	})
 	t.Run("fall back to proxy context when all control plane nodes are not ready", func(t *testing.T) {
-		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -1658,29 +1541,9 @@ func TestStoreCreate(t *testing.T) {
 			},
 		}, nil).Times(1)
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          allowAuthorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager, func(s *Store) { s.nodeCache = nodeCache })
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
@@ -1703,10 +1566,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.Contains(t, config.Contexts, "downstream2-cp2")
 	})
 	t.Run("exclude default entry with mixed clusters", func(t *testing.T) {
-		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -1722,29 +1581,9 @@ func TestStoreCreate(t *testing.T) {
 
 		tokenManager := &fakeTokenManager{}
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          allowAuthorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager)
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:            []string{downstream1, downstream2},
@@ -1773,10 +1612,6 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, "downstream1", config.CurrentContext)
 	})
 	t.Run("include default entry explicitly", func(t *testing.T) {
-		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		var configMap *corev1.ConfigMap
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
@@ -1792,29 +1627,9 @@ func TestStoreCreate(t *testing.T) {
 
 		tokenManager := &fakeTokenManager{}
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          allowAuthorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager)
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters:            []string{downstream1},
@@ -1867,12 +1682,7 @@ func TestStoreCreate(t *testing.T) {
 			shouldGenerateToken: shouldGenerateToken,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(adminID, authTokenID)
 
 		obj, err := store.Create(ctx, &ext.Kubeconfig{}, nil, &metav1.CreateOptions{})
 		require.NoError(t, err)
@@ -1894,38 +1704,14 @@ func TestStoreCreate(t *testing.T) {
 		// mapBackingError must be applied to the configMapClient.Create call so
 		// that a quota-exceeded or webhook-rejected Forbidden reaches the client
 		// as 403, not wrapped as a 500 InternalError.
-		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-			return authorizer.DecisionAllow, "", nil
-		})
-
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Create(gomock.Any()).Return(nil,
 			apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("quota exceeded")),
 		).Times(1)
 
-		store := &Store{
-			mcmEnabled:          true,
-			authorizer:          allowAuthorizer,
-			nsCache:             nsCache,
-			configMapClient:     configMapClient,
-			userCache:           userCache,
-			tokenStore:          tokenStore,
-			clusterCache:        clusterCache,
-			nodeCache:           nodeCache,
-			tokenMgr:            tokenManager,
-			getCACert:           func() string { return rancherCACert },
-			getDefaultTTL:       getDefaultTTL,
-			getMaxTTL:           getMaxTTL,
-			getServerURL:        getServerURL,
-			shouldGenerateToken: shouldGenerateToken,
-		}
+		store := newStore(configMapClient, tokenStore, tokenManager)
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {authTokenID},
-			},
-		})
+		ctx := userContext(userID, authTokenID)
 		kubeconfig := &ext.Kubeconfig{
 			Spec: ext.KubeconfigSpec{
 				Clusters: []string{downstream1},
@@ -1938,6 +1724,403 @@ func TestStoreCreate(t *testing.T) {
 		assert.True(t, apierrors.IsForbidden(err), "backing Forbidden must surface as 403, got %v", err)
 		assert.False(t, apierrors.IsInternalError(err), "must not be wrapped as InternalError, got %v", err)
 	})
+	t.Run("completion write retries when the backing configmap changed concurrently", func(t *testing.T) {
+		// Create is a two-phase write and the client never sees the
+		// resourceVersion of the first phase, so a conflict on the second one
+		// has to be sorted out here instead of failing the request. Anything
+		// that adds labels to ConfigMaps outside of Rancher sets this off - the
+		// k3k kubelet copying them between the host cluster and the virtual one,
+		// for example - and the labels it added have to survive the retry.
+		const foreignLabel = "objectset.rio.cattle.io/owner-name"
+
+		var stored *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			stored = obj.DeepCopy()
+			stored.Name = names.SimpleNameGenerator.GenerateName(obj.GenerateName)
+			stored.ResourceVersion = "1"
+			response := stored.DeepCopy()
+
+			// The other writer gets in right after the response was sent, so
+			// the store is left holding an out-of-date resourceVersion.
+			stored.ResourceVersion = "2"
+			stored.Labels[foreignLabel] = "virtual"
+
+			return response, nil
+		}).Times(1)
+
+		var updates int
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			updates++
+			if obj.ResourceVersion != stored.ResourceVersion {
+				return nil, apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.Name,
+					errors.New("the object has been modified; please apply your changes to the latest version and try again"))
+			}
+			stored = obj.DeepCopy()
+			return stored.DeepCopy(), nil
+		}).Times(2)
+
+		var gets int
+		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(_, name string, _ metav1.GetOptions) (*corev1.ConfigMap, error) {
+			gets++
+			assert.Equal(t, stored.Name, name)
+			return stored.DeepCopy(), nil
+		}).Times(1)
+
+		store := newStore(configMapClient, tokenStore, &fakeTokenManager{})
+
+		ctx := userContext(userID, authTokenID)
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{Clusters: []string{downstream1}},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, updates, "the conflicting update must be retried")
+		assert.Equal(t, 1, gets, "the retry must re-read the configmap")
+
+		created := obj.(*ext.Kubeconfig)
+		assert.Equal(t, StatusSummaryComplete, created.Status.Summary)
+		assert.NotEmpty(t, created.Status.Value)
+		require.Len(t, created.Status.Tokens, 1)
+
+		require.NotNil(t, stored)
+		assert.Equal(t, "virtual", stored.Labels[foreignLabel], "the concurrent writer's label must survive the retry")
+		assert.Equal(t, KindLabelValue, stored.Labels[KindLabel])
+		assert.Equal(t, userID, stored.Labels[UserIDLabel])
+		assert.NotEmpty(t, stored.Annotations[UIDAnnotation])
+		assert.Equal(t, StatusSummaryComplete, stored.Data[StatusSummaryField])
+		tokensValue, err := json.Marshal(created.Status.Tokens)
+		require.NoError(t, err)
+		assert.Equal(t, string(tokensValue), stored.Data[StatusTokensField])
+	})
+	t.Run("completion write that keeps conflicting reports a conflict and revokes the tokens", func(t *testing.T) {
+		// Once the retries run out the client gets an error, and nothing points
+		// at the tokens that were created: their IDs never reached the
+		// ConfigMap, so deleting the kubeconfig later won't delete them. Both
+		// the tokens and the unfinished record have to go.
+		var configMapName string
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			created := obj.DeepCopy()
+			created.Name = names.SimpleNameGenerator.GenerateName(obj.GenerateName)
+			created.ResourceVersion = "1"
+			configMapName = created.Name
+			return created, nil
+		}).Times(1)
+
+		var updates int
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			updates++
+			return nil, apierrors.NewConflict(schema.GroupResource{Resource: "configmaps"}, obj.Name,
+				errors.New("the object has been modified; please apply your changes to the latest version and try again"))
+		}).AnyTimes()
+		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(_, name string, _ metav1.GetOptions) (*corev1.ConfigMap, error) {
+			return &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            name,
+					Namespace:       namespace,
+					ResourceVersion: strconv.Itoa(updates + 1),
+					Labels:          map[string]string{KindLabel: KindLabelValue},
+				},
+			}, nil
+		}).AnyTimes()
+
+		var deletedConfigMaps []string
+		configMapClient.EXPECT().Delete(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(_, name string, _ *metav1.DeleteOptions) error {
+			deletedConfigMaps = append(deletedConfigMaps, name)
+			return nil
+		}).Times(1)
+
+		var deletedTokens []string
+		deletingTokenStore := &fakeTokenStore{
+			fetchFunc: tokenStore.fetchFunc,
+			deleteFunc: func(name string, _ *metav1.DeleteOptions) error {
+				deletedTokens = append(deletedTokens, name)
+				return nil
+			},
+		}
+
+		var createdTokens []string
+		tokenManager := &fakeTokenManager{}
+		tokenManager.createTokenFunc = func(ctx context.Context, token *ext.Token, userInfo k8suser.Info) (*ext.Token, error) {
+			created, err := tokenManager.generate(token)
+			if err != nil {
+				return nil, err
+			}
+			createdTokens = append(createdTokens, created.Name)
+			return created, nil
+		}
+
+		store := newStore(configMapClient, deletingTokenStore, tokenManager)
+
+		ctx := userContext(userID, authTokenID)
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{Clusters: []string{downstream1, downstream2}},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsConflict(err), "an unresolvable conflict must surface as 409, got %v", err)
+		assert.False(t, apierrors.IsInternalError(err), "must not be wrapped as InternalError, got %v", err)
+
+		assert.Greater(t, updates, 1, "the conflicting update must be retried")
+		require.Len(t, createdTokens, 2)
+		assert.Equal(t, createdTokens, deletedTokens, "the issued tokens must be revoked")
+		assert.Equal(t, []string{configMapName}, deletedConfigMaps, "the incomplete record must be removed")
+	})
+	t.Run("completion write rejected outright reports the backing error and revokes the tokens", func(t *testing.T) {
+		// A rejection that isn't a conflict - a quota or a webhook, say - is not
+		// retried. It has to reach the client with its own status code rather
+		// than as a 500, and it leaves behind the same unfinished record to
+		// clean up.
+		var configMapName string
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			created := obj.DeepCopy()
+			created.Name = names.SimpleNameGenerator.GenerateName(obj.GenerateName)
+			created.ResourceVersion = "1"
+			configMapName = created.Name
+			return created, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).Return(nil,
+			apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, "", errors.New("quota exceeded")),
+		).Times(1) // A rejection that isn't a conflict must not be retried.
+
+		var deletedConfigMaps []string
+		configMapClient.EXPECT().Delete(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(_, name string, _ *metav1.DeleteOptions) error {
+			deletedConfigMaps = append(deletedConfigMaps, name)
+			return nil
+		}).Times(1)
+
+		var deletedTokens []string
+		deletingTokenStore := &fakeTokenStore{
+			fetchFunc: tokenStore.fetchFunc,
+			deleteFunc: func(name string, _ *metav1.DeleteOptions) error {
+				deletedTokens = append(deletedTokens, name)
+				return nil
+			},
+		}
+
+		var createdTokens []string
+		tokenManager := &fakeTokenManager{}
+		tokenManager.createTokenFunc = func(ctx context.Context, token *ext.Token, userInfo k8suser.Info) (*ext.Token, error) {
+			created, err := tokenManager.generate(token)
+			if err != nil {
+				return nil, err
+			}
+			createdTokens = append(createdTokens, created.Name)
+			return created, nil
+		}
+
+		store := newStore(configMapClient, deletingTokenStore, tokenManager)
+
+		ctx := userContext(userID, authTokenID)
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{Clusters: []string{downstream1}},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsForbidden(err), "the backing Forbidden must surface as 403, got %v", err)
+		assert.False(t, apierrors.IsInternalError(err), "must not be wrapped as InternalError, got %v", err)
+
+		require.Len(t, createdTokens, 1)
+		assert.Equal(t, createdTokens, deletedTokens, "the issued tokens must be revoked")
+		assert.Equal(t, []string{configMapName}, deletedConfigMaps, "the incomplete record must be removed")
+	})
+	t.Run("a token is recorded even when the rest of the create fails", func(t *testing.T) {
+		// Everything that can delete a token - the stored record and the
+		// cleanup of a failed create - works off the list of token IDs, so a
+		// token has to be added to that list as soon as it exists. Here the
+		// owner reference lookup that comes right after creating it fails.
+		var stored *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			stored = obj.DeepCopy()
+			stored.Name = names.SimpleNameGenerator.GenerateName(obj.GenerateName)
+			stored.ResourceVersion = "1"
+			return stored.DeepCopy(), nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			stored = obj.DeepCopy()
+			return stored.DeepCopy(), nil
+		}).Times(1)
+		// The record is saved, so there is nothing to clean up: a Delete here
+		// would be an unexpected call and fail the test.
+
+		failingTokenStore := &fakeTokenStore{
+			fetchFunc: tokenStore.fetchFunc,
+			getSecretFunc: func(name string, _ *metav1.GetOptions, _ bool) (*corev1.Secret, error) {
+				return nil, apierrors.NewInternalError(errors.New("etcd unavailable"))
+			},
+		}
+
+		var createdTokens []string
+		tokenManager := &fakeTokenManager{}
+		tokenManager.createTokenFunc = func(ctx context.Context, token *ext.Token, userInfo k8suser.Info) (*ext.Token, error) {
+			created, err := tokenManager.generate(token)
+			if err != nil {
+				return nil, err
+			}
+			createdTokens = append(createdTokens, created.Name)
+			return created, nil
+		}
+
+		store := newStore(configMapClient, failingTokenStore, tokenManager)
+
+		ctx := userContext(userID, authTokenID)
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{Clusters: []string{downstream1}},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+
+		require.Len(t, createdTokens, 1)
+		require.NotNil(t, stored)
+		assert.Equal(t, StatusSummaryError, stored.Data[StatusSummaryField])
+		tokensValue, err := json.Marshal(createdTokens)
+		require.NoError(t, err)
+		assert.Equal(t, string(tokensValue), stored.Data[StatusTokensField],
+			"the token must be recorded so deleting the kubeconfig still revokes it")
+	})
+}
+
+func TestMergeConfigMap(t *testing.T) {
+	t.Parallel()
+
+	secretRef := func(name string, uid types.UID) metav1.OwnerReference {
+		return metav1.OwnerReference{APIVersion: "v1", Kind: "Secret", Name: name, UID: uid}
+	}
+
+	tests := []struct {
+		name    string
+		latest  *corev1.ConfigMap
+		desired *corev1.ConfigMap
+		want    *corev1.ConfigMap
+	}{
+		{
+			name: "keeps the latest resourceVersion and the metadata of other writers",
+			latest: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kubeconfig-abcde",
+					Namespace:       namespace,
+					ResourceVersion: "2",
+					Labels:          map[string]string{KindLabel: KindLabelValue, "foreign": "kept"},
+					Annotations:     map[string]string{UIDAnnotation: "uid", "foreign": "kept"},
+				},
+				Data: map[string]string{StatusSummaryField: StatusSummaryPending},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kubeconfig-abcde",
+					Namespace:       namespace,
+					ResourceVersion: "1",
+					Labels:          map[string]string{KindLabel: KindLabelValue, UserIDLabel: "u-abcde"},
+					Annotations:     map[string]string{UIDAnnotation: "uid"},
+				},
+				Data: map[string]string{StatusSummaryField: StatusSummaryComplete, TTLField: "0"},
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "kubeconfig-abcde",
+					Namespace:       namespace,
+					ResourceVersion: "2",
+					Labels:          map[string]string{KindLabel: KindLabelValue, UserIDLabel: "u-abcde", "foreign": "kept"},
+					Annotations:     map[string]string{UIDAnnotation: "uid", "foreign": "kept"},
+				},
+				Data: map[string]string{StatusSummaryField: StatusSummaryComplete, TTLField: "0"},
+			},
+		},
+		{
+			name: "drops data keys the store no longer owns",
+			latest: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+				Data:       map[string]string{StatusSummaryField: StatusSummaryPending, "stale": "value"},
+			},
+			desired: &corev1.ConfigMap{
+				Data: map[string]string{StatusSummaryField: StatusSummaryComplete},
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"},
+				Data:       map[string]string{StatusSummaryField: StatusSummaryComplete},
+			},
+		},
+		{
+			name:   "populates metadata maps the latest version doesn't have",
+			latest: &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      map[string]string{KindLabel: KindLabelValue},
+					Annotations: map[string]string{UIDAnnotation: "uid"},
+				},
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+					Labels:          map[string]string{KindLabel: KindLabelValue},
+					Annotations:     map[string]string{UIDAnnotation: "uid"},
+				},
+			},
+		},
+		{
+			name: "adds the token owner references without dropping the existing ones",
+			latest: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+					OwnerReferences: []metav1.OwnerReference{secretRef("other", "uid-other")},
+				},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{secretRef("token-a", "uid-a")},
+				},
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+					OwnerReferences: []metav1.OwnerReference{secretRef("other", "uid-other"), secretRef("token-a", "uid-a")},
+				},
+			},
+		},
+		{
+			name: "an owner reference present on both sides is not duplicated",
+			latest: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+					OwnerReferences: []metav1.OwnerReference{secretRef("stale-name", "uid-a")},
+				},
+			},
+			desired: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					OwnerReferences: []metav1.OwnerReference{secretRef("token-a", "uid-a")},
+				},
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "2",
+					OwnerReferences: []metav1.OwnerReference{secretRef("token-a", "uid-a")},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			latest := test.latest.DeepCopy()
+			merged := mergeConfigMap(latest, test.desired)
+
+			assert.Equal(t, test.want, merged)
+			assert.Equal(t, test.latest, latest, "the latest version must not be mutated")
+		})
+	}
 }
 
 func generateCAKeyAndCert() (*ecdsa.PrivateKey, string, error) {
@@ -2170,12 +2353,7 @@ func TestStoreGet(t *testing.T) {
 
 	tokenManager := &fakeTokenManager{}
 
-	ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-		Name: userID,
-		Extra: map[string][]string{
-			common.ExtraRequestTokenID: {authTokenID},
-		},
-	})
+	ctx := userContext(userID, authTokenID)
 
 	t.Run("admin gets kubeconfig", func(t *testing.T) {
 		store := &Store{
@@ -2185,12 +2363,7 @@ func TestStoreGet(t *testing.T) {
 			tokenMgr:       tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-			Extra: map[string][]string{
-				common.ExtraRequestTokenID: {"token-8wrqh"},
-			},
-		})
+		ctx := userContext(adminID, "token-8wrqh")
 
 		obj, err := store.Get(ctx, kubeconfigID, &metav1.GetOptions{})
 		require.NoError(t, err)
@@ -2411,9 +2584,7 @@ func TestStoreList(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-		})
+		ctx := userContext(adminID, "")
 
 		obj, err := store.List(ctx, &metainternalversion.ListOptions{})
 		require.NoError(t, err)
@@ -2437,9 +2608,7 @@ func TestStoreList(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID1,
-		})
+		ctx := userContext(userID1, "")
 
 		obj, err := store.List(ctx, &metainternalversion.ListOptions{})
 		require.NoError(t, err)
@@ -2530,9 +2699,7 @@ func TestStoreWatch(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-		})
+		ctx := userContext(adminID, "")
 
 		watcher, err := store.Watch(ctx, &metainternalversion.ListOptions{})
 		require.NoError(t, err)
@@ -2696,9 +2863,7 @@ func TestStoreWatch(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 
 		watcher, err := store.Watch(ctx, &metainternalversion.ListOptions{})
 		require.NoError(t, err)
@@ -2814,9 +2979,7 @@ func TestStoreUpdate(t *testing.T) {
 			return nil
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-		})
+		ctx := userContext(adminID, "")
 
 		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
 		assert.NoError(t, err)
@@ -2882,9 +3045,7 @@ func TestStoreUpdate(t *testing.T) {
 			return nil
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID, // Kubeconfig owner.
-		})
+		ctx := userContext(userID, "") // Kubeconfig owner.
 
 		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
 		assert.NoError(t, err)
@@ -2930,9 +3091,7 @@ func TestStoreUpdate(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: "not-an-owner",
-		})
+		ctx := userContext("not-an-owner", "")
 
 		options := &metav1.UpdateOptions{}
 
@@ -2963,9 +3122,7 @@ func TestStoreUpdate(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 
 		options := &metav1.UpdateOptions{}
 
@@ -2994,9 +3151,7 @@ func TestStoreUpdate(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 
 		options := &metav1.UpdateOptions{}
 
@@ -3027,9 +3182,7 @@ func TestStoreUpdate(t *testing.T) {
 
 		updateValidation := func(ctx context.Context, obj, old runtime.Object) error { return nil }
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 
 		options := &metav1.UpdateOptions{}
 
@@ -3105,9 +3258,7 @@ func TestStoreUpdate(t *testing.T) {
 			return nil
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID, // Kubeconfig owner.
-		})
+		ctx := userContext(userID, "") // Kubeconfig owner.
 
 		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
 		assert.NoError(t, err)
@@ -3148,9 +3299,7 @@ func TestStoreUpdate(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 
 		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
 		require.NoError(t, err)
@@ -3181,9 +3330,7 @@ func TestStoreUpdate(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 
 		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
 		require.NoError(t, err)
@@ -3213,9 +3360,7 @@ func TestStoreUpdate(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: userID,
-		})
+		ctx := userContext(userID, "")
 
 		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
 		require.NoError(t, err)
@@ -3257,9 +3402,7 @@ func TestStoreUpdate(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-		})
+		ctx := userContext(adminID, "")
 
 		kc, err := store.fromConfigMap(oldConfigMap)
 		require.NoError(t, err)
@@ -3513,9 +3656,7 @@ func TestStoreDelete(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-		})
+		ctx := userContext(adminID, "")
 
 		obj, _, err := store.Delete(ctx, kubeconfigID, deleteValidation, deleteOptions)
 		require.NoError(t, err)
@@ -3676,9 +3817,7 @@ func TestStoreDelete(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: "not-an-owner",
-		})
+		ctx := userContext("not-an-owner", "")
 
 		obj, _, err := store.Delete(ctx, kubeconfigID, nil, &metav1.DeleteOptions{})
 		require.Error(t, err)
@@ -3718,7 +3857,7 @@ func TestStoreDelete(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+		ctx := userContext(adminID, "")
 
 		_, _, err := store.Delete(ctx, kubeconfigID, nil, &metav1.DeleteOptions{
 			DryRun: []string{metav1.DryRunAll},
@@ -3839,9 +3978,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
-			Name: adminID,
-		})
+		ctx := userContext(adminID, "")
 
 		obj, err := store.DeleteCollection(ctx, deleteValidation, deleteOptions, listOptions)
 		require.NoError(t, err)
@@ -3884,7 +4021,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+		ctx := userContext(adminID, "")
 
 		obj, err := store.DeleteCollection(ctx, nil, deleteOptions, listOptions)
 		require.NoError(t, err)
@@ -3917,7 +4054,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+		ctx := userContext(adminID, "")
 
 		_, err := store.DeleteCollection(ctx, nil, deleteOptions, listOptions)
 		require.Error(t, err)
@@ -3950,7 +4087,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+		ctx := userContext(adminID, "")
 
 		_, err := store.DeleteCollection(ctx, deleteValidation, &metav1.DeleteOptions{}, &metainternalversion.ListOptions{})
 		require.Error(t, err)
@@ -3986,7 +4123,7 @@ func TestStoreDeleteCollection(t *testing.T) {
 			tokenMgr:        tokenManager,
 		}
 
-		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{Name: adminID})
+		ctx := userContext(adminID, "")
 
 		_, err := store.DeleteCollection(ctx, nil, &metav1.DeleteOptions{
 			DryRun: []string{metav1.DryRunAll},


### PR DESCRIPTION
## Issue: #56916<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Creating an ext.Kubeconfig is a two-phase write. A ConfigMap is created first so the tokens can be named after it, then updated with the finished record. The second write reused the resourceVersion from the first and failed with a conflict whenever anything else touched the ConfigMap in between. The k3k kubelet does this when it stamps sync labels on ConfigMaps shared between a host cluster and a virtual one. The conflict was not recoverable by the client: the resourceVersion of the first write is never returned, and repeating the request produces a new ConfigMap and a new set of tokens.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
The second write is now retried against a fresh read of the ConfigMap. Only the fields the store owns are written onto the stored version. Labels, annotations and owner references left by other writers survive the retry.

A token is now recorded as soon as it is created rather than after the owner reference for it is resolved. A failure in between left a usable token that nothing referenced. Tokens and the unfinished ConfigMap are also removed when creation fails before the record is saved.

Additionally:

- Log lines in the Kubeconfig store are prefixed so they can be filtered.
- Shared helpers for building the test store, the request context and the allow-all authorizer replace the copies in each subtest.


## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit tests