### PR TITLE
Add an NTLM bind with channel binding to the Active Directory provider

### DIFF
--- a/pkg/apis/management.cattle.io/v3/authn_types.go
+++ b/pkg/apis/management.cattle.io/v3/authn_types.go
@@ -526,6 +526,13 @@ type ActiveDirectoryConfig struct {
 	GroupMemberMappingAttribute  string   `json:"groupMemberMappingAttribute,omitempty" norman:"default=member,required"`
 	ConnectionTimeout            int64    `json:"connectionTimeout,omitempty"           norman:"default=5000,notnullable,required"`
 	NestedGroupMembershipEnabled *bool    `json:"nestedGroupMembershipEnabled,omitempty" norman:"default=false"`
+
+	// BindMechanism selects how Rancher binds to the directory.
+	// "simple" (default) is an LDAP simple bind. "ntlm" is a Sicily NTLMv2 bind
+	// carrying an RFC 5929 tls-server-end-point channel binding token, required
+	// by domain controllers enforcing LdapEnforceChannelBinding=Always.
+	// "kerberos" is reserved for a future mechanism and is currently rejected.
+	BindMechanism string `json:"bindMechanism,omitempty" norman:"type=enum,options=simple|ntlm,default=simple"`
 }
 
 func (c *ActiveDirectoryConfig) GetUserSearchAttributes(searchAttributes ...string) []string {

--- a/pkg/auth/providers/activedirectory/activedirectory_actions.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_actions.go
@@ -171,8 +171,8 @@ func (p *adProvider) validateTestAndApplyInput(input *v32.ActiveDirectoryTestAnd
 	return nil
 }
 
-// connectForTestAndApply validates before it dials. The order is the contract:
-// an invalid mechanism must never open a socket.
+// connectForTestAndApply validates before dialing so an invalid mechanism
+// never opens a socket.
 func (p *adProvider) connectForTestAndApply(input *v32.ActiveDirectoryTestAndApplyInput) (ldapv3.Client, error) {
 	if err := p.validateTestAndApplyInput(input); err != nil {
 		return nil, err

--- a/pkg/auth/providers/activedirectory/activedirectory_actions.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_actions.go
@@ -68,9 +68,46 @@ func (p *adProvider) testAndApply(request *types.APIContext) error {
 		config.ServiceAccountPassword = value
 	}
 
-	caPool, err := newCAPool(config.Certificate)
+	lConn, err := p.connectForTestAndApply(configApplyInput)
 	if err != nil {
 		return err
+	}
+	defer lConn.Close()
+
+	userPrincipal, groupPrincipals, err := p.loginUser(lConn, login, config)
+	if err != nil {
+		return err
+	}
+
+	// If this works, save adConfig CR adding enabled flag.
+	config.Enabled = configApplyInput.Enabled
+	err = p.saveActiveDirectoryConfig(config)
+	if err != nil {
+		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Failed to save activedirectory config: %v", err))
+	}
+
+	user, err := p.userMGR.SetPrincipalOnCurrentUser(request.Request, userPrincipal)
+	if err != nil {
+		return err
+	}
+
+	userExtraInfo := p.GetUserExtraAttributes(userPrincipal)
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		return p.userMGR.UserAttributeCreateOrUpdate(user.Name, userPrincipal.Provider, groupPrincipals, userExtraInfo)
+	}); err != nil {
+		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Failed to create or update userAttribute: %v", err))
+	}
+
+	return p.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, "", 0, "Token via AD Configuration", request)
+}
+
+// validateTestAndApplyInput checks the parts of a testAndApply request that
+// can be validated without a directory connection.
+func (p *adProvider) validateTestAndApplyInput(input *v32.ActiveDirectoryTestAndApplyInput) error {
+	config := &input.ActiveDirectoryConfig
+
+	if err := validateBindConfiguration(config); err != nil {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 	}
 
 	if len(config.Servers) < 1 {
@@ -131,41 +168,24 @@ func (p *adProvider) testAndApply(request *types.APIContext) error {
 		}
 	}
 
-	lConn, err := p.ldapConnection(config, caPool)
+	return nil
+}
+
+// connectForTestAndApply validates before it dials. The order is the contract:
+// an invalid mechanism must never open a socket.
+func (p *adProvider) connectForTestAndApply(input *v32.ActiveDirectoryTestAndApplyInput) (ldapv3.Client, error) {
+	if err := p.validateTestAndApplyInput(input); err != nil {
+		return nil, err
+	}
+	caPool, err := newCAPool(input.ActiveDirectoryConfig.Certificate)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer lConn.Close()
-
-	userPrincipal, groupPrincipals, err := p.loginUser(lConn, login, config)
-	if err != nil {
-		return err
-	}
-
-	// If this works, save adConfig CR adding enabled flag.
-	config.Enabled = configApplyInput.Enabled
-	err = p.saveActiveDirectoryConfig(config)
-	if err != nil {
-		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Failed to save activedirectory config: %v", err))
-	}
-
-	user, err := p.userMGR.SetPrincipalOnCurrentUser(request.Request, userPrincipal)
-	if err != nil {
-		return err
-	}
-
-	userExtraInfo := p.GetUserExtraAttributes(userPrincipal)
-	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		return p.userMGR.UserAttributeCreateOrUpdate(user.Name, userPrincipal.Provider, groupPrincipals, userExtraInfo)
-	}); err != nil {
-		return httperror.NewAPIError(httperror.ServerError, fmt.Sprintf("Failed to create or update userAttribute: %v", err))
-	}
-
-	return p.tokenMGR.CreateTokenAndSetCookie(user.Name, userPrincipal, groupPrincipals, "", 0, "Token via AD Configuration", request)
+	return p.ldapConnectionOrDefault(&input.ActiveDirectoryConfig, caPool)
 }
 
 func (p *adProvider) saveActiveDirectoryConfig(config *v32.ActiveDirectoryConfig) error {
-	storedConfig, _, err := p.getActiveDirectoryConfig()
+	storedConfig, _, err := p.configOrDefault()
 	if err != nil {
 		return err
 	}

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -28,16 +28,28 @@ func (p *adProvider) loginUser(lConn ldapv3.Client, credentials *v3.BasicLogin, 
 		return v3.Principal{}, nil, apierror.NewAPIError(validation.MissingRequired, "password not provided")
 	}
 
-	sAMAccountName := credentials.Username
-	if strings.Contains(credentials.Username, `\`) {
-		sAMAccountName = strings.SplitN(credentials.Username, `\`, 2)[1]
+	lookupUsername := credentials.Username
+	var bindIdentity *ntlmIdentity
+
+	if config.BindMechanism == bindMechanismNTLM {
+		// Resolve the identity before any directory I/O so an unsupported form
+		// fails with a readable message instead of an unauthorized result from
+		// a search that could never have matched.
+		domain, user, err := splitNTLMIdentity(credentials.Username, config.DefaultLoginDomain)
+		if err != nil {
+			return v3.Principal{}, nil, err
+		}
+		lookupUsername = user
+		bindIdentity = &ntlmIdentity{Domain: domain, Username: user}
+	} else if strings.Contains(credentials.Username, `\`) {
+		lookupUsername = strings.SplitN(credentials.Username, `\`, 2)[1]
 	}
 
-	err := ldap.AuthenticateServiceAccountUser(config.ServiceAccountPassword, config.ServiceAccountUsername, config.DefaultLoginDomain, lConn)
-	if err != nil {
-		return v3.Principal{}, nil, err
+	if err := p.bindServiceAccount(lConn, config); err != nil {
+		return v3.Principal{}, nil, classifyServiceAccountBindError(err)
 	}
 
+	var err error
 	if config.UserLoginFilter != "" {
 		// Make sure user login filter contains a valid LDAP query expression
 		// before interpolating it into the search filter.
@@ -49,7 +61,7 @@ func (p *adProvider) loginUser(lConn ldapv3.Client, credentials *v3.BasicLogin, 
 	filter := fmt.Sprintf(
 		"(&(%s=%s)%s)",
 		ldap.SanitizeAttr(config.UserLoginAttribute),
-		ldapv3.EscapeFilter(sAMAccountName),
+		ldapv3.EscapeFilter(lookupUsername),
 		config.UserLoginFilter,
 	)
 	logrus.Debugf("LDAP Search query: {%s}", filter)
@@ -73,9 +85,14 @@ func (p *adProvider) loginUser(lConn ldapv3.Client, credentials *v3.BasicLogin, 
 	}
 
 	logrus.Debug("Binding username password")
-	externalID := ldap.GetUserExternalID(credentials.Username, config.DefaultLoginDomain)
-	err = lConn.Bind(externalID, password)
+	err = p.bindUser(lConn, config, bindIdentity, credentials.Username, password)
 	if err != nil {
+		if classifyBindFailure(err) != bindFailureNone {
+			// A channel binding rejection, or a malformed token of our own
+			// making, arrives as invalidCredentials without being a wrong
+			// password.
+			return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.ServerError, mapBindError(err).Error())
+		}
 		if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) {
 			return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.Unauthorized, "Unauthorized")
 		}
@@ -99,20 +116,24 @@ func (p *adProvider) loginUser(lConn ldapv3.Client, credentials *v3.BasicLogin, 
 }
 
 func (p *adProvider) RefetchGroupPrincipals(principalID string, secret string) ([]v3.Principal, error) {
-	config, caPool, err := p.getActiveDirectoryConfig()
+	config, caPool, err := p.configOrDefault()
 	if err != nil {
 		return nil, err
 	}
 
-	lConn, err := p.ldapConnection(config, caPool)
+	lConn, err := p.ldapConnectionOrDefault(config, caPool)
 	if err != nil {
 		return nil, err
 	}
 	defer lConn.Close()
 
-	err = ldap.AuthenticateServiceAccountUser(config.ServiceAccountPassword, config.ServiceAccountUsername, config.DefaultLoginDomain, lConn)
+	return p.refetchGroupPrincipalsOnConn(lConn, config, principalID)
+}
+
+func (p *adProvider) refetchGroupPrincipalsOnConn(lConn ldapv3.Client, config *v3.ActiveDirectoryConfig, principalID string) ([]v3.Principal, error) {
+	err := p.bindServiceAccount(lConn, config)
 	if err != nil {
-		return nil, err
+		return nil, classifyServiceAccountBindError(err)
 	}
 
 	externalID, _, err := p.getDNAndScopeFromPrincipalID(principalID)
@@ -273,10 +294,14 @@ func (p *adProvider) getGroupPrincipalsFromSearch(
 		config.GetGroupSearchAttributes(ObjectClass),
 	)
 
-	serviceAccountUsername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
-	err := lConn.Bind(serviceAccountUsername, config.ServiceAccountPassword)
-
+	err := p.bindServiceAccount(lConn, config)
 	if err != nil {
+		if classifyBindFailure(err) != bindFailureNone {
+			// Not a rotated password. Degrading here would mask a channel
+			// binding misconfiguration, or a malformed message of our own
+			// making, behind partial group data.
+			return nilPrincipal, mapBindError(err)
+		}
 		if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) && config.Enabled {
 			// If bind fails because service account password has changed, just return identities formed from groups in `memberOf`
 			groupList := []v3.Principal{}
@@ -316,6 +341,16 @@ func (p *adProvider) getGroupPrincipalsFromSearch(
 }
 
 func (p *adProvider) getPrincipal(distinguishedName string, scope string, config *v3.ActiveDirectoryConfig, caPool *x509.CertPool) (*v3.Principal, error) {
+	lConn, err := p.ldapConnectionOrDefault(config, caPool)
+	if err != nil {
+		return nil, err
+	}
+	defer lConn.Close()
+
+	return p.getPrincipalOnConn(lConn, distinguishedName, scope, config)
+}
+
+func (p *adProvider) getPrincipalOnConn(lConn ldapv3.Client, distinguishedName, scope string, config *v3.ActiveDirectoryConfig) (*v3.Principal, error) {
 	var search *ldapv3.SearchRequest
 	var filter string
 	if !slice.ContainsString(scopes, scope) {
@@ -346,16 +381,16 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 	}
 
 	logrus.Debugf("Query for getPrincipal(%s): %s", distinguishedName, filter)
-	lConn, err := p.ldapConnection(config, caPool)
-	if err != nil {
-		return nil, err
-	}
-	defer lConn.Close()
 	// Bind before query
 	// If service account bind fails, and auth is on, return principal formed using DN
-	serviceAccountUsername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
-	err = lConn.Bind(serviceAccountUsername, config.ServiceAccountPassword)
+	err = p.bindServiceAccount(lConn, config)
 	if err != nil {
+		if classifyBindFailure(err) != bindFailureNone {
+			// Not a rotated password. Degrading here would mask a channel
+			// binding misconfiguration, or a malformed message of our own
+			// making, behind a DN-formed principal.
+			return nil, mapBindError(err)
+		}
 		if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) && config.Enabled {
 			var kind string
 			if strings.EqualFold(UserScope, scope) {
@@ -415,7 +450,7 @@ func (p *adProvider) getPrincipal(distinguishedName string, scope string, config
 	return principal, nil
 }
 
-func (p *adProvider) searchPrincipals(name, principalType string, config *v3.ActiveDirectoryConfig, lConn *ldapv3.Conn) ([]v3.Principal, error) {
+func (p *adProvider) searchPrincipals(name, principalType string, config *v3.ActiveDirectoryConfig, lConn ldapv3.Client) ([]v3.Principal, error) {
 	var principals []v3.Principal
 
 	if principalType == "" || principalType == "user" {
@@ -437,7 +472,7 @@ func (p *adProvider) searchPrincipals(name, principalType string, config *v3.Act
 	return principals, nil
 }
 
-func (p *adProvider) searchUser(name string, config *v3.ActiveDirectoryConfig, lConn *ldapv3.Conn) ([]v3.Principal, error) {
+func (p *adProvider) searchUser(name string, config *v3.ActiveDirectoryConfig, lConn ldapv3.Client) ([]v3.Principal, error) {
 	if config.UserSearchFilter != "" {
 		// Make sure user search filter contains a valid LDAP query expression
 		// before interpolating it into the search filter.
@@ -459,7 +494,7 @@ func (p *adProvider) searchUser(name string, config *v3.ActiveDirectoryConfig, l
 	return p.searchLdap(query, UserScope, config, lConn)
 }
 
-func (p *adProvider) searchGroup(name string, config *v3.ActiveDirectoryConfig, lConn *ldapv3.Conn) ([]v3.Principal, error) {
+func (p *adProvider) searchGroup(name string, config *v3.ActiveDirectoryConfig, lConn ldapv3.Client) ([]v3.Principal, error) {
 	if config.GroupSearchFilter != "" {
 		// Make sure group search filter contains a valid LDAP query expression
 		// before interpolating it into the search filter.
@@ -482,7 +517,7 @@ func (p *adProvider) searchGroup(name string, config *v3.ActiveDirectoryConfig, 
 	return p.searchLdap(query, GroupScope, config, lConn)
 }
 
-func (p *adProvider) searchLdap(query string, scope string, config *v3.ActiveDirectoryConfig, lConn *ldapv3.Conn) ([]v3.Principal, error) {
+func (p *adProvider) searchLdap(query string, scope string, config *v3.ActiveDirectoryConfig, lConn ldapv3.Client) ([]v3.Principal, error) {
 	var principals []v3.Principal
 	var search *ldapv3.SearchRequest
 
@@ -505,10 +540,9 @@ func (p *adProvider) searchLdap(query string, scope string, config *v3.ActiveDir
 	}
 
 	// Bind before query
-	serviceAccountUsername := ldap.GetUserExternalID(config.ServiceAccountUsername, config.DefaultLoginDomain)
-	err := lConn.Bind(serviceAccountUsername, config.ServiceAccountPassword)
+	err := p.bindServiceAccount(lConn, config)
 	if err != nil {
-		return nil, fmt.Errorf("activedirectory: error binding service account: %w", err)
+		return nil, fmt.Errorf("activedirectory: error binding service account: %w", mapBindError(err))
 	}
 
 	results, err := lConn.SearchWithPaging(search, 1000)

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -96,6 +96,15 @@ func (p *adProvider) loginUser(lConn ldapv3.Client, credentials *v3.BasicLogin, 
 		if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) {
 			return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.Unauthorized, "Unauthorized")
 		}
+		if apierror.IsAPIError(err) {
+			// bindAs reports its own preconditions — an invalid mechanism, a
+			// connection without TLS state, a missing peer certificate, an
+			// underivable channel binding token — as APIErrors carrying
+			// actionable messages. Re-wrapping would replace the message with
+			// the generic one, because WrapAPIError drops the cause from the
+			// response.
+			return v3.Principal{}, nil, err
+		}
 		return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.ServerError, "server error while authenticating")
 	}
 

--- a/pkg/auth/providers/activedirectory/activedirectory_client.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client.go
@@ -88,21 +88,18 @@ func (p *adProvider) loginUser(lConn ldapv3.Client, credentials *v3.BasicLogin, 
 	err = p.bindUser(lConn, config, bindIdentity, credentials.Username, password)
 	if err != nil {
 		if classifyBindFailure(err) != bindFailureNone {
-			// A channel binding rejection, or a malformed token of our own
-			// making, arrives as invalidCredentials without being a wrong
-			// password.
+			// A channel binding rejection, or a malformed token, arrives as
+			// invalidCredentials even though it is not a wrong password.
 			return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.ServerError, mapBindError(err).Error())
 		}
 		if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) {
 			return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.Unauthorized, "Unauthorized")
 		}
 		if apierror.IsAPIError(err) {
-			// bindAs reports its own preconditions — an invalid mechanism, a
-			// connection without TLS state, a missing peer certificate, an
-			// underivable channel binding token — as APIErrors carrying
-			// actionable messages. Re-wrapping would replace the message with
-			// the generic one, because WrapAPIError drops the cause from the
-			// response.
+			// bindAs reports the failures it detects itself (see its doc) as
+			// APIErrors carrying actionable messages. Re-wrapping would
+			// replace the message with the generic one, because WrapAPIError
+			// drops the cause from the response.
 			return v3.Principal{}, nil, err
 		}
 		return v3.Principal{}, nil, apierror.WrapAPIError(err, validation.ServerError, "server error while authenticating")
@@ -307,8 +304,8 @@ func (p *adProvider) getGroupPrincipalsFromSearch(
 	if err != nil {
 		if classifyBindFailure(err) != bindFailureNone {
 			// Not a rotated password. Degrading here would mask a channel
-			// binding misconfiguration, or a malformed message of our own
-			// making, behind partial group data.
+			// binding misconfiguration, or a malformed message,
+			// behind partial group data.
 			return nilPrincipal, mapBindError(err)
 		}
 		if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) && config.Enabled {
@@ -396,8 +393,8 @@ func (p *adProvider) getPrincipalOnConn(lConn ldapv3.Client, distinguishedName, 
 	if err != nil {
 		if classifyBindFailure(err) != bindFailureNone {
 			// Not a rotated password. Degrading here would mask a channel
-			// binding misconfiguration, or a malformed message of our own
-			// making, behind a DN-formed principal.
+			// binding misconfiguration, or a malformed message,
+			// behind a DN-formed principal.
 			return nil, mapBindError(err)
 		}
 		if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) && config.Enabled {

--- a/pkg/auth/providers/activedirectory/activedirectory_client_test.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client_test.go
@@ -1,6 +1,7 @@
 package activedirectory
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"sync/atomic"
@@ -895,4 +896,62 @@ func TestGetPrincipalFallbackDistinguishesFailureKinds(t *testing.T) {
 			assert.Contains(t, err.Error(), test.wantInMsg)
 		})
 	}
+}
+
+func TestLoginUserNTLMSurfacesABindPreconditionFailure(t *testing.T) {
+	t.Parallel()
+
+	config := v3.ActiveDirectoryConfig{
+		BindMechanism:          bindMechanismNTLM,
+		TLS:                    true,
+		DefaultLoginDomain:     "FOO",
+		ServiceAccountUsername: saUsername,
+		ServiceAccountPassword: saPassword,
+		UserObjectClass:        userObjectClassName,
+		UserLoginAttribute:     "sAMAccountName",
+		UserSearchBase:         baseDN,
+	}
+
+	// The TLS state disappears between the service-account bind and the user
+	// bind, so the user bind fails one of the bind helper's own preconditions.
+	// The APIError it returns must reach the caller with its message intact
+	// rather than be re-wrapped into the generic server error.
+	var tlsStateCalls atomic.Int32
+	ldapConn := &ldapFakes.FakeLdapConn{
+		TLSConnectionStateFunc: func() (tls.ConnectionState, bool) {
+			if tlsStateCalls.Add(1) == 1 {
+				return tlsStateWithPeer()()
+			}
+			return tls.ConnectionState{}, false
+		},
+		NTLMChallengeBindFunc: func(*ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+			return &ldapv3.NTLMBindResult{}, nil
+		},
+		SearchFunc: func(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+			return &ldapv3.SearchResult{
+				Entries: []*ldapv3.Entry{
+					{
+						DN: userDN,
+						Attributes: []*ldapv3.EntryAttribute{
+							{Name: ObjectClass, Values: []string{"top", "person", "user"}},
+							{Name: "sAMAccountName", Values: []string{userName}},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+
+	provider := adProvider{tokenMGR: &tokens.Manager{}}
+	credentials := v3.BasicLogin{Username: userName, Password: userPassword}
+
+	_, _, err := provider.loginUser(ldapConn, &credentials, &config)
+	require.Error(t, err)
+
+	herr, ok := err.(*apierror.APIError)
+	require.True(t, ok)
+	assert.Equal(t, validation.ServerError, herr.Code)
+	assert.Contains(t, herr.Message, "TLS")
+	assert.NotEqual(t, "server error while authenticating", herr.Message,
+		"the bind helper's own diagnostic must not be flattened to the generic message")
 }

--- a/pkg/auth/providers/activedirectory/activedirectory_client_test.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_client_test.go
@@ -1,7 +1,9 @@
 package activedirectory
 
 import (
+	"crypto/x509"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	ldapv3 "github.com/go-ldap/ldap/v3"
@@ -23,6 +25,7 @@ const (
 	userName            = "user"
 	baseDN              = "ou=foo,dc=foo,dc=bar"
 	userDN              = "cn=user," + baseDN
+	groupDN             = "cn=group," + baseDN
 	userPassword        = "secret"
 	userObjectClassName = "person"
 )
@@ -400,4 +403,496 @@ func TestADProviderLoginUser(t *testing.T) {
 		require.True(t, ok)
 		require.Equal(t, validation.Unauthorized, herr.Code)
 	})
+}
+
+func TestLoginUserNTLMRejectsUPNBeforeAnyDirectoryIO(t *testing.T) {
+	t.Parallel()
+
+	config := v3.ActiveDirectoryConfig{
+		BindMechanism:          bindMechanismNTLM,
+		TLS:                    true,
+		ServiceAccountUsername: saUsername,
+		ServiceAccountPassword: saPassword,
+		UserObjectClass:        userObjectClassName,
+		UserLoginAttribute:     "sAMAccountName",
+		UserSearchBase:         baseDN,
+	}
+
+	ldapConn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(string, string) error {
+			t.Fatal("no simple bind may be attempted")
+			return nil
+		},
+		NTLMChallengeBindFunc: func(*ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+			t.Fatal("no NTLM bind may be attempted")
+			return nil, nil
+		},
+		SearchFunc: func(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+			t.Fatal("no search may be performed for an unsupported identity")
+			return nil, nil
+		},
+	}
+
+	provider := adProvider{tokenMGR: &tokens.Manager{}}
+	credentials := v3.BasicLogin{Username: "alice@example.com", Password: userPassword}
+
+	_, _, err := provider.loginUser(ldapConn, &credentials, &config)
+	require.Error(t, err)
+
+	herr, ok := err.(*apierror.APIError)
+	require.True(t, ok)
+	assert.Equal(t, validation.InvalidOption, herr.Code)
+}
+
+func TestLoginUserSimpleKeepsUPNBehaviour(t *testing.T) {
+	t.Parallel()
+
+	config := v3.ActiveDirectoryConfig{
+		ServiceAccountUsername: saUsername,
+		ServiceAccountPassword: saPassword,
+		UserObjectClass:        userObjectClassName,
+		UserLoginAttribute:     "sAMAccountName",
+		UserSearchBase:         baseDN,
+	}
+
+	var searched []string
+	ldapConn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(string, string) error { return nil },
+		SearchFunc: func(request *ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+			searched = append(searched, request.Filter)
+			return &ldapv3.SearchResult{}, nil
+		},
+	}
+
+	provider := adProvider{tokenMGR: &tokens.Manager{}}
+	credentials := v3.BasicLogin{Username: "alice@example.com", Password: userPassword}
+
+	// A UPN still reaches the search and fails there, exactly as before.
+	_, _, err := provider.loginUser(ldapConn, &credentials, &config)
+	require.Error(t, err)
+	require.Len(t, searched, 1)
+	assert.Contains(t, searched[0], "alice@example.com")
+}
+
+func TestLoginUserNTLMNeverPerformsASimpleBind(t *testing.T) {
+	t.Parallel()
+
+	config := v3.ActiveDirectoryConfig{
+		BindMechanism:               bindMechanismNTLM,
+		TLS:                         true,
+		DefaultLoginDomain:          "FOO",
+		ServiceAccountUsername:      saUsername,
+		ServiceAccountPassword:      saPassword,
+		UserObjectClass:             userObjectClassName,
+		UserLoginAttribute:          "sAMAccountName",
+		UserDisabledBitMask:         2,
+		UserEnabledAttribute:        "userAccountControl",
+		UserNameAttribute:           "name",
+		UserSearchBase:              baseDN,
+		GroupDNAttribute:            "distinguishedName",
+		GroupMemberMappingAttribute: "member",
+		GroupMemberUserAttribute:    "distinguishedName",
+		GroupNameAttribute:          "name",
+		GroupObjectClass:            "group",
+		GroupSearchAttribute:        "sAMAccountName",
+	}
+
+	userSearchResult := &ldapv3.SearchResult{
+		Entries: []*ldapv3.Entry{
+			{
+				DN: userDN,
+				Attributes: []*ldapv3.EntryAttribute{
+					{Name: ObjectClass, Values: []string{"top", "person", "user"}},
+					{Name: "name", Values: []string{"user"}},
+					{Name: "sAMAccountName", Values: []string{"user"}},
+					{Name: "userAccountControl", Values: []string{"512"}},
+				},
+			},
+		},
+	}
+
+	var ntlmBinds []ntlmIdentity
+	ldapConn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(username, password string) error {
+			t.Fatalf("simple bind reached with ntlm selected: %s", username)
+			return nil
+		},
+		TLSConnectionStateFunc: tlsStateWithPeer(),
+		NTLMChallengeBindFunc: func(request *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+			ntlmBinds = append(ntlmBinds, ntlmIdentity{Domain: request.Domain, Username: request.Username})
+			return &ldapv3.NTLMBindResult{}, nil
+		},
+		SearchFunc: func(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+			return userSearchResult, nil
+		},
+		SearchWithPagingFunc: func(*ldapv3.SearchRequest, uint32) (*ldapv3.SearchResult, error) {
+			return &ldapv3.SearchResult{}, nil
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	userManager := userMocks.NewMockManager(ctrl)
+	userManager.EXPECT().CheckAccess(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+
+	provider := adProvider{userMGR: userManager, tokenMGR: &tokens.Manager{}}
+	credentials := v3.BasicLogin{Username: userName, Password: userPassword}
+
+	_, _, err := provider.loginUser(ldapConn, &credentials, &config)
+	require.NoError(t, err)
+
+	require.Len(t, ntlmBinds, 2, "the service account bind and the user bind both go through NTLM")
+	assert.Equal(t, ntlmIdentity{Domain: "FOO", Username: "sa"}, ntlmBinds[0])
+	assert.Equal(t, ntlmIdentity{Domain: "FOO", Username: userName}, ntlmBinds[1])
+}
+
+func TestNTLMMechanismNeverPerformsASimpleBind(t *testing.T) {
+	t.Parallel()
+
+	config := v3.ActiveDirectoryConfig{
+		BindMechanism:               bindMechanismNTLM,
+		TLS:                         true,
+		DefaultLoginDomain:          "FOO",
+		ServiceAccountUsername:      saUsername,
+		ServiceAccountPassword:      saPassword,
+		UserObjectClass:             userObjectClassName,
+		UserLoginAttribute:          "sAMAccountName",
+		UserNameAttribute:           "name",
+		UserSearchBase:              baseDN,
+		GroupDNAttribute:            "distinguishedName",
+		GroupMemberMappingAttribute: "member",
+		GroupMemberUserAttribute:    "distinguishedName",
+		GroupNameAttribute:          "name",
+		GroupObjectClass:            "group",
+		GroupSearchAttribute:        "sAMAccountName",
+		GroupSearchBase:             baseDN,
+	}
+
+	tests := []struct {
+		name string
+		call func(p *adProvider, conn ldapv3.Client, config *v3.ActiveDirectoryConfig)
+	}{
+		{
+			name: "refetch group principals",
+			call: func(p *adProvider, conn ldapv3.Client, config *v3.ActiveDirectoryConfig) {
+				_, _ = p.refetchGroupPrincipalsOnConn(conn, config, UserScope+"://"+userDN)
+			},
+		},
+		{
+			name: "group principals from search",
+			call: func(p *adProvider, conn ldapv3.Client, config *v3.ActiveDirectoryConfig) {
+				_, _ = p.getGroupPrincipalsFromSearch(conn, config, baseDN, "(objectClass=group)", []string{userDN})
+			},
+		},
+		{
+			name: "get principal",
+			call: func(p *adProvider, conn ldapv3.Client, config *v3.ActiveDirectoryConfig) {
+				_, _ = p.getPrincipalOnConn(conn, userDN, UserScope, config)
+			},
+		},
+		{
+			name: "search ldap",
+			call: func(p *adProvider, conn ldapv3.Client, config *v3.ActiveDirectoryConfig) {
+				_, _ = p.searchLdap("(objectClass=person)", UserScope, config, conn)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var ntlmBinds []ntlmIdentity
+			conn := &ldapFakes.FakeLdapConn{
+				BindFunc: func(username, _ string) error {
+					t.Fatalf("simple bind reached with ntlm selected: %s", username)
+					return nil
+				},
+				TLSConnectionStateFunc: tlsStateWithPeer(),
+				NTLMChallengeBindFunc: func(request *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+					ntlmBinds = append(ntlmBinds, ntlmIdentity{Domain: request.Domain, Username: request.Username})
+					return &ldapv3.NTLMBindResult{}, nil
+				},
+			}
+
+			localConfig := config
+			test.call(&adProvider{}, conn, &localConfig)
+
+			require.Len(t, ntlmBinds, 1, "the service account bind goes through NTLM")
+			assert.Equal(t, ntlmIdentity{Domain: "FOO", Username: "sa"}, ntlmBinds[0])
+		})
+	}
+}
+
+func TestLoginUserPreservesTheMissingServiceAccountPasswordCode(t *testing.T) {
+	t.Parallel()
+
+	config := v3.ActiveDirectoryConfig{
+		ServiceAccountUsername: saUsername,
+		// ServiceAccountPassword deliberately empty.
+		UserObjectClass:    userObjectClassName,
+		UserLoginAttribute: "sAMAccountName",
+		UserSearchBase:     baseDN,
+	}
+
+	ldapConn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(string, string) error {
+			t.Fatal("no bind should be attempted without a service account password")
+			return nil
+		},
+	}
+
+	provider := adProvider{tokenMGR: &tokens.Manager{}}
+	credentials := v3.BasicLogin{Username: userName, Password: userPassword}
+
+	_, _, err := provider.loginUser(ldapConn, &credentials, &config)
+	require.Error(t, err)
+
+	herr, ok := err.(*apierror.APIError)
+	require.True(t, ok)
+	assert.Equal(t, validation.MissingRequired, herr.Code,
+		"the classifier must not flatten an APIError the bind helpers already produced")
+}
+
+func TestLoginUserNTLMSurfacesAChannelBindingRejection(t *testing.T) {
+	t.Parallel()
+
+	config := v3.ActiveDirectoryConfig{
+		BindMechanism:          bindMechanismNTLM,
+		TLS:                    true,
+		DefaultLoginDomain:     "FOO",
+		ServiceAccountUsername: saUsername,
+		ServiceAccountPassword: saPassword,
+		UserObjectClass:        userObjectClassName,
+		UserLoginAttribute:     "sAMAccountName",
+		UserSearchBase:         baseDN,
+	}
+
+	ldapConn := &ldapFakes.FakeLdapConn{
+		TLSConnectionStateFunc: tlsStateWithPeer(),
+		NTLMChallengeBindFunc: func(*ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+			return nil, ldapError(ldapv3.LDAPResultInvalidCredentials,
+				"comment: AcceptSecurityContext error, data 80090346, v4563")
+		},
+	}
+
+	provider := adProvider{tokenMGR: &tokens.Manager{}}
+	credentials := v3.BasicLogin{Username: userName, Password: userPassword}
+
+	_, _, err := provider.loginUser(ldapConn, &credentials, &config)
+	require.Error(t, err)
+
+	herr, ok := err.(*apierror.APIError)
+	require.True(t, ok)
+	assert.Equal(t, validation.ServerError, herr.Code)
+	assert.Contains(t, herr.Message, "80090346")
+	assert.Contains(t, herr.Message, "channel binding")
+}
+
+// bindFailingProvider returns a provider whose connection is real enough to
+// bind and search, and whose bind fails with the given diagnostic.
+func bindFailingProvider(t *testing.T, diagnostic string, enabled bool) (*adProvider, *atomic.Bool) {
+	t.Helper()
+
+	var closed atomic.Bool
+	conn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(string, string) error {
+			return ldapError(ldapv3.LDAPResultInvalidCredentials, diagnostic)
+		},
+		SearchFunc: func(*ldapv3.SearchRequest) (*ldapv3.SearchResult, error) {
+			t.Fatal("search must not run after a failed bind")
+			return nil, nil
+		},
+		CloseFunc: func() error { closed.Store(true); return nil },
+	}
+
+	// No ownership assertion here. This helper serves two kinds of test, and
+	// only one of them owns the connection: a provider entry point defers
+	// Close, while the ...OnConn helpers deliberately do not close a
+	// connection they were handed. An unconditional cleanup assertion fails
+	// every direct-helper test even when its subject passes.
+	//
+	// Callers that do own the connection assert `closed` themselves.
+
+	return &adProvider{
+		loadConfig: func() (*v3.ActiveDirectoryConfig, *x509.CertPool, error) {
+			return &v3.ActiveDirectoryConfig{
+				AuthConfig:             v3.AuthConfig{Enabled: enabled},
+				ServiceAccountUsername: saUsername,
+				ServiceAccountPassword: saPassword,
+				UserSearchBase:         baseDN,
+				UserObjectClass:        userObjectClassName,
+				UserLoginAttribute:     "sAMAccountName",
+				UserNameAttribute:      "name",
+				GroupObjectClass:       "group",
+				GroupNameAttribute:     "name",
+				GroupSearchAttribute:   "sAMAccountName",
+				GroupDNAttribute:       "distinguishedName",
+			}, nil, nil
+		},
+		dial: func(*v3.ActiveDirectoryConfig, *x509.CertPool) (ldapv3.Client, error) { return conn, nil },
+	}, &closed
+}
+
+func TestSearchPrincipalsSurfacesNonCredentialBindFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		diagnostic string
+		wantInMsg  string
+	}{
+		{name: "bad bindings", diagnostic: capturedBadBindings, wantInMsg: "channel binding"},
+		{name: "malformed token", diagnostic: capturedBadToken, wantInMsg: "malformed"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider, closed := bindFailingProvider(t, test.diagnostic, true)
+
+			got, err := provider.SearchPrincipals("alice", "user", &v3.Token{})
+
+			require.Error(t, err, "the mapped error must reach the caller, not be swallowed")
+			assert.True(t, closed.Load(), "SearchPrincipals owns the connection and must close it")
+			assert.Empty(t, got)
+			assert.Contains(t, err.Error(), test.wantInMsg)
+
+			herr, ok := err.(*apierror.APIError)
+			require.True(t, ok)
+			assert.Equal(t, validation.ServerError, herr.Code)
+		})
+	}
+}
+
+func TestSearchPrincipalsStillSwallowsOrdinaryFailures(t *testing.T) {
+	t.Parallel()
+
+	// A wrong service-account password must keep returning an empty result and
+	// a nil error. Callers depend on principal search degrading rather than
+	// erroring, and only the two non-credential classes may change that.
+	provider, closed := bindFailingProvider(t, typicalWrongPassword, true)
+
+	got, err := provider.SearchPrincipals("alice", "user", &v3.Token{})
+
+	assert.NoError(t, err)
+	assert.Empty(t, got)
+	assert.True(t, closed.Load())
+}
+
+func TestGroupPrincipalsFallbackDistinguishesFailureKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		diagnostic   string
+		wantFallback bool   // degrade to memberOf-derived principals
+		wantInMsg    string // when not degrading
+	}{
+		{
+			name:         "rotated password still degrades",
+			diagnostic:   typicalWrongPassword,
+			wantFallback: true,
+		},
+		{
+			name:       "bad bindings surfaces",
+			diagnostic: capturedBadBindings,
+			wantInMsg:  "channel binding",
+		},
+		{
+			name:       "malformed token surfaces",
+			diagnostic: capturedBadToken,
+			wantInMsg:  "malformed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider, _ := bindFailingProvider(t, test.diagnostic, true)
+			config, _, err := provider.configOrDefault()
+			require.NoError(t, err)
+			conn, err := provider.ldapConnectionOrDefault(config, nil)
+			require.NoError(t, err)
+
+			// getGroupPrincipalsFromSearch is handed a connection it does not
+			// own, so closing it is this test's job.
+			defer func() { _ = conn.Close() }()
+
+			got, err := provider.getGroupPrincipalsFromSearch(
+				conn, config, baseDN, "(objectClass=group)", []string{groupDN})
+
+			if test.wantFallback {
+				require.NoError(t, err, "a rotated password must still degrade")
+				require.Len(t, got, 1, "the fallback returns principals derived from memberOf")
+				assert.Equal(t, GroupScope+"://"+groupDN, got[0].Name)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Empty(t, got, "partial group data must not be returned for a non-credential failure")
+			assert.Contains(t, err.Error(), test.wantInMsg)
+		})
+	}
+}
+
+func TestGetPrincipalFallbackDistinguishesFailureKinds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		diagnostic   string
+		wantFallback bool
+		wantInMsg    string
+	}{
+		{
+			name:         "rotated password still degrades",
+			diagnostic:   typicalWrongPassword,
+			wantFallback: true,
+		},
+		{
+			name:       "bad bindings surfaces",
+			diagnostic: capturedBadBindings,
+			wantInMsg:  "channel binding",
+		},
+		{
+			name:       "malformed token surfaces",
+			diagnostic: capturedBadToken,
+			wantInMsg:  "malformed",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			provider, _ := bindFailingProvider(t, test.diagnostic, true)
+			config, _, err := provider.configOrDefault()
+			require.NoError(t, err)
+			conn, err := provider.ldapConnectionOrDefault(config, nil)
+			require.NoError(t, err)
+
+			// Same ownership rule as site 4: the ...OnConn helper does not
+			// close a connection it was given.
+			defer func() { _ = conn.Close() }()
+
+			got, err := provider.getPrincipalOnConn(conn, userDN, UserScope, config)
+
+			if test.wantFallback {
+				// Site 5 degrades differently from site 4: it returns a single
+				// principal formed from the DN, not principals derived from
+				// memberOf.
+				require.NoError(t, err, "a rotated password must still degrade")
+				require.NotNil(t, got)
+				assert.Equal(t, UserScope+"://"+userDN, got.Name)
+				assert.Equal(t, userDN, got.LoginName)
+				return
+			}
+
+			require.Error(t, err)
+			assert.Nil(t, got, "a DN-formed principal must not stand in for a non-credential failure")
+			assert.Contains(t, err.Error(), test.wantInMsg)
+		})
+	}
 }

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	ldapv3 "github.com/go-ldap/ldap/v3"
 	"github.com/pkg/errors"
 	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/norman/types"
@@ -54,6 +55,24 @@ type adProvider struct {
 	certs       string
 	caPool      *x509.CertPool
 	tokenMGR    *tokens.Manager
+
+	// Test seams. All nil in production; each falls back to the real method.
+	dial       func(*v3.ActiveDirectoryConfig, *x509.CertPool) (ldapv3.Client, error)
+	loadConfig func() (*v3.ActiveDirectoryConfig, *x509.CertPool, error)
+}
+
+func (p *adProvider) ldapConnectionOrDefault(config *v3.ActiveDirectoryConfig, caPool *x509.CertPool) (ldapv3.Client, error) {
+	if p.dial != nil {
+		return p.dial(config, caPool)
+	}
+	return p.ldapConnection(config, caPool)
+}
+
+func (p *adProvider) configOrDefault() (*v3.ActiveDirectoryConfig, *x509.CertPool, error) {
+	if p.loadConfig != nil {
+		return p.loadConfig()
+	}
+	return p.getActiveDirectoryConfig()
 }
 
 func Configure(mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager) common.AuthProvider {
@@ -99,8 +118,11 @@ func (p *adProvider) AuthenticateUser(_ http.ResponseWriter, _ *http.Request, in
 		return v3.Principal{}, nil, "", errors.New("unexpected input type")
 	}
 
-	config, caPool, err := p.getActiveDirectoryConfig()
+	config, caPool, err := p.configOrDefault()
 	if err != nil {
+		if errors.Is(err, errBindConfiguration) {
+			return v3.Principal{}, nil, "", apierror.WrapAPIError(err, validation.InvalidOption, err.Error())
+		}
 		return v3.Principal{}, nil, "", errors.New("can't find authprovider")
 	}
 
@@ -127,8 +149,11 @@ func (p *adProvider) SearchPrincipals(searchKey, principalType string, myToken a
 	var principals []v3.Principal
 	var err error
 
-	config, caPool, err := p.getActiveDirectoryConfig()
+	config, caPool, err := p.configOrDefault()
 	if err != nil {
+		if errors.Is(err, errBindConfiguration) {
+			return nil, apierror.WrapAPIError(err, validation.InvalidOption, err.Error())
+		}
 		return principals, nil
 	}
 
@@ -155,8 +180,11 @@ func (p *adProvider) SearchPrincipals(searchKey, principalType string, myToken a
 }
 
 func (p *adProvider) GetPrincipal(principalID string, token accessor.TokenAccessor) (v3.Principal, error) {
-	config, caPool, err := p.getActiveDirectoryConfig()
+	config, caPool, err := p.configOrDefault()
 	if err != nil {
+		if errors.Is(err, errBindConfiguration) {
+			return v3.Principal{}, apierror.WrapAPIError(err, validation.InvalidOption, err.Error())
+		}
 		return v3.Principal{}, nil
 	}
 
@@ -186,12 +214,21 @@ func (p *adProvider) getActiveDirectoryConfig() (*v3.ActiveDirectoryConfig, *x50
 	if !ok {
 		return nil, nil, fmt.Errorf("failed to retrieve ActiveDirectoryConfig, cannot read k8s Unstructured data")
 	}
-	storedADConfigMap := u.UnstructuredContent()
+	return p.decodeActiveDirectoryConfig(u.UnstructuredContent())
+}
 
+// decodeActiveDirectoryConfig holds everything after the fetch: decode,
+// validate, CA pool, service-account secret. Pure with respect to the API
+// server, so it is directly testable from a map.
+func (p *adProvider) decodeActiveDirectoryConfig(storedADConfigMap map[string]any) (*v3.ActiveDirectoryConfig, *x509.CertPool, error) {
 	storedADConfig := &v3.ActiveDirectoryConfig{}
-	err = common.Decode(storedADConfigMap, storedADConfig)
+	err := common.Decode(storedADConfigMap, storedADConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("unable to decode Active Directory Config: %w", err)
+	}
+
+	if err := validateBindConfiguration(storedADConfig); err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", errBindConfiguration, err)
 	}
 
 	if p.certs != storedADConfig.Certificate || p.caPool == nil {
@@ -225,7 +262,7 @@ func newCAPool(cert string) (*x509.CertPool, error) {
 }
 
 func (p *adProvider) CanAccessWithGroupProviders(userPrincipalID string, groupPrincipals []v3.Principal) (bool, error) {
-	config, _, err := p.getActiveDirectoryConfig()
+	config, _, err := p.configOrDefault()
 	if err != nil {
 		logrus.Errorf("Error fetching AD config: %v", err)
 		return false, err
@@ -260,7 +297,7 @@ func (e LoginDisabledError) Error() string {
 
 // IsDisabledProvider checks if the Azure Active Directory provider is currently disabled in Rancher.
 func (p *adProvider) IsDisabledProvider() (bool, error) {
-	adConfig, _, err := p.getActiveDirectoryConfig()
+	adConfig, _, err := p.configOrDefault()
 	if err != nil {
 		return false, err
 	}

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -131,7 +131,7 @@ func (p *adProvider) AuthenticateUser(_ http.ResponseWriter, _ *http.Request, in
 		return v3.Principal{}, nil, "", apierror.WrapAPIError(err, validation.ClusterUnavailable, StatusLoginDisabled)
 	}
 
-	lConn, err := p.ldapConnection(config, caPool)
+	lConn, err := p.ldapConnectionOrDefault(config, caPool)
 	if err != nil {
 		return v3.Principal{}, nil, "", err
 	}
@@ -157,22 +157,31 @@ func (p *adProvider) SearchPrincipals(searchKey, principalType string, myToken a
 		return principals, nil
 	}
 
-	lConn, err := p.ldapConnection(config, caPool)
+	lConn, err := p.ldapConnectionOrDefault(config, caPool)
 	if err != nil {
 		return principals, nil
 	}
 	defer lConn.Close()
 
 	principals, err = p.searchPrincipals(searchKey, principalType, config, lConn)
-	if err == nil {
-		for _, principal := range principals {
-			if principal.PrincipalType == "user" {
-				if common.SamePrincipal(myToken.GetUserPrincipal(), principal) {
-					principal.Me = true
-				}
-			} else if principal.PrincipalType == "group" {
-				principal.MemberOf = p.userMGR.IsMemberOf(myToken, principal)
+	if err != nil {
+		// A channel binding rejection or a malformed token is a fault an
+		// operator must see. Every other search failure keeps the historic
+		// behaviour of returning an empty result, because callers rely on
+		// principal search degrading rather than erroring.
+		if classifyBindFailure(err) != bindFailureNone {
+			return nil, apierror.WrapAPIError(err, validation.ServerError, mapBindError(err).Error())
+		}
+		return principals, nil
+	}
+
+	for _, principal := range principals {
+		if principal.PrincipalType == "user" {
+			if common.SamePrincipal(myToken.GetUserPrincipal(), principal) {
+				principal.Me = true
 			}
+		} else if principal.PrincipalType == "group" {
+			principal.MemberOf = p.userMGR.IsMemberOf(myToken, principal)
 		}
 	}
 

--- a/pkg/auth/providers/activedirectory/activedirectory_provider.go
+++ b/pkg/auth/providers/activedirectory/activedirectory_provider.go
@@ -226,7 +226,7 @@ func (p *adProvider) getActiveDirectoryConfig() (*v3.ActiveDirectoryConfig, *x50
 	return p.decodeActiveDirectoryConfig(u.UnstructuredContent())
 }
 
-// decodeActiveDirectoryConfig holds everything after the fetch: decode,
+// decodeActiveDirectoryConfig performs everything after the fetch: decode,
 // validate, CA pool, service-account secret. Pure with respect to the API
 // server, so it is directly testable from a map.
 func (p *adProvider) decodeActiveDirectoryConfig(storedADConfigMap map[string]any) (*v3.ActiveDirectoryConfig, *x509.CertPool, error) {

--- a/pkg/auth/providers/activedirectory/bind.go
+++ b/pkg/auth/providers/activedirectory/bind.go
@@ -3,8 +3,12 @@ package activedirectory
 import (
 	"errors"
 	"fmt"
+	"strings"
 
+	ldapv3 "github.com/go-ldap/ldap/v3"
+	"github.com/rancher/apiserver/pkg/apierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 )
 
 const (
@@ -39,3 +43,48 @@ func validateBindConfiguration(config *v3.ActiveDirectoryConfig) error {
 // sentinel lets them surface the one class of error an operator can act on
 // without changing behavior for any other.
 var errBindConfiguration = errors.New("invalid Active Directory bind configuration")
+
+// splitNTLMIdentity returns the NetBIOS domain and sAMAccountName the NTLM
+// mechanism accepts. It never applies to simple binds, which keep passing the
+// raw value through ldap.GetUserExternalID.
+//
+// Only DOMAIN\user and a bare user name with a configured default login domain
+// are accepted. A user principal name needs a search against
+// userPrincipalName and a canonicalization step that does not exist yet, so it
+// is rejected outright rather than silently treated as a bare name and failing
+// later as an unrelated lookup error.
+func splitNTLMIdentity(username, defaultDomain string) (string, string, error) {
+	invalid := func(reason string) error {
+		return apierror.NewAPIError(validation.InvalidOption,
+			fmt.Sprintf("username %q cannot be used with bindMechanism %q: %s", username, bindMechanismNTLM, reason))
+	}
+
+	if strings.TrimSpace(username) == "" {
+		return "", "", invalid("it is empty")
+	}
+	if strings.Contains(username, "@") {
+		return "", "", invalid("user principal names are not supported, use DOMAIN\\user or configure a default login domain")
+	}
+	if _, err := ldapv3.ParseDN(username); err == nil {
+		return "", "", invalid("distinguished names are not supported, use DOMAIN\\user")
+	}
+
+	domain := defaultDomain
+	user := username
+
+	if parts := strings.Split(username, `\`); len(parts) > 1 {
+		if len(parts) > 2 {
+			return "", "", invalid("it contains more than one backslash")
+		}
+		domain, user = parts[0], parts[1]
+	}
+
+	if strings.TrimSpace(domain) == "" {
+		return "", "", invalid("no domain was given and defaultLoginDomain is not set")
+	}
+	if strings.TrimSpace(user) == "" {
+		return "", "", invalid("the user part is empty")
+	}
+
+	return domain, user, nil
+}

--- a/pkg/auth/providers/activedirectory/bind.go
+++ b/pkg/auth/providers/activedirectory/bind.go
@@ -1,0 +1,41 @@
+package activedirectory
+
+import (
+	"errors"
+	"fmt"
+
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+)
+
+const (
+	bindMechanismSimple   = "simple"
+	bindMechanismNTLM     = "ntlm"
+	bindMechanismKerberos = "kerberos"
+)
+
+// validateBindConfiguration reports whether config selects a bind mechanism
+// this build supports on the configured transport. It has no side effects and
+// performs no I/O, so it is safe to call on every path that can reach a bind.
+func validateBindConfiguration(config *v3.ActiveDirectoryConfig) error {
+	switch config.BindMechanism {
+	case "", bindMechanismSimple:
+		return nil
+	case bindMechanismNTLM:
+		if !config.TLS && !config.StartTLS {
+			return fmt.Errorf("bindMechanism %q requires tls or starttls", bindMechanismNTLM)
+		}
+		return nil
+	case bindMechanismKerberos:
+		return fmt.Errorf("bindMechanism %q is reserved and not yet supported", bindMechanismKerberos)
+	default:
+		return fmt.Errorf("invalid bindMechanism %q, must be one of %q or %q",
+			config.BindMechanism, bindMechanismSimple, bindMechanismNTLM)
+	}
+}
+
+// errBindConfiguration marks a failure caused by an invalid bind configuration
+// rather than by an unreachable or malformed auth config. Callers of
+// getActiveDirectoryConfig deliberately swallow generic load failures; this
+// sentinel lets them surface the one class of error an operator can act on
+// without changing behavior for any other.
+var errBindConfiguration = errors.New("invalid Active Directory bind configuration")

--- a/pkg/auth/providers/activedirectory/bind.go
+++ b/pkg/auth/providers/activedirectory/bind.go
@@ -8,7 +8,10 @@ import (
 	ldapv3 "github.com/go-ldap/ldap/v3"
 	"github.com/rancher/apiserver/pkg/apierror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/auth/providers/common/ldap"
+	"github.com/rancher/rancher/pkg/auth/providers/common/ldap/ntlm"
 	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
+	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -87,4 +90,144 @@ func splitNTLMIdentity(username, defaultDomain string) (string, string, error) {
 	}
 
 	return domain, user, nil
+}
+
+// ntlmIdentity is a bind identity already resolved by splitNTLMIdentity.
+// loginUser resolves the end user's identity before any directory I/O and
+// passes the result down, so the raw login value is parsed exactly once.
+type ntlmIdentity struct {
+	Domain   string
+	Username string
+}
+
+// ntlmChallengeBinder is the part of *ldapv3.Conn that performs an NTLM bind.
+// ldapv3.Client does not include NTLMChallengeBind, so the concrete capability
+// is asserted at the call site.
+type ntlmChallengeBinder interface {
+	NTLMChallengeBind(request *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error)
+}
+
+// bindServiceAccount binds conn as the configured service account.
+//
+// The bind error is returned unclassified. Sites that build an API response
+// pass it through classifyServiceAccountBindError; sites with a config.Enabled
+// fallback must not, because that fallback inspects the LDAP result code.
+func (p *adProvider) bindServiceAccount(conn ldapv3.Client, config *v3.ActiveDirectoryConfig) error {
+	logrus.Debug("Binding service account username password")
+
+	if config.ServiceAccountPassword == "" {
+		return apierror.NewAPIError(validation.MissingRequired, "service account password not provided")
+	}
+	return p.bindAs(conn, config, nil, config.ServiceAccountUsername, config.ServiceAccountPassword)
+}
+
+// bindUser binds conn as an end user. identity may be nil for the simple
+// mechanism; the NTLM path requires it to have been resolved by loginUser.
+func (p *adProvider) bindUser(conn ldapv3.Client, config *v3.ActiveDirectoryConfig, identity *ntlmIdentity, username, password string) error {
+	return p.bindAs(conn, config, identity, username, password)
+}
+
+// bindAs binds conn according to config.BindMechanism. It is the only place in
+// the provider that performs a bind, so no path can reach the directory with a
+// mechanism the configuration did not select.
+//
+// identity, when non-nil, is an already-resolved NTLM identity and takes
+// precedence over parsing username.
+func (p *adProvider) bindAs(conn ldapv3.Client, config *v3.ActiveDirectoryConfig, identity *ntlmIdentity, username, password string) error {
+	// Defense in depth: the config is validated where it is loaded and where
+	// it is applied, but a future caller could reach here another way.
+	if err := validateBindConfiguration(config); err != nil {
+		return apierror.WrapAPIError(err, validation.InvalidOption, err.Error())
+	}
+
+	if config.BindMechanism != bindMechanismNTLM {
+		return conn.Bind(ldap.GetUserExternalID(username, config.DefaultLoginDomain), password)
+	}
+
+	binder, ok := conn.(ntlmChallengeBinder)
+	if !ok {
+		// A programming error, not a configuration one. Never fall back to a
+		// simple bind: that would silently defeat channel binding.
+		return apierror.NewAPIError(validation.ServerError,
+			fmt.Sprintf("activedirectory: connection of type %T cannot perform an NTLM bind", conn))
+	}
+
+	if identity == nil {
+		domain, user, err := splitNTLMIdentity(username, config.DefaultLoginDomain)
+		if err != nil {
+			return err
+		}
+		identity = &ntlmIdentity{Domain: domain, Username: user}
+	}
+
+	state, ok := conn.TLSConnectionState()
+	if !ok {
+		return apierror.NewAPIError(validation.ServerError,
+			"activedirectory: an NTLM bind needs a TLS connection, but the connection is not using TLS")
+	}
+	if len(state.PeerCertificates) == 0 {
+		return apierror.NewAPIError(validation.ServerError,
+			"activedirectory: an NTLM bind needs the server certificate to derive a channel binding token, but the TLS connection presented none")
+	}
+
+	cbt, err := ntlm.ChannelBindingToken(state.PeerCertificates[0])
+	if err != nil {
+		return apierror.WrapAPIError(err, validation.ServerError, err.Error())
+	}
+
+	negotiator, err := ntlm.NewNegotiator(cbt)
+	if err != nil {
+		return apierror.WrapAPIError(err, validation.ServerError, err.Error())
+	}
+
+	logrus.Debugf("activedirectory: binding %s with mechanism %s", identity.Domain, bindMechanismNTLM)
+
+	// Password only. Leaving Hash empty keeps pass-the-hash unreachable and
+	// makes go-ldap derive the NT hash it passes to the negotiator.
+	//
+	// The error is returned unwrapped. Callers inspect it with
+	// ldapv3.IsErrorWithCode, and classification into an APIError happens at
+	// the call sites that produce an API response — never here.
+	_, err = binder.NTLMChallengeBind(&ldapv3.NTLMBindRequest{
+		Domain:     identity.Domain,
+		Username:   identity.Username,
+		Password:   password,
+		Negotiator: negotiator,
+	})
+	return err
+}
+
+// classifyServiceAccountBindError turns a service-account bind failure into
+// the APIError the login and refresh paths have always returned.
+//
+// It replaces the classification that lived in ldap.AuthenticateServiceAccountUser.
+// The channel-binding case is separated out because it arrives as
+// invalidCredentials but is a configuration fault, not a wrong password, and
+// apierror.WrapAPIError drops the cause from the response — so the mapped
+// explanation has to be the message.
+func classifyServiceAccountBindError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	// bindServiceAccount and bindAs already return APIErrors for the problems
+	// they detect themselves: a missing service account password
+	// (MissingRequired), an invalid mechanism, a connection with no TLS state,
+	// a missing peer certificate, a CBT that cannot be derived. Those carry
+	// codes and messages an operator can act on, so they pass through
+	// untouched. Only an error from the directory reaches the LDAP
+	// classification below.
+	if apierror.IsAPIError(err) {
+		return err
+	}
+
+	// Both non-credential failures arrive as result code 49 and must be
+	// separated from a wrong password before the Unauthorized branch below.
+	if classifyBindFailure(err) != bindFailureNone {
+		return apierror.WrapAPIError(err, validation.ServerError, mapBindError(err).Error())
+	}
+	if ldapv3.IsErrorWithCode(err, ldapv3.LDAPResultInvalidCredentials) {
+		return apierror.WrapAPIError(err, validation.Unauthorized, "authentication failed")
+	}
+	return apierror.WrapAPIError(err, validation.ServerError, "server error while authenticating")
 }

--- a/pkg/auth/providers/activedirectory/bind.go
+++ b/pkg/auth/providers/activedirectory/bind.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Values of ActiveDirectoryConfig.BindMechanism.
 const (
 	bindMechanismSimple   = "simple"
 	bindMechanismNTLM     = "ntlm"
@@ -93,8 +94,6 @@ func splitNTLMIdentity(username, defaultDomain string) (string, string, error) {
 }
 
 // ntlmIdentity is a bind identity already resolved by splitNTLMIdentity.
-// loginUser resolves the end user's identity before any directory I/O and
-// passes the result down, so the raw login value is parsed exactly once.
 type ntlmIdentity struct {
 	Domain   string
 	Username string
@@ -121,8 +120,8 @@ func (p *adProvider) bindServiceAccount(conn ldapv3.Client, config *v3.ActiveDir
 	return p.bindAs(conn, config, nil, config.ServiceAccountUsername, config.ServiceAccountPassword)
 }
 
-// bindUser binds conn as an end user. identity may be nil for the simple
-// mechanism; the NTLM path requires it to have been resolved by loginUser.
+// bindUser binds conn as an end user. identity is optional: when nil, the
+// NTLM path in bindAs parses username itself.
 func (p *adProvider) bindUser(conn ldapv3.Client, config *v3.ActiveDirectoryConfig, identity *ntlmIdentity, username, password string) error {
 	return p.bindAs(conn, config, identity, username, password)
 }
@@ -133,6 +132,11 @@ func (p *adProvider) bindUser(conn ldapv3.Client, config *v3.ActiveDirectoryConf
 //
 // identity, when non-nil, is an already-resolved NTLM identity and takes
 // precedence over parsing username.
+//
+// Failures bindAs detects itself — an invalid mechanism, a connection
+// without TLS state, a missing peer certificate, an underivable channel
+// binding token — are returned as APIErrors carrying actionable messages.
+// Only an error from the directory comes back unclassified.
 func (p *adProvider) bindAs(conn ldapv3.Client, config *v3.ActiveDirectoryConfig, identity *ntlmIdentity, username, password string) error {
 	// Defense in depth: the config is validated where it is loaded and where
 	// it is applied, but a future caller could reach here another way.
@@ -211,9 +215,7 @@ func classifyServiceAccountBindError(err error) error {
 	}
 
 	// bindServiceAccount and bindAs already return APIErrors for the problems
-	// they detect themselves: a missing service account password
-	// (MissingRequired), an invalid mechanism, a connection with no TLS state,
-	// a missing peer certificate, a CBT that cannot be derived. Those carry
+	// they detect themselves (see the bindAs doc for the list). Those carry
 	// codes and messages an operator can act on, so they pass through
 	// untouched. Only an error from the directory reaches the LDAP
 	// classification below.

--- a/pkg/auth/providers/activedirectory/bind_test.go
+++ b/pkg/auth/providers/activedirectory/bind_test.go
@@ -1,0 +1,254 @@
+package activedirectory
+
+import (
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+	"github.com/rancher/norman/httperror"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	ldapFakes "github.com/rancher/rancher/pkg/auth/providers/common/ldap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateBindConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		config  v3.ActiveDirectoryConfig
+		wantErr bool
+	}{
+		{
+			name:   "empty mechanism is simple",
+			config: v3.ActiveDirectoryConfig{},
+		},
+		{
+			name:   "simple over plaintext",
+			config: v3.ActiveDirectoryConfig{BindMechanism: "simple"},
+		},
+		{
+			name:   "ntlm over tls",
+			config: v3.ActiveDirectoryConfig{BindMechanism: "ntlm", TLS: true},
+		},
+		{
+			name:   "ntlm over starttls",
+			config: v3.ActiveDirectoryConfig{BindMechanism: "ntlm", StartTLS: true},
+		},
+		{
+			name:    "ntlm over plaintext",
+			config:  v3.ActiveDirectoryConfig{BindMechanism: "ntlm"},
+			wantErr: true,
+		},
+		{
+			name:    "kerberos is reserved but not accepted",
+			config:  v3.ActiveDirectoryConfig{BindMechanism: "kerberos", TLS: true},
+			wantErr: true,
+		},
+		{
+			name:    "unknown mechanism",
+			config:  v3.ActiveDirectoryConfig{BindMechanism: "gssapi", TLS: true},
+			wantErr: true,
+		},
+		{
+			name:    "mechanism is case sensitive",
+			config:  v3.ActiveDirectoryConfig{BindMechanism: "NTLM", TLS: true},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := validateBindConfiguration(&test.config)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestDecodeActiveDirectoryConfigRejectsBadMechanism(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		mechanism string
+		tls       bool
+		wantErr   bool
+	}{
+		{name: "unknown mechanism", mechanism: "gssapi", tls: true, wantErr: true},
+		{name: "ntlm over plaintext", mechanism: bindMechanismNTLM, wantErr: true},
+		{name: "kerberos reserved", mechanism: bindMechanismKerberos, tls: true, wantErr: true},
+		{name: "ntlm over tls", mechanism: bindMechanismNTLM, tls: true},
+		{name: "empty is simple", mechanism: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, _, err := (&adProvider{}).decodeActiveDirectoryConfig(map[string]any{
+				"metadata":      map[string]any{"name": "activedirectory"},
+				"bindMechanism": test.mechanism,
+				"tls":           test.tls,
+				"servers":       []any{"dc1.example.com"},
+			})
+
+			if !test.wantErr {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.ErrorIs(t, err, errBindConfiguration)
+			assert.Contains(t, err.Error(), "bindMechanism")
+		})
+	}
+}
+
+// badConfigProvider returns a provider whose config load fails with the given
+// error, so the three swallowing callers can be driven directly.
+func badConfigProvider(err error) *adProvider {
+	return &adProvider{
+		loadConfig: func() (*v3.ActiveDirectoryConfig, *x509.CertPool, error) { return nil, nil, err },
+		dial: func(*v3.ActiveDirectoryConfig, *x509.CertPool) (ldapv3.Client, error) {
+			panic("dial must not be reached when the config failed to load")
+		},
+	}
+}
+
+func TestStoredConfigCallersSurfaceBindConfigurationErrors(t *testing.T) {
+	t.Parallel()
+
+	loadErr := fmt.Errorf("%w: invalid bindMechanism %q", errBindConfiguration, "gssapi")
+
+	t.Run("AuthenticateUser", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, _, err := badConfigProvider(loadErr).AuthenticateUser(nil, nil,
+			&v3.BasicLogin{Username: userName, Password: userPassword})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bindMechanism")
+		assert.NotContains(t, err.Error(), "can't find authprovider",
+			"a bind configuration fault must not be reported as a missing auth provider")
+	})
+
+	t.Run("SearchPrincipals", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := badConfigProvider(loadErr).SearchPrincipals("alice", "user", &v3.Token{})
+
+		require.Error(t, err, "previously returned a nil error and an empty slice")
+		assert.Empty(t, got)
+		assert.Contains(t, err.Error(), "bindMechanism")
+	})
+
+	t.Run("GetPrincipal", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := badConfigProvider(loadErr).GetPrincipal(UserScope+"://"+userDN, &v3.Token{})
+
+		require.Error(t, err, "previously returned a nil error and a zero principal")
+		assert.Contains(t, err.Error(), "bindMechanism")
+	})
+}
+
+func TestStoredConfigCallersStillSwallowUnrelatedFailures(t *testing.T) {
+	t.Parallel()
+
+	// Anything that is not errBindConfiguration keeps the historic behaviour.
+	// This is what stops the change becoming a wider behavioural one than
+	// intended, and it is the test most likely to fail if the sentinel check
+	// is written as a catch-all.
+	loadErr := errors.New("failed to retrieve ActiveDirectoryConfig: connection refused")
+
+	t.Run("AuthenticateUser still reports the generic message", func(t *testing.T) {
+		t.Parallel()
+
+		_, _, _, err := badConfigProvider(loadErr).AuthenticateUser(nil, nil,
+			&v3.BasicLogin{Username: userName, Password: userPassword})
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "can't find authprovider")
+	})
+
+	t.Run("SearchPrincipals still returns empty and nil", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := badConfigProvider(loadErr).SearchPrincipals("alice", "user", &v3.Token{})
+
+		assert.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("GetPrincipal still returns zero and nil", func(t *testing.T) {
+		t.Parallel()
+
+		got, err := badConfigProvider(loadErr).GetPrincipal(UserScope+"://"+userDN, &v3.Token{})
+
+		assert.NoError(t, err)
+		assert.Empty(t, got.Name)
+	})
+}
+
+func TestConnectForTestAndApplyValidatesBeforeDialling(t *testing.T) {
+	t.Parallel()
+
+	var dialled atomic.Bool
+	provider := &adProvider{
+		dial: func(*v3.ActiveDirectoryConfig, *x509.CertPool) (ldapv3.Client, error) {
+			dialled.Store(true)
+			return nil, errors.New("dial must not be reached")
+		},
+	}
+
+	_, err := provider.connectForTestAndApply(&v3.ActiveDirectoryTestAndApplyInput{
+		Username: userName,
+		Password: userPassword,
+		ActiveDirectoryConfig: v3.ActiveDirectoryConfig{
+			BindMechanism: bindMechanismNTLM, // no TLS, no StartTLS
+			Servers:       []string{"dc1.example.com"},
+		},
+	})
+
+	require.Error(t, err)
+	herr, ok := err.(*httperror.APIError)
+	require.True(t, ok)
+	assert.Equal(t, httperror.InvalidBodyContent, herr.Code)
+	assert.False(t, dialled.Load(), "validation must run before the connection is opened")
+}
+
+func TestConnectForTestAndApplyDialsWhenValid(t *testing.T) {
+	t.Parallel()
+
+	// The mirror case: without it, a validator that rejected everything would
+	// pass the test above.
+	var dialled atomic.Bool
+	provider := &adProvider{
+		dial: func(*v3.ActiveDirectoryConfig, *x509.CertPool) (ldapv3.Client, error) {
+			dialled.Store(true)
+			return &ldapFakes.FakeLdapConn{}, nil
+		},
+	}
+
+	_, err := provider.connectForTestAndApply(&v3.ActiveDirectoryTestAndApplyInput{
+		Username: userName,
+		Password: userPassword,
+		ActiveDirectoryConfig: v3.ActiveDirectoryConfig{
+			BindMechanism: bindMechanismNTLM,
+			TLS:           true,
+			Servers:       []string{"dc1.example.com"},
+		},
+	})
+
+	require.NoError(t, err)
+	assert.True(t, dialled.Load())
+}

--- a/pkg/auth/providers/activedirectory/bind_test.go
+++ b/pkg/auth/providers/activedirectory/bind_test.go
@@ -8,9 +8,11 @@ import (
 	"testing"
 
 	ldapv3 "github.com/go-ldap/ldap/v3"
+	"github.com/rancher/apiserver/pkg/apierror"
 	"github.com/rancher/norman/httperror"
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	ldapFakes "github.com/rancher/rancher/pkg/auth/providers/common/ldap"
+	"github.com/rancher/wrangler/v3/pkg/schemas/validation"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -251,4 +253,71 @@ func TestConnectForTestAndApplyDialsWhenValid(t *testing.T) {
 
 	require.NoError(t, err)
 	assert.True(t, dialled.Load())
+}
+
+func TestSplitNTLMIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		username      string
+		defaultDomain string
+		wantDomain    string
+		wantUser      string
+		wantErr       bool
+	}{
+		{
+			name:       "domain qualified",
+			username:   `FOO\alice`,
+			wantDomain: "FOO",
+			wantUser:   "alice",
+		},
+		{
+			name:          "domain qualified ignores the default domain",
+			username:      `FOO\alice`,
+			defaultDomain: "BAR",
+			wantDomain:    "FOO",
+			wantUser:      "alice",
+		},
+		{
+			name:          "bare name uses the default domain",
+			username:      "alice",
+			defaultDomain: "FOO",
+			wantDomain:    "FOO",
+			wantUser:      "alice",
+		},
+		{
+			name:     "bare name without a default domain",
+			username: "alice",
+			wantErr:  true,
+		},
+		{name: "empty", username: "", defaultDomain: "FOO", wantErr: true},
+		{name: "empty domain", username: `\alice`, defaultDomain: "FOO", wantErr: true},
+		{name: "empty user", username: `FOO\`, wantErr: true},
+		{name: "only a backslash", username: `\`, wantErr: true},
+		{name: "two backslashes", username: `A\B\alice`, wantErr: true},
+		{name: "upn", username: "alice@example.com", defaultDomain: "FOO", wantErr: true},
+		{name: "upn with a domain prefix", username: `FOO\alice@example.com`, wantErr: true},
+		{name: "distinguished name", username: "cn=alice,ou=foo,dc=example,dc=com", defaultDomain: "FOO", wantErr: true},
+		{name: "whitespace only", username: "   ", defaultDomain: "FOO", wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			domain, user, err := splitNTLMIdentity(test.username, test.defaultDomain)
+			if test.wantErr {
+				require.Error(t, err)
+
+				herr, ok := err.(*apierror.APIError)
+				require.True(t, ok, "callers map this to an operator readable API error")
+				assert.Equal(t, validation.InvalidOption, herr.Code)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.wantDomain, domain)
+			assert.Equal(t, test.wantUser, user)
+		})
+	}
 }

--- a/pkg/auth/providers/activedirectory/bind_test.go
+++ b/pkg/auth/providers/activedirectory/bind_test.go
@@ -1,6 +1,7 @@
 package activedirectory
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
@@ -320,4 +321,217 @@ func TestSplitNTLMIdentity(t *testing.T) {
 			assert.Equal(t, test.wantUser, user)
 		})
 	}
+}
+
+// testPeerCertificate returns a certificate a channel binding token can be
+// derived from.
+func testPeerCertificate() *x509.Certificate {
+	return &x509.Certificate{Raw: []byte("test-der-bytes"), SignatureAlgorithm: x509.SHA256WithRSA}
+}
+
+func tlsStateWithPeer() func() (tls.ConnectionState, bool) {
+	return func() (tls.ConnectionState, bool) {
+		return tls.ConnectionState{PeerCertificates: []*x509.Certificate{testPeerCertificate()}}, true
+	}
+}
+
+func TestBindAsSimpleMechanism(t *testing.T) {
+	t.Parallel()
+
+	var bound []v3.BasicLogin
+	conn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(username, password string) error {
+			bound = append(bound, v3.BasicLogin{Username: username, Password: password})
+			return nil
+		},
+		NTLMChallengeBindFunc: func(*ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+			t.Fatal("an NTLM bind must not happen for the simple mechanism")
+			return nil, nil
+		},
+	}
+
+	config := &v3.ActiveDirectoryConfig{DefaultLoginDomain: "FOO"}
+	provider := &adProvider{}
+
+	require.NoError(t, provider.bindAs(conn, config, nil, "alice", "secret"))
+	require.Len(t, bound, 1)
+	assert.Equal(t, v3.BasicLogin{Username: `FOO\alice`, Password: "secret"}, bound[0],
+		"the simple path keeps using GetUserExternalID verbatim")
+}
+
+func TestBindAsNTLMMechanism(t *testing.T) {
+	t.Parallel()
+
+	var request *ldapv3.NTLMBindRequest
+	conn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(string, string) error {
+			t.Fatal("a simple bind must never happen once ntlm is selected")
+			return nil
+		},
+		TLSConnectionStateFunc: tlsStateWithPeer(),
+		NTLMChallengeBindFunc: func(r *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+			request = r
+			return &ldapv3.NTLMBindResult{}, nil
+		},
+	}
+
+	config := &v3.ActiveDirectoryConfig{BindMechanism: bindMechanismNTLM, TLS: true, DefaultLoginDomain: "FOO"}
+	provider := &adProvider{}
+
+	require.NoError(t, provider.bindAs(conn, config, nil, "alice", "secret"))
+	require.NotNil(t, request)
+	assert.Equal(t, "FOO", request.Domain)
+	assert.Equal(t, "alice", request.Username)
+	assert.Equal(t, "secret", request.Password)
+	assert.Empty(t, request.Hash, "pass the hash is never exposed")
+	assert.NotNil(t, request.Negotiator)
+}
+
+func TestBindAsNTLMUsesThePreflightIdentity(t *testing.T) {
+	t.Parallel()
+
+	var request *ldapv3.NTLMBindRequest
+	conn := &ldapFakes.FakeLdapConn{
+		BindFunc:               func(string, string) error { t.Fatal("no simple bind"); return nil },
+		TLSConnectionStateFunc: tlsStateWithPeer(),
+		NTLMChallengeBindFunc: func(r *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+			request = r
+			return &ldapv3.NTLMBindResult{}, nil
+		},
+	}
+
+	config := &v3.ActiveDirectoryConfig{BindMechanism: bindMechanismNTLM, TLS: true, DefaultLoginDomain: "IGNORED"}
+	provider := &adProvider{}
+	identity := &ntlmIdentity{Domain: "BAR", Username: "bob"}
+
+	require.NoError(t, provider.bindAs(conn, config, identity, "whatever-raw-value", "secret"))
+	require.NotNil(t, request)
+	assert.Equal(t, "BAR", request.Domain)
+	assert.Equal(t, "bob", request.Username, "the resolved identity is used, the raw value is not re-parsed")
+}
+
+func TestBindAsRejects(t *testing.T) {
+	t.Parallel()
+
+	failIfBound := func(t *testing.T) *ldapFakes.FakeLdapConn {
+		t.Helper()
+		return &ldapFakes.FakeLdapConn{
+			BindFunc: func(string, string) error {
+				t.Fatal("no bind of any kind should be attempted")
+				return nil
+			},
+			NTLMChallengeBindFunc: func(*ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+				t.Fatal("no bind of any kind should be attempted")
+				return nil, nil
+			},
+		}
+	}
+
+	t.Run("unknown mechanism", func(t *testing.T) {
+		t.Parallel()
+
+		provider := &adProvider{}
+		config := &v3.ActiveDirectoryConfig{BindMechanism: "gssapi", TLS: true}
+		require.Error(t, provider.bindAs(failIfBound(t), config, nil, "alice", "secret"))
+	})
+
+	t.Run("ntlm over plaintext", func(t *testing.T) {
+		t.Parallel()
+
+		provider := &adProvider{}
+		config := &v3.ActiveDirectoryConfig{BindMechanism: bindMechanismNTLM}
+		require.Error(t, provider.bindAs(failIfBound(t), config, nil, "alice", "secret"))
+	})
+
+	t.Run("no tls connection state", func(t *testing.T) {
+		t.Parallel()
+
+		conn := &ldapFakes.FakeLdapConn{
+			BindFunc: func(string, string) error { t.Fatal("no simple bind fallback"); return nil },
+			TLSConnectionStateFunc: func() (tls.ConnectionState, bool) {
+				return tls.ConnectionState{}, false
+			},
+			NTLMChallengeBindFunc: func(*ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+				t.Fatal("an unbound NTLM bind must not be attempted")
+				return nil, nil
+			},
+		}
+		provider := &adProvider{}
+		config := &v3.ActiveDirectoryConfig{BindMechanism: bindMechanismNTLM, TLS: true}
+		require.Error(t, provider.bindAs(conn, config, nil, "alice", "secret"))
+	})
+
+	t.Run("no peer certificate", func(t *testing.T) {
+		t.Parallel()
+
+		conn := &ldapFakes.FakeLdapConn{
+			BindFunc: func(string, string) error { t.Fatal("no simple bind fallback"); return nil },
+			TLSConnectionStateFunc: func() (tls.ConnectionState, bool) {
+				return tls.ConnectionState{}, true
+			},
+			NTLMChallengeBindFunc: func(*ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+				t.Fatal("an unbound NTLM bind must not be attempted")
+				return nil, nil
+			},
+		}
+		provider := &adProvider{}
+		config := &v3.ActiveDirectoryConfig{BindMechanism: bindMechanismNTLM, TLS: true}
+		require.Error(t, provider.bindAs(conn, config, nil, "alice", "secret"))
+	})
+
+	t.Run("connection cannot do an ntlm challenge bind", func(t *testing.T) {
+		t.Parallel()
+
+		provider := &adProvider{}
+		config := &v3.ActiveDirectoryConfig{BindMechanism: bindMechanismNTLM, TLS: true, DefaultLoginDomain: "FOO"}
+
+		conn := &nonNTLMConn{Client: failIfBound(t)}
+		require.Error(t, provider.bindAs(conn, config, nil, "alice", "secret"))
+	})
+
+	t.Run("upn is rejected before any bind", func(t *testing.T) {
+		t.Parallel()
+
+		provider := &adProvider{}
+		config := &v3.ActiveDirectoryConfig{BindMechanism: bindMechanismNTLM, TLS: true}
+		conn := failIfBound(t)
+		conn.TLSConnectionStateFunc = tlsStateWithPeer()
+
+		require.Error(t, provider.bindAs(conn, config, nil, "alice@example.com", "secret"))
+	})
+}
+
+// nonNTLMConn stands in for a connection that cannot carry an NTLM bind.
+// Embedding the ldapv3.Client interface rather than the fake struct promotes
+// only the interface's methods, and NTLMChallengeBind is not one of them, so
+// the value satisfies ldapv3.Client but fails the ntlmChallengeBinder
+// assertion.
+type nonNTLMConn struct {
+	ldapv3.Client
+}
+
+var (
+	_ ldapv3.Client = &nonNTLMConn{}
+	_ ldapv3.Client = &ldapFakes.FakeLdapConn{}
+)
+
+func TestBindServiceAccountRequiresAPassword(t *testing.T) {
+	t.Parallel()
+
+	provider := &adProvider{}
+	config := &v3.ActiveDirectoryConfig{ServiceAccountUsername: `FOO\sa`}
+
+	conn := &ldapFakes.FakeLdapConn{
+		BindFunc: func(string, string) error {
+			t.Fatal("an empty service account password must not reach a bind")
+			return nil
+		},
+	}
+
+	err := provider.bindServiceAccount(conn, config)
+	require.Error(t, err)
+
+	herr, ok := err.(*apierror.APIError)
+	require.True(t, ok)
+	assert.Equal(t, validation.MissingRequired, herr.Code)
 }

--- a/pkg/auth/providers/activedirectory/errors.go
+++ b/pkg/auth/providers/activedirectory/errors.go
@@ -1,0 +1,144 @@
+package activedirectory
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+)
+
+// AD encodes two independent status fields in the diagnostic message of an
+// invalidCredentials result, and they are not the same value:
+//
+//	80090346: LdapErr: DSID-0C09059A, comment: AcceptSecurityContext error, data 80090346, v4563
+//	80090308: LdapErr: DSID-0C09089F, comment: AcceptSecurityContext error, data 57, v4563
+//
+// Both were captured from a live domain controller. The leading field is the
+// SSPI security status; the `data` token is AD's own sub-status. In the first
+// they coincide, in the second they do not — which is why parsing only one of
+// them cannot classify both.
+var (
+	securityStatusPattern = regexp.MustCompile(`(?i)^\s*([0-9a-f]{8}):`)
+	dataStatusPattern     = regexp.MustCompile(`(?i)\bdata\s+([0-9a-f]{1,8})\s*(?:,|$)`)
+)
+
+const (
+	// dataBadBindings is SEC_E_BAD_BINDINGS as AD reports it in the data
+	// token: the bind carried no channel binding token, or one that did not
+	// match the TLS channel it arrived on.
+	dataBadBindings = "80090346"
+
+	// dataInvalidParameter is ERROR_INVALID_PARAMETER. Paired with a
+	// SEC_E_INVALID_TOKEN security status it means the AUTHENTICATE message
+	// was refused as malformed, without the binding being evaluated.
+	dataInvalidParameter = "57"
+
+	// secInvalidToken is SEC_E_INVALID_TOKEN. It is NOT sufficient on its own:
+	// AD also reports it for ordinary credential failures such as data 52e
+	// (wrong password) and data 533 (account disabled). Only the pair
+	// identifies a malformed message.
+	secInvalidToken = "80090308"
+)
+
+// adDiagnostic holds the two status fields parsed out of an AD diagnostic.
+// Either may be absent.
+type adDiagnostic struct {
+	SecurityStatus string
+	Data           string
+}
+
+// parseADDiagnostic extracts both status fields from an LDAP error.
+func parseADDiagnostic(err error) (adDiagnostic, bool) {
+	var ldapErr *ldapv3.Error
+	if !errors.As(err, &ldapErr) {
+		return adDiagnostic{}, false
+	}
+
+	// ldapv3.Error.Error() prefixes its own text, so match against the
+	// underlying diagnostic where the security status is still leading.
+	diagnostic := ldapErr.Error()
+	if ldapErr.Err != nil {
+		diagnostic = ldapErr.Err.Error()
+	}
+
+	var out adDiagnostic
+	if m := securityStatusPattern.FindStringSubmatch(diagnostic); m != nil {
+		out.SecurityStatus = strings.ToLower(m[1])
+	}
+	if m := dataStatusPattern.FindStringSubmatch(diagnostic); m != nil {
+		out.Data = strings.ToLower(m[1])
+	}
+	return out, out.SecurityStatus != "" || out.Data != ""
+}
+
+// bindFailureKind classifies a bind failure that is not a credential problem.
+type bindFailureKind int
+
+const (
+	bindFailureNone bindFailureKind = iota
+	bindFailureBadBindings
+	bindFailureMalformedToken
+)
+
+// classifyBindFailure reports whether a bind error is one of the two
+// non-credential failures this feature can produce.
+//
+// Both arrive as LDAP result code 49, indistinguishable from a wrong password
+// unless the diagnostic is parsed. Every branch that treats code 49 as a
+// credential problem — the Unauthorized mapping, and the config.Enabled
+// password-rotation fallbacks — must consult this first.
+func classifyBindFailure(err error) bindFailureKind {
+	d, ok := parseADDiagnostic(err)
+	if !ok {
+		return bindFailureNone
+	}
+
+	switch {
+	case d.Data == dataBadBindings:
+		// Data alone, deliberately. An eight-hex SEC_E_* value in the data
+		// field is self-identifying — AD uses short sub-statuses (52e, 533,
+		// 57) for everything else — so the security status adds no
+		// discrimination here, and requiring it would break against any DC
+		// version reporting this sub-status under a different leading value.
+		// The malformed-token case below is the opposite: two digits, no such
+		// guarantee, so it needs both fields.
+		return bindFailureBadBindings
+	case d.Data == dataInvalidParameter && d.SecurityStatus == secInvalidToken:
+		return bindFailureMalformedToken
+	default:
+		// Everything else, including data 52e and the rest of the AD
+		// credential sub-statuses, keeps its existing handling.
+		return bindFailureNone
+	}
+}
+
+// mapBindError turns a non-credential bind failure into a message an operator
+// can act on, and leaves every other error exactly as it was so existing
+// lockout and invalid-credential handling is unaffected.
+func mapBindError(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	switch classifyBindFailure(err) {
+	case bindFailureBadBindings:
+		// A bad-bindings result on a TLS channel Rancher already verified most
+		// often means the channel is being terminated somewhere in between.
+		return fmt.Errorf("the domain controller rejected the channel binding token (%s, SEC_E_BAD_BINDINGS). "+
+			"Likely causes, in order: the bind carried no channel binding token or a malformed one; "+
+			"the token was derived with the wrong certificate hash algorithm; "+
+			"or a proxy or appliance is terminating and re-originating TLS between Rancher and the domain controller: %w",
+			dataBadBindings, err)
+
+	case bindFailureMalformedToken:
+		return fmt.Errorf("the domain controller rejected the NTLM token as malformed "+
+			"(SEC_E_INVALID_TOKEN %s, data %s). This indicates a defect in how Rancher builds the "+
+			"authenticate message — not a credential, certificate or configuration problem: %w",
+			secInvalidToken, dataInvalidParameter, err)
+
+	default:
+		return err
+	}
+}

--- a/pkg/auth/providers/activedirectory/errors.go
+++ b/pkg/auth/providers/activedirectory/errors.go
@@ -56,12 +56,14 @@ func parseADDiagnostic(err error) (adDiagnostic, bool) {
 		return adDiagnostic{}, false
 	}
 
-	// ldapv3.Error.Error() prefixes its own text, so match against the
-	// underlying diagnostic where the security status is still leading.
-	diagnostic := ldapErr.Error()
-	if ldapErr.Err != nil {
-		diagnostic = ldapErr.Err.Error()
+	// Match against the underlying diagnostic, where the security status is
+	// still leading: ldapv3.Error.Error() prefixes its own text, and it also
+	// renders through Err unconditionally, so with a nil Err there is both
+	// nothing to parse and nothing safe to call.
+	if ldapErr.Err == nil {
+		return adDiagnostic{}, false
 	}
+	diagnostic := ldapErr.Err.Error()
 
 	var out adDiagnostic
 	if m := securityStatusPattern.FindStringSubmatch(diagnostic); m != nil {

--- a/pkg/auth/providers/activedirectory/errors.go
+++ b/pkg/auth/providers/activedirectory/errors.go
@@ -126,8 +126,6 @@ func mapBindError(err error) error {
 
 	switch classifyBindFailure(err) {
 	case bindFailureBadBindings:
-		// A bad-bindings result on a TLS channel Rancher already verified most
-		// often means the channel is being terminated somewhere in between.
 		return fmt.Errorf("the domain controller rejected the channel binding token (%s, SEC_E_BAD_BINDINGS). "+
 			"Likely causes, in order: the bind carried no channel binding token or a malformed one; "+
 			"the token was derived with the wrong certificate hash algorithm; "+

--- a/pkg/auth/providers/activedirectory/errors_test.go
+++ b/pkg/auth/providers/activedirectory/errors_test.go
@@ -63,6 +63,12 @@ func TestParseADDiagnostic(t *testing.T) {
 			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, "the data was rejected"),
 		},
 		{name: "not an ldap error", err: errors.New("connection refused")},
+		{
+			// go-ldap's Error() renders through Err, so a nil Err must be
+			// rejected before anything calls it.
+			name: "ldap error with no underlying error",
+			err:  &ldapv3.Error{ResultCode: ldapv3.LDAPResultInvalidCredentials},
+		},
 		{name: "nil", err: nil},
 	}
 

--- a/pkg/auth/providers/activedirectory/errors_test.go
+++ b/pkg/auth/providers/activedirectory/errors_test.go
@@ -1,0 +1,184 @@
+package activedirectory
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ldapError builds the error shape go-ldap returns for a failed bind. The
+// diagnostic text lives in Err; Error() renders it as
+// `LDAP Result Code 49 "Invalid Credentials": <diagnostic>`.
+func ldapError(code uint16, diagnostic string) error {
+	return &ldapv3.Error{ResultCode: code, Err: errors.New(diagnostic)}
+}
+
+// The two diagnostics below are verbatim captures from a live domain
+// controller on 2026-08-26. Synthetic strings are what let the previous
+// revision ship an unreachable mapping: it tested `data 80090308`, a shape AD
+// never emits, while the real message carries `data 57`.
+const (
+	capturedBadBindings = "80090346: LdapErr: DSID-0C09059A, comment: AcceptSecurityContext error, data 80090346, v4563"
+	capturedBadToken    = "80090308: LdapErr: DSID-0C09089F, comment: AcceptSecurityContext error, data 57, v4563"
+	// Not captured here, but the shape AD uses for a wrong password. It shares
+	// its security status with capturedBadToken, which is why the pair matters.
+	typicalWrongPassword = "80090308: LdapErr: DSID-0C0903A9, comment: AcceptSecurityContext error, data 52e, v4563"
+)
+
+func TestParseADDiagnostic(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        error
+		wantSec    string
+		wantData   string
+		wantParsed bool
+	}{
+		{
+			name:    "bad bindings, both fields the same",
+			err:     ldapError(ldapv3.LDAPResultInvalidCredentials, capturedBadBindings),
+			wantSec: "80090346", wantData: "80090346", wantParsed: true,
+		},
+		{
+			name:    "malformed token, fields differ",
+			err:     ldapError(ldapv3.LDAPResultInvalidCredentials, capturedBadToken),
+			wantSec: "80090308", wantData: "57", wantParsed: true,
+		},
+		{
+			name:    "wrong password shares the security status",
+			err:     ldapError(ldapv3.LDAPResultInvalidCredentials, typicalWrongPassword),
+			wantSec: "80090308", wantData: "52e", wantParsed: true,
+		},
+		{
+			name: "no diagnostic fields",
+			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, "invalid credentials"),
+		},
+		{
+			name: "the word data without a hex value",
+			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, "the data was rejected"),
+		},
+		{name: "not an ldap error", err: errors.New("connection refused")},
+		{name: "nil", err: nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := parseADDiagnostic(test.err)
+			assert.Equal(t, test.wantParsed, ok)
+			assert.Equal(t, test.wantSec, got.SecurityStatus)
+			assert.Equal(t, test.wantData, got.Data)
+		})
+	}
+}
+
+func TestClassifyBindFailure(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bindFailureKind
+	}{
+		{
+			name: "bad bindings",
+			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, capturedBadBindings),
+			want: bindFailureBadBindings,
+		},
+		{
+			name: "malformed token",
+			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, capturedBadToken),
+			want: bindFailureMalformedToken,
+		},
+		{
+			// The security status alone would misclassify this as malformed,
+			// reporting a wrong password as a Rancher defect.
+			name: "wrong password is not a construction failure",
+			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, typicalWrongPassword),
+			want: bindFailureNone,
+		},
+		{
+			name: "data 57 without the matching security status",
+			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, "8009030c: LdapErr: comment: AcceptSecurityContext error, data 57, v4563"),
+			want: bindFailureNone,
+		},
+		{
+			// The asymmetry, pinned: bad bindings is keyed on the data value
+			// alone, so a different leading status must not change the result.
+			name: "bad bindings under a different security status still classifies",
+			err:  ldapError(ldapv3.LDAPResultInvalidCredentials, "8009030c: LdapErr: comment: AcceptSecurityContext error, data 80090346, v4563"),
+			want: bindFailureBadBindings,
+		},
+		{name: "plain error", err: errors.New("dial tcp: connection refused"), want: bindFailureNone},
+		{name: "nil", err: nil, want: bindFailureNone},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, test.want, classifyBindFailure(test.err))
+		})
+	}
+}
+
+func TestMapBindError(t *testing.T) {
+	t.Parallel()
+
+	t.Run("bad bindings explains the likely causes", func(t *testing.T) {
+		t.Parallel()
+
+		in := ldapError(ldapv3.LDAPResultInvalidCredentials, capturedBadBindings)
+
+		got := mapBindError(in)
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "channel binding")
+		assert.Contains(t, got.Error(), "80090346")
+		assert.Contains(t, got.Error(), "proxy")
+		assert.NotContains(t, got.Error(), "server name",
+			"TLS verification already checks the certificate name, so suggesting it misdirects the operator")
+		assert.ErrorIs(t, got, in)
+	})
+
+	t.Run("malformed token is named as a Rancher defect", func(t *testing.T) {
+		t.Parallel()
+
+		in := ldapError(ldapv3.LDAPResultInvalidCredentials, capturedBadToken)
+
+		got := mapBindError(in)
+		require.Error(t, got)
+		assert.Contains(t, got.Error(), "malformed")
+		assert.Contains(t, got.Error(), "80090308")
+		assert.NotContains(t, got.Error(), "channel binding token",
+			"a malformed message is not a channel binding rejection and must not read as one")
+		assert.ErrorIs(t, got, in)
+	})
+
+	t.Run("wrong password is untouched", func(t *testing.T) {
+		t.Parallel()
+
+		in := ldapError(ldapv3.LDAPResultInvalidCredentials, typicalWrongPassword)
+
+		assert.Equal(t, in, mapBindError(in), "lockout and negative authentication behaviour is unchanged")
+		assert.True(t, ldapv3.IsErrorWithCode(mapBindError(in), ldapv3.LDAPResultInvalidCredentials))
+	})
+
+	t.Run("non ldap errors pass through", func(t *testing.T) {
+		t.Parallel()
+
+		in := fmt.Errorf("dial tcp: connection refused")
+		assert.Equal(t, in, mapBindError(in))
+	})
+
+	t.Run("nil stays nil", func(t *testing.T) {
+		t.Parallel()
+
+		assert.NoError(t, mapBindError(nil))
+	})
+}

--- a/pkg/auth/providers/common/ldap/fakes.go
+++ b/pkg/auth/providers/common/ldap/fakes.go
@@ -9,25 +9,42 @@ import (
 )
 
 type FakeLdapConn struct {
-	BindFunc             func(username, password string) error
-	SearchFunc           func(searchRequest *ldapv3.SearchRequest) (*ldapv3.SearchResult, error)
-	SearchWithPagingFunc func(searchRequest *ldapv3.SearchRequest, pagingSize uint32) (*ldapv3.SearchResult, error)
+	BindFunc               func(username, password string) error
+	SearchFunc             func(searchRequest *ldapv3.SearchRequest) (*ldapv3.SearchResult, error)
+	SearchWithPagingFunc   func(searchRequest *ldapv3.SearchRequest, pagingSize uint32) (*ldapv3.SearchResult, error)
+	NTLMChallengeBindFunc  func(request *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error)
+	TLSConnectionStateFunc func() (tls.ConnectionState, bool)
+	CloseFunc              func() error
 }
 
 func (m *FakeLdapConn) Start()                     { panic("unimplemented") }
 func (m *FakeLdapConn) StartTLS(*tls.Config) error { panic("unimplemented") }
-func (m *FakeLdapConn) Close() error               { panic("unimplemented") }
-func (m *FakeLdapConn) GetLastError() error        { panic("unimplemented") }
-func (m *FakeLdapConn) IsClosing() bool            { panic("unimplemented") }
-func (m *FakeLdapConn) SetTimeout(time.Duration)   { panic("unimplemented") }
+func (m *FakeLdapConn) Close() error {
+	if m.CloseFunc != nil {
+		return m.CloseFunc()
+	}
+	return nil
+}
+func (m *FakeLdapConn) GetLastError() error      { panic("unimplemented") }
+func (m *FakeLdapConn) IsClosing() bool          { panic("unimplemented") }
+func (m *FakeLdapConn) SetTimeout(time.Duration) { panic("unimplemented") }
 func (m *FakeLdapConn) TLSConnectionState() (tls.ConnectionState, bool) {
-	panic("unimplemented")
+	if m.TLSConnectionStateFunc != nil {
+		return m.TLSConnectionStateFunc()
+	}
+	return tls.ConnectionState{}, false
 }
 func (m *FakeLdapConn) Bind(username, password string) error {
 	if m.BindFunc != nil {
 		return m.BindFunc(username, password)
 	}
 	return nil
+}
+func (m *FakeLdapConn) NTLMChallengeBind(request *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
+	if m.NTLMChallengeBindFunc != nil {
+		return m.NTLMChallengeBindFunc(request)
+	}
+	return &ldapv3.NTLMBindResult{}, nil
 }
 func (m *FakeLdapConn) UnauthenticatedBind(username string) error { panic("unimplemented") }
 func (m *FakeLdapConn) NTLMUnauthenticatedBind(domain, username string) error {

--- a/pkg/auth/providers/common/ldap/fakes.go
+++ b/pkg/auth/providers/common/ldap/fakes.go
@@ -40,6 +40,9 @@ func (m *FakeLdapConn) Bind(username, password string) error {
 	}
 	return nil
 }
+
+// NTLMChallengeBind defaults to success rather than panicking, matching Bind,
+// so tests exercising paths after a bind need not stub it.
 func (m *FakeLdapConn) NTLMChallengeBind(request *ldapv3.NTLMBindRequest) (*ldapv3.NTLMBindResult, error) {
 	if m.NTLMChallengeBindFunc != nil {
 		return m.NTLMChallengeBindFunc(request)

--- a/pkg/auth/providers/common/ldap/ntlm/authenticate.go
+++ b/pkg/auth/providers/common/ldap/ntlm/authenticate.go
@@ -1,0 +1,183 @@
+package ntlm
+
+import (
+	"crypto/hmac"
+	"crypto/md5" // #nosec G501 -- HMAC-MD5 is mandated by MS-NLMP for NTLMv2.
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// clientChallengeHeaderSize is the fixed part of NTLMv2_CLIENT_CHALLENGE
+// preceding the AV pairs: response type, reserved fields, timestamp and the
+// client nonce.
+const clientChallengeHeaderSize = 28
+
+// responseKeyNT computes NTOWFv2: HMAC-MD5 of the uppercased user name
+// concatenated with the domain, keyed by the NT hash. Only the user name is
+// uppercased; MS-NLMP uses the domain verbatim.
+func responseKeyNT(ntHash []byte, user, domain string) []byte {
+	mac := hmac.New(md5.New, ntHash)
+	mac.Write(utf16LE(strings.ToUpper(user) + domain))
+	return mac.Sum(nil)
+}
+
+func hmacMD5(key []byte, parts ...[]byte) []byte {
+	mac := hmac.New(md5.New, key)
+	for _, p := range parts {
+		mac.Write(p)
+	}
+	return mac.Sum(nil)
+}
+
+// authenticateInput is everything buildAuthenticate needs. ClientNonce and Now
+// are parameters rather than generated internally so the output is
+// deterministic and testable against fixed vectors.
+type authenticateInput struct {
+	NTHash      []byte
+	User        string
+	Domain      string
+	Challenge   *challenge
+	CBT         [16]byte
+	ClientNonce [8]byte
+	Now         time.Time
+	Layout      layout
+}
+
+// buildAuthenticate returns the AUTHENTICATE_MESSAGE and the exported session
+// key. When in.Layout.mic is set the MIC field is present and zeroed; the caller
+// computes and patches it, because the MIC covers this message's own bytes.
+func buildAuthenticate(in authenticateInput) ([]byte, []byte, error) {
+	if in.Challenge == nil {
+		return nil, nil, fmt.Errorf("ntlm: no challenge to respond to")
+	}
+
+	// Resolved here as well as in ChallengeResponse. Both derive it from the
+	// same two inputs, so they cannot disagree, and validating here means a
+	// direct caller cannot produce a message whose header contradicts its own
+	// flag word.
+	activeLayout, err := effectiveLayout(in.Layout, in.Challenge.Flags)
+	if err != nil {
+		return nil, nil, err
+	}
+	in.Layout = activeLayout
+
+	serverPairs, err := parseTargetInfo(in.Challenge.TargetInfo)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	targetInfo, err := transformTargetInfo(serverPairs, in.CBT, in.Layout.mic)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// MS-NLMP 3.1.5.1.2: when the server supplied a timestamp the client
+	// echoes it and sends no LM response. Otherwise it stamps its own clock
+	// and computes an LMv2 response. The branch is decided by what the server
+	// sent, not by the client challenge, which always carries a timestamp.
+	timestamp := make([]byte, 8)
+	serverTimestamp, hasServerTimestamp := findAVPair(serverPairs, avTimestamp)
+	if hasServerTimestamp {
+		if len(serverTimestamp) != 8 {
+			return nil, nil, fmt.Errorf("ntlm: MsvAvTimestamp has %d bytes, expected 8", len(serverTimestamp))
+		}
+		copy(timestamp, serverTimestamp)
+	} else {
+		binary.LittleEndian.PutUint64(timestamp, fileTime(in.Now))
+	}
+
+	// NTLMv2_CLIENT_CHALLENGE, MS-NLMP 2.2.2.7.
+	temp := make([]byte, 0, clientChallengeHeaderSize+len(targetInfo)+4)
+	temp = append(temp, 0x01, 0x01)             // RespType, HiRespType
+	temp = append(temp, 0x00, 0x00)             // Reserved1
+	temp = append(temp, 0x00, 0x00, 0x00, 0x00) // Reserved2
+	temp = append(temp, timestamp...)
+	temp = append(temp, in.ClientNonce[:]...)
+	temp = append(temp, 0x00, 0x00, 0x00, 0x00) // Reserved3
+	temp = append(temp, targetInfo...)
+	temp = append(temp, 0x00, 0x00, 0x00, 0x00) // Reserved4
+
+	keyNT := responseKeyNT(in.NTHash, in.User, in.Domain)
+	ntProofStr := hmacMD5(keyNT, in.Challenge.ServerChallenge[:], temp)
+
+	ntResponse := make([]byte, 0, len(ntProofStr)+len(temp))
+	ntResponse = append(ntResponse, ntProofStr...)
+	ntResponse = append(ntResponse, temp...)
+
+	lmResponse := make([]byte, 24)
+	if !hasServerTimestamp {
+		// ResponseKeyLM equals ResponseKeyNT for NTLMv2.
+		proof := hmacMD5(keyNT, in.Challenge.ServerChallenge[:], in.ClientNonce[:])
+		copy(lmResponse[0:16], proof)
+		copy(lmResponse[16:24], in.ClientNonce[:])
+	}
+
+	// No key exchange is negotiated, so the exported session key is the
+	// session base key and no encrypted session key is sent.
+	sessionKey := hmacMD5(keyNT, ntProofStr)
+
+	domain := utf16LE(in.Domain)
+	user := utf16LE(in.User)
+
+	headerSize := in.Layout.authenticateHeaderSize()
+	msg := make([]byte, headerSize)
+	copy(msg[0:8], ntlmSignature)
+	binary.LittleEndian.PutUint32(msg[8:12], messageTypeAuthenticate)
+
+	offset := headerSize
+	var payloadErr error
+	appendPayload := func(at int, name string, payload []byte) {
+		if payloadErr != nil {
+			return
+		}
+		if err := putVarField(msg[at:at+8], len(payload), offset, name); err != nil {
+			payloadErr = err
+			return
+		}
+		msg = append(msg, payload...)
+		offset += len(payload)
+	}
+	appendPayload(12, "LM response", lmResponse)
+	appendPayload(20, "NT response", ntResponse)
+	appendPayload(28, "domain", domain)
+	appendPayload(36, "user", user)
+	appendPayload(44, "workstation", nil) // go-ldap always binds with an empty one.
+	appendPayload(52, "session key", nil) // Unused without key exchange.
+	if payloadErr != nil {
+		return nil, nil, payloadErr
+	}
+
+	binary.LittleEndian.PutUint32(msg[60:64], authenticateFlags(in.Layout, in.Challenge.Flags))
+	if in.Layout.version {
+		copy(msg[64:72], versionStructure[:])
+	}
+	// When in.Layout.mic is set, the 16 bytes at in.Layout.micOffset() are the
+	// MIC field, left zeroed here for patchMIC to fill.
+
+	return msg, sessionKey, nil
+}
+
+// patchMIC computes the message integrity code over the three exchanged
+// messages and writes it into the AUTHENTICATE message in place.
+//
+// The MIC covers the AUTHENTICATE message including its own field, so that
+// field must be present and zeroed when the HMAC is taken and only then
+// overwritten. authenticate must be the exact bytes returned by
+// buildAuthenticate with WithMIC set.
+func patchMIC(l layout, authenticate, negotiate, challengeBytes, sessionKey []byte) error {
+	if !l.mic {
+		return nil
+	}
+
+	headerSize := l.authenticateHeaderSize()
+	if len(authenticate) < headerSize {
+		return fmt.Errorf("ntlm: authenticate message of %d bytes is shorter than the %d byte header", len(authenticate), headerSize)
+	}
+
+	at := l.micOffset()
+	mic := hmacMD5(sessionKey, negotiate, challengeBytes, authenticate)
+	copy(authenticate[at:at+16], mic)
+	return nil
+}

--- a/pkg/auth/providers/common/ldap/ntlm/authenticate_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/authenticate_test.go
@@ -1,0 +1,403 @@
+package ntlm
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MS-NLMP 4.2.4 NTLMv2 test values. Every constant below is published in the
+// specification and was independently reproduced before this plan was written;
+// none is a value this implementation generated. If a test using them fails,
+// the implementation is wrong, not the constant.
+const (
+	specUser     = "User"
+	specDomain   = "Domain"
+	specPassword = "Password"
+
+	// NTOWFv1 — MD4(UTF16LE("Password")). MS-NLMP 4.2.4.1.1.
+	specNTHash = "a4f49c406510bdcab6824ee7c30fd852"
+	// NTOWFv2 — HMAC-MD5(NTOWFv1, UTF16LE("USER" + "Domain")). 4.2.4.1.1.
+	specResponseKeyNT = "0c868a403bfd7a93a3001ef22ef02e3f"
+	// SessionBaseKey — HMAC-MD5(NTOWFv2, NTProofStr). 4.2.4.1.2.
+	specSessionBaseKey = "8de40ccadbc14a82f15cb0ad0de95ca3"
+	// LMv2Response for the 4.2.4 inputs. 4.2.4.2.1.
+	specLMv2Response = "86c35097ac9cec102554764a57cccc19aaaaaaaaaaaaaaaa"
+	// NTProofStr, the first 16 bytes of NtChallengeResponse. 4.2.4.2.2.
+	specNTProofStr = "68cd0ab851e51c96aabc927bebef6a1c"
+)
+
+// The 4.2.4 fixtures: server challenge, client challenge, and the TargetInfo
+// carrying NbDomainName "Domain" and NbComputerName "Server".
+var (
+	specServerChallenge = [8]byte{0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef}
+	specClientChallenge = [8]byte{0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa, 0xaa}
+)
+
+// specTargetInfo is the 4.2.4 server TargetInfo, hex
+// 02000c0044006f006d00610069006e0001000c00530065007200760065007200 0000 0000.
+func specTargetInfo() []byte {
+	return eolTerminated(
+		avPair{ID: avNbDomainName, Value: utf16LE("Domain")},
+		avPair{ID: avNbComputerName, Value: utf16LE("Server")},
+	)
+}
+
+func mustDecodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+func TestResponseKeyNTMatchesSpecVector(t *testing.T) {
+	t.Parallel()
+
+	got := responseKeyNT(mustDecodeHex(t, specNTHash), specUser, specDomain)
+	assert.Equal(t, mustDecodeHex(t, specResponseKeyNT), got)
+}
+
+func TestResponseKeyNTUppercasesOnlyTheUser(t *testing.T) {
+	t.Parallel()
+
+	hash := mustDecodeHex(t, specNTHash)
+
+	assert.Equal(t,
+		responseKeyNT(hash, "user", specDomain),
+		responseKeyNT(hash, "USER", specDomain),
+		"the user name is uppercased")
+	assert.NotEqual(t,
+		responseKeyNT(hash, specUser, "domain"),
+		responseKeyNT(hash, specUser, "DOMAIN"),
+		"the domain is used verbatim")
+}
+
+func TestResponseKeyNTDependsOnDomain(t *testing.T) {
+	t.Parallel()
+
+	hash := mustDecodeHex(t, specNTHash)
+	assert.NotEqual(t, responseKeyNT(hash, specUser, "A"), responseKeyNT(hash, specUser, "B"))
+}
+
+// TestSpecVectorChain reproduces the full MS-NLMP 4.2.4 derivation against the
+// published constants. It is the independent oracle for the response key, the
+// client challenge framing, the NT proof and the session key: every value is
+// from the specification, so a passing run means the formulas are right rather
+// than merely self-consistent.
+//
+// The 4.2.4 fixtures predate channel binding, so the TargetInfo is passed
+// through untransformed and the timestamp is zero. Layout variation and the
+// CBT are covered separately.
+func TestSpecVectorChain(t *testing.T) {
+	t.Parallel()
+
+	keyNT := responseKeyNT(mustDecodeHex(t, specNTHash), specUser, specDomain)
+	require.Equal(t, mustDecodeHex(t, specResponseKeyNT), keyNT)
+
+	lmv2 := append(
+		hmacMD5(keyNT, specServerChallenge[:], specClientChallenge[:]),
+		specClientChallenge[:]...,
+	)
+	assert.Equal(t, mustDecodeHex(t, specLMv2Response), lmv2, "LMv2 response, 4.2.4.2.1")
+
+	temp := []byte{0x01, 0x01, 0, 0, 0, 0, 0, 0}
+	temp = append(temp, make([]byte, 8)...) // Timestamp is zero in 4.2.4.
+	temp = append(temp, specClientChallenge[:]...)
+	temp = append(temp, 0, 0, 0, 0)
+	temp = append(temp, specTargetInfo()...)
+	temp = append(temp, 0, 0, 0, 0)
+
+	proof := hmacMD5(keyNT, specServerChallenge[:], temp)
+	assert.Equal(t, mustDecodeHex(t, specNTProofStr), proof, "NTProofStr, 4.2.4.2.2")
+	assert.Equal(t, mustDecodeHex(t, specSessionBaseKey), hmacMD5(keyNT, proof), "SessionBaseKey, 4.2.4.1.2")
+}
+
+func testAuthenticateInput(t *testing.T, serverTargetInfo []byte) authenticateInput {
+	t.Helper()
+
+	return authenticateInput{
+		NTHash:      mustDecodeHex(t, specNTHash),
+		User:        specUser,
+		Domain:      specDomain,
+		Challenge:   &challenge{ServerChallenge: [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, Flags: testChallengeFlags(), TargetInfo: serverTargetInfo},
+		CBT:         [16]byte{0xAA},
+		ClientNonce: [8]byte{0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA},
+		Now:         time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC),
+		Layout:      layout{version: true, mic: true},
+	}
+}
+
+func TestBuildAuthenticateLayout(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, eolTerminated())
+	msg, sessionKey, err := buildAuthenticate(in)
+	require.NoError(t, err)
+	require.Len(t, sessionKey, 16)
+	require.GreaterOrEqual(t, len(msg), in.Layout.authenticateHeaderSize())
+
+	assert.Equal(t, ntlmSignature, string(msg[0:8]))
+	assert.Equal(t, uint32(messageTypeAuthenticate), binary.LittleEndian.Uint32(msg[8:12]))
+	assert.Equal(t, authenticateFlags(in.Layout, in.Challenge.Flags), binary.LittleEndian.Uint32(msg[60:64]))
+	assert.Equal(t, versionStructure[:], msg[64:72])
+
+	// Every payload offset lands at or after the header, so the MIC field is
+	// never overwritten by payload bytes.
+	for name, at := range map[string]int{
+		"lm response": 12, "nt response": 20, "domain": 28,
+		"user": 36, "workstation": 44, "session key": 52,
+	} {
+		offset := binary.LittleEndian.Uint32(msg[at+4 : at+8])
+		assert.GreaterOrEqualf(t, int(offset), in.Layout.authenticateHeaderSize(), "%s offset", name)
+	}
+
+	domain, err := readVarField(msg, 28, "domain")
+	require.NoError(t, err)
+	assert.Equal(t, utf16LE(specDomain), domain)
+
+	user, err := readVarField(msg, 36, "user")
+	require.NoError(t, err)
+	assert.Equal(t, utf16LE(specUser), user, "the user name is sent verbatim, only the response key uppercases it")
+
+	workstation, err := readVarField(msg, 44, "workstation")
+	require.NoError(t, err)
+	assert.Empty(t, workstation)
+
+	sessionKeyField, err := readVarField(msg, 52, "session key")
+	require.NoError(t, err)
+	assert.Empty(t, sessionKeyField, "no key exchange, so no encrypted session key is sent")
+}
+
+func TestMICOffsetConstant(t *testing.T) {
+	t.Parallel()
+
+	// The AUTHENTICATE header is positional. Version occupies 64..71 and the
+	// MIC 72..87, so the payload cannot start before 88. Changing either
+	// constant relocates the MIC and silently invalidates it at the server.
+	shipping := layout{version: true, mic: true}
+	assert.Equal(t, 72, shipping.micOffset())
+	assert.Equal(t, 88, shipping.authenticateHeaderSize())
+	assert.Equal(t, shipping.micOffset()+16, shipping.authenticateHeaderSize())
+}
+
+func TestAuthenticateFlagsValue(t *testing.T) {
+	t.Parallel()
+
+	shipping := layout{version: true, mic: true}
+
+	// A challenge returning everything offered reproduces the shipping word.
+	assert.Equal(t, uint32(0x02888205), authenticateFlags(shipping, baseFlags|flagVersion))
+	assert.Zero(t, authenticateFlags(shipping, baseFlags|flagVersion)&flagKeyExch)
+	assert.Zero(t, authenticateFlags(shipping, baseFlags|flagVersion)&flagLMKey)
+
+	// A flag the server withheld is not asserted back at it. ALWAYS_SIGN is
+	// the only offered flag parseChallenge does not require, so it is the only
+	// one that can legitimately be absent here.
+	got := authenticateFlags(shipping, (baseFlags|flagVersion)&^flagAlwaysSign)
+	assert.Zero(t, got&flagAlwaysSign, "the client does not claim a capability the server withheld")
+	assert.NotZero(t, got&flagUnicode)
+}
+
+func TestBuildAuthenticateCarriesTheChannelBinding(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, eolTerminated(avPair{ID: avNbDomainName, Value: utf16LE("FOO")}))
+	msg, _, err := buildAuthenticate(in)
+	require.NoError(t, err)
+
+	ntResponse, err := readVarField(msg, 20, "nt response")
+	require.NoError(t, err)
+	require.Greater(t, len(ntResponse), 16+28)
+
+	// NtChallengeResponse is NTProofStr(16) || temp; the AV pairs start 28
+	// bytes into temp and run to the end minus the 4 trailing reserved bytes.
+	targetInfo := ntResponse[16+28 : len(ntResponse)-4]
+	pairs, err := parseTargetInfo(targetInfo)
+	require.NoError(t, err)
+
+	value, ok := findAVPair(pairs, avChannelBindings)
+	require.True(t, ok)
+	assert.Equal(t, in.CBT[:], value)
+}
+
+func TestBuildAuthenticateLMBranchServerTimestampPresent(t *testing.T) {
+	t.Parallel()
+
+	serverTimestamp := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}
+	in := testAuthenticateInput(t, eolTerminated(avPair{ID: avTimestamp, Value: serverTimestamp}))
+
+	msg, _, err := buildAuthenticate(in)
+	require.NoError(t, err)
+
+	lmResponse, err := readVarField(msg, 12, "lm response")
+	require.NoError(t, err)
+	assert.Equal(t, make([]byte, 24), lmResponse,
+		"a server supplied timestamp means the LM response is 24 zero bytes")
+
+	ntResponse, err := readVarField(msg, 20, "nt response")
+	require.NoError(t, err)
+	// temp starts at 16; its timestamp is at temp offset 8, so message offset 24.
+	assert.Equal(t, serverTimestamp, ntResponse[24:32],
+		"the server timestamp is copied into the client challenge")
+}
+
+func TestBuildAuthenticateLMBranchServerTimestampAbsent(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, eolTerminated(avPair{ID: avNbDomainName, Value: utf16LE("FOO")}))
+
+	msg, _, err := buildAuthenticate(in)
+	require.NoError(t, err)
+
+	lmResponse, err := readVarField(msg, 12, "lm response")
+	require.NoError(t, err)
+	require.Len(t, lmResponse, 24)
+	assert.NotEqual(t, make([]byte, 24), lmResponse,
+		"with no server timestamp the LMv2 response is computed")
+	assert.Equal(t, in.ClientNonce[:], lmResponse[16:24],
+		"the LMv2 response ends with the client nonce")
+
+	ntResponse, err := readVarField(msg, 20, "nt response")
+	require.NoError(t, err)
+	want := make([]byte, 8)
+	binary.LittleEndian.PutUint64(want, fileTime(in.Now))
+	assert.Equal(t, want, ntResponse[24:32], "the injected clock is used")
+}
+
+func TestBuildAuthenticateIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, eolTerminated())
+
+	first, firstKey, err := buildAuthenticate(in)
+	require.NoError(t, err)
+	second, secondKey, err := buildAuthenticate(in)
+	require.NoError(t, err)
+
+	assert.True(t, bytes.Equal(first, second), "same inputs produce the same bytes")
+	assert.Equal(t, firstKey, secondKey)
+}
+
+func TestBuildAuthenticateRejectsMalformedTargetInfo(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, []byte{0x02, 0x00, 0xFF, 0xFF})
+
+	_, _, err := buildAuthenticate(in)
+	require.Error(t, err)
+}
+
+func TestBuildAuthenticateHandlesUnicodeCredentials(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, eolTerminated())
+	in.User = "üser"
+	in.Domain = "DÖMÄNE"
+
+	msg, _, err := buildAuthenticate(in)
+	require.NoError(t, err)
+
+	user, err := readVarField(msg, 36, "user")
+	require.NoError(t, err)
+	assert.Equal(t, utf16LE("üser"), user)
+
+	domain, err := readVarField(msg, 28, "domain")
+	require.NoError(t, err)
+	assert.Equal(t, utf16LE("DÖMÄNE"), domain)
+}
+
+func TestPatchMIC(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, eolTerminated())
+	negotiate := buildNegotiate(in.Layout)
+	challengeBytes := buildTestChallenge(testChallengeFlags(), in.Challenge.ServerChallenge, in.Challenge.TargetInfo)
+
+	msg, sessionKey, err := buildAuthenticate(in)
+	require.NoError(t, err)
+	require.Equal(t, make([]byte, 16), msg[in.Layout.micOffset():in.Layout.micOffset()+16], "the MIC field starts zeroed")
+
+	// The expected MIC is HMAC-MD5 over the three messages with the MIC field
+	// still zeroed.
+	zeroed := make([]byte, len(msg))
+	copy(zeroed, msg)
+	want := hmacMD5(sessionKey, negotiate, challengeBytes, zeroed)
+
+	require.NoError(t, patchMIC(in.Layout, msg, negotiate, challengeBytes, sessionKey))
+	assert.Equal(t, want, msg[in.Layout.micOffset():in.Layout.micOffset()+16])
+
+	// Only the MIC field changed.
+	copy(zeroed[in.Layout.micOffset():in.Layout.micOffset()+16], msg[in.Layout.micOffset():in.Layout.micOffset()+16])
+	assert.Equal(t, zeroed, msg)
+}
+
+func TestPatchMICRejectsShortMessage(t *testing.T) {
+	t.Parallel()
+
+	shipping := layout{version: true, mic: true}
+	require.Error(t, patchMIC(shipping, make([]byte, shipping.authenticateHeaderSize()-1), nil, nil, make([]byte, 16)))
+}
+
+func TestPatchMICIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	in := testAuthenticateInput(t, eolTerminated())
+	negotiate := buildNegotiate(in.Layout)
+	challengeBytes := buildTestChallenge(testChallengeFlags(), in.Challenge.ServerChallenge, in.Challenge.TargetInfo)
+
+	build := func() []byte {
+		msg, key, err := buildAuthenticate(in)
+		require.NoError(t, err)
+		require.NoError(t, patchMIC(in.Layout, msg, negotiate, challengeBytes, key))
+		return msg
+	}
+
+	assert.Equal(t, build(), build())
+}
+
+func TestMICChangesWhenTheChannelBindingChanges(t *testing.T) {
+	t.Parallel()
+
+	negotiate := buildNegotiate(layout{version: true, mic: true})
+
+	build := func(cbt [16]byte) []byte {
+		in := testAuthenticateInput(t, eolTerminated())
+		in.CBT = cbt
+		challengeBytes := buildTestChallenge(testChallengeFlags(), in.Challenge.ServerChallenge, in.Challenge.TargetInfo)
+		msg, key, err := buildAuthenticate(in)
+		require.NoError(t, err)
+		require.NoError(t, patchMIC(in.Layout, msg, negotiate, challengeBytes, key))
+		return msg[in.Layout.micOffset() : in.Layout.micOffset()+16]
+	}
+
+	assert.NotEqual(t, build([16]byte{0x01}), build([16]byte{0x02}),
+		"the channel binding feeds the NT proof, the session key and therefore the MIC")
+}
+
+// The end-to-end fixture that pins a complete AUTHENTICATE message is
+// deliberately absent from this repository.
+//
+// It was captured on 2026-08-26 against Windows Server 2019 Datacenter
+// 10.0.17763 with LdapEnforceChannelBinding = 2, and this implementation
+// reproduced all 444 accepted bytes including the MIC. The capture is retained
+// outside this repository because the message body embeds the domain
+// controller's real host and domain names as UTF-16 inside the target info,
+// and the test needs the bind account's NT hash — an unsalted MD4 of its
+// password. Neither belongs in a public repository.
+//
+// The tests above therefore validate the pieces rather than the whole: the
+// derivation chain against the published MS-NLMP 4.2.4 vectors, the four header
+// layouts against a size table, the channel binding token against an
+// independently computed value, and the target info against a round trip. What
+// they cannot catch is a correct field assembled at the wrong offset.
+//
+// Restoring that coverage needs a capture from a lab domain controller with
+// disposable names and a single-use account. See the "Deviation from the spec"
+// section of the implementation plan for what the live run established, and the
+// AD lab plan for the throwaway environment that would produce a publishable
+// capture.

--- a/pkg/auth/providers/common/ldap/ntlm/authenticate_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/authenticate_test.go
@@ -12,9 +12,8 @@ import (
 )
 
 // MS-NLMP 4.2.4 NTLMv2 test values. Every constant below is published in the
-// specification and was independently reproduced before this plan was written;
-// none is a value this implementation generated. If a test using them fails,
-// the implementation is wrong, not the constant.
+// specification; none is a value this implementation generated. If a test
+// using them fails, the implementation is wrong, not the constant.
 const (
 	specUser     = "User"
 	specDomain   = "Domain"
@@ -397,7 +396,5 @@ func TestMICChangesWhenTheChannelBindingChanges(t *testing.T) {
 // they cannot catch is a correct field assembled at the wrong offset.
 //
 // Restoring that coverage needs a capture from a lab domain controller with
-// disposable names and a single-use account. See the "Deviation from the spec"
-// section of the implementation plan for what the live run established, and the
-// AD lab plan for the throwaway environment that would produce a publishable
-// capture.
+// disposable names and a single-use account, run in a throwaway environment so
+// the resulting capture is safe to publish.

--- a/pkg/auth/providers/common/ldap/ntlm/cbt.go
+++ b/pkg/auth/providers/common/ldap/ntlm/cbt.go
@@ -1,0 +1,90 @@
+// Package ntlm implements the subset of MS-NLMP (NTLMv2) needed to bind to an
+// Active Directory domain controller with an RFC 5929 tls-server-end-point
+// channel binding token. It depends only on the Go standard library.
+//
+// The MD4, MD5 and HMAC-MD5 primitives used here are mandated by MS-NLMP and
+// RFC 5929. They are protocol conformance requirements, not a cryptographic
+// choice made by Rancher.
+package ntlm
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/md5" // #nosec G501 -- MD5 is mandated by MS-NLMP for the channel binding token.
+	"crypto/x509"
+	"encoding/binary"
+	"fmt"
+
+	_ "crypto/sha256" // Register SHA-256 for crypto.Hash.New.
+	_ "crypto/sha512" // Register SHA-384 and SHA-512 for crypto.Hash.New.
+)
+
+// channelBindingPrefix is the RFC 5929 tls-server-end-point prefix that
+// precedes the certificate digest in the GSS application data.
+const channelBindingPrefix = "tls-server-end-point:"
+
+// certificateHashAlgorithm returns the digest to apply to the certificate
+// under RFC 5929 section 4.1: the hash of the certificate's own signature
+// algorithm, with MD5 and SHA-1 replaced by SHA-256. Signature algorithms
+// that do not identify exactly one hash are rejected, because guessing
+// produces an opaque SEC_E_BAD_BINDINGS at the domain controller.
+func certificateHashAlgorithm(alg x509.SignatureAlgorithm) (crypto.Hash, error) {
+	switch alg {
+	case x509.MD5WithRSA,
+		x509.SHA1WithRSA,
+		x509.DSAWithSHA1,
+		x509.ECDSAWithSHA1,
+		x509.SHA256WithRSA,
+		x509.DSAWithSHA256,
+		x509.ECDSAWithSHA256,
+		x509.SHA256WithRSAPSS:
+		return crypto.SHA256, nil
+	case x509.SHA384WithRSA, x509.ECDSAWithSHA384, x509.SHA384WithRSAPSS:
+		return crypto.SHA384, nil
+	case x509.SHA512WithRSA, x509.ECDSAWithSHA512, x509.SHA512WithRSAPSS:
+		return crypto.SHA512, nil
+	default:
+		return 0, fmt.Errorf("cannot derive a channel binding hash from certificate signature algorithm %v", alg)
+	}
+}
+
+// ChannelBindingToken returns the 16-byte MsvAvChannelBindings value binding an
+// NTLM exchange to the TLS channel terminated by cert.
+//
+// The all-zero value means "no channel binding" on the wire and is never
+// returned: a caller with no peer certificate must fail the bind instead.
+func ChannelBindingToken(cert *x509.Certificate) ([16]byte, error) {
+	var token [16]byte
+
+	if cert == nil || len(cert.Raw) == 0 {
+		return token, fmt.Errorf("channel binding requires a server certificate")
+	}
+
+	hash, err := certificateHashAlgorithm(cert.SignatureAlgorithm)
+	if err != nil {
+		return token, err
+	}
+
+	digester := hash.New()
+	digester.Write(cert.Raw)
+	applicationData := append([]byte(channelBindingPrefix), digester.Sum(nil)...)
+
+	// gss_channel_bindings_struct, RFC 2744 section 3.11, serialized as
+	// Microsoft implements it: little-endian, empty initiator and acceptor
+	// addresses, application data carrying the prefixed certificate digest.
+	var buf bytes.Buffer
+	writeUint32 := func(v uint32) {
+		var b [4]byte
+		binary.LittleEndian.PutUint32(b[:], v)
+		buf.Write(b[:])
+	}
+	writeUint32(0) // initiator_addtype
+	writeUint32(0) // initiator_address length
+	writeUint32(0) // acceptor_addrtype
+	writeUint32(0) // acceptor_address length
+	writeUint32(uint32(len(applicationData)))
+	buf.Write(applicationData)
+
+	token = md5.Sum(buf.Bytes()) // #nosec G401 -- MD5 is mandated by MS-NLMP.
+	return token, nil
+}

--- a/pkg/auth/providers/common/ldap/ntlm/cbt_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/cbt_test.go
@@ -1,0 +1,100 @@
+package ntlm
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCertificateHashAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		alg     x509.SignatureAlgorithm
+		want    crypto.Hash
+		wantErr bool
+	}{
+		{name: "sha256 rsa", alg: x509.SHA256WithRSA, want: crypto.SHA256},
+		{name: "sha256 rsa pss", alg: x509.SHA256WithRSAPSS, want: crypto.SHA256},
+		{name: "sha256 ecdsa", alg: x509.ECDSAWithSHA256, want: crypto.SHA256},
+		{name: "sha384 rsa", alg: x509.SHA384WithRSA, want: crypto.SHA384},
+		{name: "sha384 ecdsa", alg: x509.ECDSAWithSHA384, want: crypto.SHA384},
+		{name: "sha512 rsa", alg: x509.SHA512WithRSA, want: crypto.SHA512},
+		{name: "sha512 ecdsa", alg: x509.ECDSAWithSHA512, want: crypto.SHA512},
+		{name: "sha1 upgrades to sha256", alg: x509.SHA1WithRSA, want: crypto.SHA256},
+		{name: "sha1 ecdsa upgrades to sha256", alg: x509.ECDSAWithSHA1, want: crypto.SHA256},
+		{name: "md5 upgrades to sha256", alg: x509.MD5WithRSA, want: crypto.SHA256},
+		{name: "unknown is rejected", alg: x509.UnknownSignatureAlgorithm, wantErr: true},
+		{name: "ed25519 identifies no hash", alg: x509.PureEd25519, wantErr: true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := certificateHashAlgorithm(test.alg)
+			if test.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestChannelBindingTokenKnownVector(t *testing.T) {
+	t.Parallel()
+
+	// A certificate whose DER body is the single byte 0x00, signed with
+	// SHA-256. The expected value below was computed independently of this
+	// implementation, so a failure means the implementation is wrong:
+	//
+	//   certHash = sha256(00)
+	//            = 6e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d
+	//   appData  = "tls-server-end-point:" || certHash          (53 bytes)
+	//   struct   = <5 little-endian uint32 zeros/length> || appData  (73 bytes)
+	//   cbt      = md5(struct)
+	//
+	// Reproduce with:
+	//   python3 -c "import hashlib,struct;d=hashlib.sha256(bytes([0])).digest();
+	//   a=b'tls-server-end-point:'+d;print(hashlib.md5(struct.pack('<IIIII',0,0,0,0,len(a))+a).hexdigest())"
+	cert := &x509.Certificate{
+		Raw:                []byte{0x00},
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	got, err := ChannelBindingToken(cert)
+	require.NoError(t, err)
+
+	want, err := hex.DecodeString("4e70888ec8512aee31c2b2d2253de9fd")
+	require.NoError(t, err)
+	assert.Equal(t, want, got[:])
+}
+
+func TestChannelBindingTokenIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	cert := &x509.Certificate{Raw: []byte("some der bytes"), SignatureAlgorithm: x509.SHA384WithRSA}
+
+	first, err := ChannelBindingToken(cert)
+	require.NoError(t, err)
+	second, err := ChannelBindingToken(cert)
+	require.NoError(t, err)
+
+	assert.Equal(t, first, second)
+}
+
+func TestChannelBindingTokenRejectsUnknownSignatureAlgorithm(t *testing.T) {
+	t.Parallel()
+
+	cert := &x509.Certificate{Raw: []byte{0x00}, SignatureAlgorithm: x509.UnknownSignatureAlgorithm}
+
+	_, err := ChannelBindingToken(cert)
+	require.Error(t, err)
+}

--- a/pkg/auth/providers/common/ldap/ntlm/challenge.go
+++ b/pkg/auth/providers/common/ldap/ntlm/challenge.go
@@ -1,0 +1,126 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// maxNTLMChallengeSize bounds the CHALLENGE message the domain controller may
+// send. Its two payloads are described by 16-bit lengths, so 256 KiB covers
+// any well-formed message while keeping parsing work bounded.
+const maxNTLMChallengeSize = 256 * 1024
+
+// challengeHeaderSize is the CHALLENGE_MESSAGE header without the optional
+// version field. Payload offsets are absolute, so a version field only shifts
+// the payload and never the fields parsed here.
+const challengeHeaderSize = 48
+
+// challenge holds the parts of a CHALLENGE_MESSAGE (MS-NLMP 2.2.1.2) the
+// client needs to build its response.
+type challenge struct {
+	ServerChallenge [8]byte
+	Flags           uint32
+	TargetInfo      []byte
+}
+
+// readVarField returns the payload a security buffer at msg[at:at+8] points
+// to, rejecting any descriptor that does not lie wholly inside msg.
+func readVarField(msg []byte, at int, name string) ([]byte, error) {
+	if at < 0 || at+8 > len(msg) {
+		return nil, fmt.Errorf("ntlm: %s descriptor at offset %d does not fit in the %d byte message", name, at, len(msg))
+	}
+
+	length := int(binary.LittleEndian.Uint16(msg[at : at+2]))
+	offset := int(binary.LittleEndian.Uint32(msg[at+4 : at+8]))
+
+	if offset < 0 || length < 0 || offset > len(msg) || length > len(msg)-offset {
+		return nil, fmt.Errorf("ntlm: %s buffer at offset %d length %d is outside the %d byte message", name, offset, length, len(msg))
+	}
+	return msg[offset : offset+length], nil
+}
+
+// parseChallenge validates and decodes a CHALLENGE_MESSAGE.
+//
+// It rejects a challenge that does not support the exchange this package
+// promises: without TARGET_INFO there is nowhere to carry the channel binding
+// token, and without EXTENDED_SESSIONSECURITY the response would not be
+// NTLMv2. It never downgrades.
+func parseChallenge(msg []byte) (*challenge, error) {
+	if len(msg) > maxNTLMChallengeSize {
+		return nil, fmt.Errorf("ntlm: challenge of %d bytes exceeds the %d byte limit", len(msg), maxNTLMChallengeSize)
+	}
+	if len(msg) < challengeHeaderSize {
+		return nil, fmt.Errorf("ntlm: challenge of %d bytes is shorter than the %d byte header", len(msg), challengeHeaderSize)
+	}
+	if string(msg[0:8]) != ntlmSignature {
+		return nil, fmt.Errorf("ntlm: challenge has an invalid NTLMSSP signature")
+	}
+	if got := binary.LittleEndian.Uint32(msg[8:12]); got != messageTypeChallenge {
+		return nil, fmt.Errorf("ntlm: expected message type %d, got %d", messageTypeChallenge, got)
+	}
+
+	flags := binary.LittleEndian.Uint32(msg[20:24])
+
+	// Every flag the AUTHENTICATE message will assert is required here, so the
+	// client can never claim a capability the server did not return. Checked
+	// before the specific messages below so the diagnostics stay useful.
+	if missing := requiredChallengeFlags &^ flags; missing != 0 {
+		switch {
+		case missing&flagTargetInfo != 0:
+			return nil, fmt.Errorf("ntlm: server did not offer NTLMSSP_NEGOTIATE_TARGET_INFO, so the channel binding token cannot be sent")
+		case missing&flagExtendedSessionSecurity != 0:
+			return nil, fmt.Errorf("ntlm: server did not offer NTLMSSP_NEGOTIATE_EXTENDED_SESSIONSECURITY, which NTLMv2 requires")
+		case missing&flagUnicode != 0:
+			return nil, fmt.Errorf("ntlm: server did not offer NTLMSSP_NEGOTIATE_UNICODE; this package only sends UTF-16 strings")
+		default:
+			return nil, fmt.Errorf("ntlm: server did not offer required negotiate flags 0x%08x", missing)
+		}
+	}
+
+	switch {
+	case flags&flagKeyExch != 0:
+		return nil, fmt.Errorf("ntlm: server requested NTLMSSP_NEGOTIATE_KEY_EXCH, which is not supported")
+	case flags&flagLMKey != 0:
+		return nil, fmt.Errorf("ntlm: server requested NTLMSSP_NEGOTIATE_LM_KEY, which is not supported")
+	}
+
+	targetInfo, err := readVarField(msg, 40, "target info")
+	if err != nil {
+		return nil, err
+	}
+
+	parsed := &challenge{Flags: flags, TargetInfo: targetInfo}
+	copy(parsed.ServerChallenge[:], msg[24:32])
+	return parsed, nil
+}
+
+// authenticateFlags is the flag word the client commits to for the session:
+// the offered set intersected with what the server returned. Nothing is
+// synthesized — a flag the server withheld is not asserted back at it.
+//
+// parseChallenge has already rejected any challenge missing a flag in
+// requiredChallengeFlags, so the intersection cannot silently drop something
+// this package depends on.
+func authenticateFlags(l layout, challengeFlags uint32) uint32 {
+	return l.flags() & challengeFlags
+}
+
+// effectiveLayout reports the layout to serialize with, given what the server
+// negotiated.
+//
+// MS-NLMP 2.2.1.3 and 2.2.2.10 tie the presence of the VERSION field to a
+// negotiated NTLMSSP_NEGOTIATE_VERSION. Emitting the field while clearing the
+// flag — or setting the flag the server never returned — produces a message
+// whose header does not match its own flag word, which is precisely the class
+// of inconsistency that makes a domain controller reject a bind with no usable
+// diagnostic.
+//
+// So a version-enabled layout requires the server to have returned the flag.
+// Real Active Directory always does. If a server does not, this fails loudly
+// with an actionable message rather than silently relocating the MIC.
+func effectiveLayout(l layout, challengeFlags uint32) (layout, error) {
+	if l.version && challengeFlags&flagVersion == 0 {
+		return layout{}, fmt.Errorf("ntlm: server did not negotiate NTLMSSP_NEGOTIATE_VERSION, so the version field and the MIC offset it fixes cannot be used")
+	}
+	return l, nil
+}

--- a/pkg/auth/providers/common/ldap/ntlm/challenge_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/challenge_test.go
@@ -1,0 +1,262 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildTestChallenge assembles a CHALLENGE_MESSAGE: a 48-byte header followed
+// by the target info payload. Payload offsets are absolute, so the header is
+// laid out the same whether or not the server sent a version field.
+func buildTestChallenge(flags uint32, serverChallenge [8]byte, targetInfo []byte) []byte {
+	return buildTestChallengeWithDescriptor(flags, serverChallenge, targetInfo, len(targetInfo))
+}
+
+// buildTestChallengeWithDescriptor is the same, but writes declaredLen into the
+// TargetInfo descriptor instead of the real payload length. Only the
+// bounds-checking tests need the two to differ.
+func buildTestChallengeWithDescriptor(flags uint32, serverChallenge [8]byte, targetInfo []byte, declaredLen int) []byte {
+	msg := make([]byte, 48)
+	copy(msg[0:8], ntlmSignature)
+	binary.LittleEndian.PutUint32(msg[8:12], messageTypeChallenge)
+	// TargetNameFields, empty.
+	if err := putVarField(msg[12:20], 0, 48, "target name"); err != nil {
+		panic(err)
+	}
+	binary.LittleEndian.PutUint32(msg[20:24], flags)
+	copy(msg[24:32], serverChallenge[:])
+	if err := putVarField(msg[40:48], declaredLen, 48, "target info"); err != nil {
+		panic(err)
+	}
+	return append(msg, targetInfo...)
+}
+
+// testChallengeFlags is what a compliant server returns: everything in
+// requiredChallengeFlags plus the optional flags Rancher offers. It must be a
+// superset of requiredChallengeFlags or every nominal test rejects its own
+// fixture.
+func testChallengeFlags() uint32 {
+	return baseFlags | flagVersion
+}
+
+func TestParseChallenge(t *testing.T) {
+	t.Parallel()
+
+	serverChallenge := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	targetInfo := []byte{0x00, 0x00, 0x00, 0x00} // MsvAvEOL only.
+
+	got, err := parseChallenge(buildTestChallenge(testChallengeFlags(), serverChallenge, targetInfo))
+	require.NoError(t, err)
+
+	assert.Equal(t, serverChallenge, got.ServerChallenge)
+	assert.Equal(t, testChallengeFlags(), got.Flags)
+	assert.Equal(t, targetInfo, got.TargetInfo)
+}
+
+func TestParseChallengeRejects(t *testing.T) {
+	t.Parallel()
+
+	serverChallenge := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	eol := []byte{0x00, 0x00, 0x00, 0x00}
+	valid := buildTestChallenge(testChallengeFlags(), serverChallenge, eol)
+
+	corrupt := func(mutate func([]byte) []byte) []byte {
+		clone := make([]byte, len(valid))
+		copy(clone, valid)
+		return mutate(clone)
+	}
+
+	tests := []struct {
+		name string
+		msg  []byte
+	}{
+		{name: "empty", msg: nil},
+		{name: "truncated header", msg: valid[:40]},
+		{
+			name: "bad signature",
+			msg:  corrupt(func(b []byte) []byte { b[0] = 'X'; return b }),
+		},
+		{
+			name: "wrong message type",
+			msg: corrupt(func(b []byte) []byte {
+				binary.LittleEndian.PutUint32(b[8:12], messageTypeNegotiate)
+				return b
+			}),
+		},
+		{
+			name: "target info offset past end",
+			msg: corrupt(func(b []byte) []byte {
+				binary.LittleEndian.PutUint32(b[44:48], 4096)
+				return b
+			}),
+		},
+		{
+			name: "target info length past end",
+			msg: corrupt(func(b []byte) []byte {
+				binary.LittleEndian.PutUint16(b[40:42], 4096)
+				return b
+			}),
+		},
+		{
+			name: "offset plus length overflows",
+			msg: corrupt(func(b []byte) []byte {
+				binary.LittleEndian.PutUint32(b[44:48], ^uint32(0))
+				binary.LittleEndian.PutUint16(b[40:42], 8)
+				return b
+			}),
+		},
+		{
+			name: "no target info flag",
+			msg:  buildTestChallenge(testChallengeFlags()&^flagTargetInfo, serverChallenge, eol),
+		},
+		{
+			name: "no extended session security flag",
+			msg:  buildTestChallenge(testChallengeFlags()&^flagExtendedSessionSecurity, serverChallenge, eol),
+		},
+		{
+			name: "no unicode flag",
+			msg:  buildTestChallenge(testChallengeFlags()&^flagUnicode, serverChallenge, eol),
+		},
+		{
+			name: "no ntlm flag",
+			msg:  buildTestChallenge(testChallengeFlags()&^flagNTLM, serverChallenge, eol),
+		},
+		{
+			name: "server demands key exchange",
+			msg:  buildTestChallenge(testChallengeFlags()|flagKeyExch, serverChallenge, eol),
+		},
+		{
+			name: "server demands lm key",
+			msg:  buildTestChallenge(testChallengeFlags()|flagLMKey, serverChallenge, eol),
+		},
+		{name: "oversized", msg: make([]byte, maxNTLMChallengeSize+1)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseChallenge(test.msg)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseChallengeAcceptsExactlyMaximumSize(t *testing.T) {
+	t.Parallel()
+
+	// A message landing exactly on the cap, built from a legal descriptor.
+	//
+	// A TargetInfo descriptor is a 16-bit length, so it can only ever describe
+	// 65 535 bytes; the cap is far above that. The message therefore reaches
+	// maxNTLMChallengeSize as a maximum-length descriptor followed by trailing
+	// bytes the descriptor does not cover. That is a legal NTLM message —
+	// security buffer offsets are 32-bit and payloads may leave gaps — and it
+	// is what lets the size limit be tested at all.
+	//
+	// This exercises the size cap and the descriptor bounds check. It does not
+	// exercise AV-pair handling; parseChallenge never parses TargetInfo, and
+	// the serializer's own length limit is covered separately.
+	const declared = maxVarFieldLen
+
+	targetInfo := make([]byte, 0, declared)
+	targetInfo = binary.LittleEndian.AppendUint16(targetInfo, 0x000A) // unknown AV id
+	targetInfo = binary.LittleEndian.AppendUint16(targetInfo, uint16(declared-8))
+	targetInfo = append(targetInfo, make([]byte, declared-8)...)
+	targetInfo = append(targetInfo, 0x00, 0x00, 0x00, 0x00) // MsvAvEOL
+	require.Len(t, targetInfo, declared)
+
+	// Pad the message out to exactly the cap. These bytes sit past the end of
+	// the TargetInfo payload and are referenced by nothing.
+	trailing := maxNTLMChallengeSize - 48 - declared
+	require.Positive(t, trailing)
+
+	msg := buildTestChallenge(testChallengeFlags(), [8]byte{}, targetInfo)
+	msg = append(msg, make([]byte, trailing)...)
+	require.Len(t, msg, maxNTLMChallengeSize)
+
+	parsed, err := parseChallenge(msg)
+	require.NoError(t, err)
+	require.Len(t, parsed.TargetInfo, declared, "the descriptor bounds the payload, not the message")
+
+	_, err = parseChallenge(append(msg, 0x00))
+	require.Error(t, err, "one byte over the cap is refused")
+}
+
+func TestParseChallengeAcceptsWithoutOptionalFlags(t *testing.T) {
+	t.Parallel()
+
+	// REQUEST_TARGET and ALWAYS_SIGN are offered but not needed to carry a
+	// channel binding token, so withholding them must not fail the exchange.
+	for _, optional := range []struct {
+		name string
+		flag uint32
+	}{
+		{name: "request target", flag: flagRequestTarget},
+		{name: "always sign", flag: flagAlwaysSign},
+	} {
+		t.Run(optional.name, func(t *testing.T) {
+			t.Parallel()
+
+			msg := buildTestChallenge(testChallengeFlags()&^optional.flag, [8]byte{1}, eolTerminated())
+
+			parsed, err := parseChallenge(msg)
+			require.NoError(t, err)
+			assert.Zero(t, parsed.Flags&optional.flag)
+
+			// And the client does not assert it back.
+			assert.Zero(t, authenticateFlags(layout{version: true, mic: true}, parsed.Flags)&optional.flag)
+		})
+	}
+}
+
+func TestEffectiveLayoutRequiresNegotiatedVersion(t *testing.T) {
+	t.Parallel()
+
+	shipping := layout{version: true, mic: true}
+
+	got, err := effectiveLayout(shipping, testChallengeFlags())
+	require.NoError(t, err)
+	assert.Equal(t, shipping, got)
+
+	// A version-enabled layout against a server that withheld the flag fails
+	// loudly. Emitting the field anyway would put the header and the flag word
+	// in disagreement and relocate the MIC without saying so.
+	_, err = effectiveLayout(shipping, testChallengeFlags()&^flagVersion)
+	require.Error(t, err)
+
+	// A version-disabled layout does not care either way.
+	noVersion := layout{mic: true}
+	got, err = effectiveLayout(noVersion, testChallengeFlags()&^flagVersion)
+	require.NoError(t, err)
+	assert.Equal(t, noVersion, got)
+}
+
+func TestBuildTestChallengeRejectsAnOversizedDescriptor(t *testing.T) {
+	t.Parallel()
+
+	// Guards the fixture builder itself: putVarField refuses a length a 16-bit
+	// field cannot hold, so a future test cannot accidentally reintroduce a
+	// truncated descriptor.
+	assert.Panics(t, func() {
+		buildTestChallengeWithDescriptor(testChallengeFlags(), [8]byte{}, nil, maxVarFieldLen+1)
+	})
+}
+
+func FuzzParseChallenge(f *testing.F) {
+	f.Add(buildTestChallenge(testChallengeFlags(), [8]byte{1}, []byte{0, 0, 0, 0}))
+	f.Add([]byte(ntlmSignature))
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, msg []byte) {
+		// The contract is only that it never panics and never returns both a
+		// nil error and a nil result.
+		got, err := parseChallenge(msg)
+		if err == nil && got == nil {
+			t.Fatal("parseChallenge returned no result and no error")
+		}
+	})
+}

--- a/pkg/auth/providers/common/ldap/ntlm/negotiate.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiate.go
@@ -1,0 +1,30 @@
+package ntlm
+
+import "encoding/binary"
+
+// buildNegotiate returns a NEGOTIATE_MESSAGE (MS-NLMP 2.2.1.1) with empty
+// domain and workstation buffers.
+//
+// The domain is deliberately not carried here. NEGOTIATE encodes it in the OEM
+// character set, which would need a codepage conversion for non-ASCII domains,
+// and the domain the server actually authenticates against is the Unicode one
+// in AUTHENTICATE. go-ldap always passes an empty workstation.
+func buildNegotiate(l layout) []byte {
+	size := l.negotiateHeaderSize()
+	msg := make([]byte, size)
+
+	copy(msg[0:8], ntlmSignature)
+	binary.LittleEndian.PutUint32(msg[8:12], messageTypeNegotiate)
+	binary.LittleEndian.PutUint32(msg[12:16], l.flags())
+
+	// Both payloads are empty, so the descriptors cannot exceed the security
+	// buffer limit and the errors are unreachable.
+	_ = putVarField(msg[16:24], 0, size, "negotiate domain")
+	_ = putVarField(msg[24:32], 0, size, "negotiate workstation")
+
+	if l.version {
+		copy(msg[32:40], versionStructure[:])
+	}
+
+	return msg
+}

--- a/pkg/auth/providers/common/ldap/ntlm/negotiate_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiate_test.go
@@ -1,0 +1,74 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUTF16LE(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, []byte{'A', 0x00, 'B', 0x00}, utf16LE("AB"))
+	assert.Equal(t, []byte{}, utf16LE(""))
+	// U+00E9 LATIN SMALL LETTER E WITH ACUTE encodes as 0xE9 0x00.
+	assert.Equal(t, []byte{0xE9, 0x00}, utf16LE("é"))
+	// U+1F600 is outside the BMP and encodes as a surrogate pair.
+	assert.Equal(t, []byte{0x3D, 0xD8, 0x00, 0xDE}, utf16LE("\U0001F600"))
+}
+
+func TestFileTime(t *testing.T) {
+	t.Parallel()
+
+	// The Windows epoch itself is zero 100ns intervals.
+	assert.Equal(t, uint64(0), fileTime(time.Date(1601, 1, 1, 0, 0, 0, 0, time.UTC)))
+	// The Unix epoch is 11644473600 seconds later.
+	assert.Equal(t, uint64(116444736000000000), fileTime(time.Unix(0, 0).UTC()))
+}
+
+func TestBuildNegotiate(t *testing.T) {
+	t.Parallel()
+
+	l := layout{version: true, mic: true}
+	msg := buildNegotiate(l)
+
+	require.Len(t, msg, l.negotiateHeaderSize(), "no payload is emitted, so the message is exactly the header")
+	assert.Equal(t, ntlmSignature, string(msg[0:8]))
+	assert.Equal(t, uint32(messageTypeNegotiate), binary.LittleEndian.Uint32(msg[8:12]))
+	assert.Equal(t, l.flags(), binary.LittleEndian.Uint32(msg[12:16]))
+
+	// Domain and workstation are empty security buffers whose offsets point at
+	// the end of the message.
+	for name, off := range map[string]int{"domain": 16, "workstation": 24} {
+		assert.Equalf(t, uint16(0), binary.LittleEndian.Uint16(msg[off:off+2]), "%s length", name)
+		assert.Equalf(t, uint16(0), binary.LittleEndian.Uint16(msg[off+2:off+4]), "%s max length", name)
+		assert.Equalf(t, uint32(l.negotiateHeaderSize()), binary.LittleEndian.Uint32(msg[off+4:off+8]), "%s offset", name)
+	}
+
+	assert.Equal(t, versionStructure[:], msg[32:40])
+}
+
+func TestNegotiateFlagsValue(t *testing.T) {
+	t.Parallel()
+
+	// UNICODE | REQUEST_TARGET | NTLM | ALWAYS_SIGN | EXTENDED_SESSIONSECURITY
+	// | TARGET_INFO | VERSION. Pinned so a flag change is a deliberate edit.
+	shipping := layout{version: true, mic: true}
+	assert.Equal(t, uint32(0x02888205), shipping.flags())
+	assert.Equal(t, uint32(0x00888205), layout{}.flags(), "without VERSION")
+
+	assert.Zero(t, baseFlags&flagKeyExch, "key exchange is not negotiated")
+	assert.Zero(t, baseFlags&flagNegotiateSign, "TLS provides integrity; NTLM signing is not negotiated")
+	assert.Zero(t, baseFlags&flagNegotiateSeal, "TLS provides confidentiality; NTLM sealing is not negotiated")
+
+	// Nothing may be required that is not offered.
+	assert.Zero(t, requiredChallengeFlags&^baseFlags, "required flags must be a subset of what is offered")
+
+	// ALWAYS_SIGN and REQUEST_TARGET are offered but optional: neither is
+	// needed to carry a channel binding token, so a server withholding them is
+	// still usable. They are simply not asserted back in AUTHENTICATE.
+	assert.Equal(t, flagAlwaysSign|flagRequestTarget, baseFlags&^requiredChallengeFlags)
+}

--- a/pkg/auth/providers/common/ldap/ntlm/negotiator.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiator.go
@@ -1,0 +1,180 @@
+package ntlm
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// ErrInvalidExchangeState is returned when the two negotiator callbacks are
+// invoked out of order or more than once.
+var ErrInvalidExchangeState = errors.New("ntlm: negotiator methods called out of order")
+
+// ErrMissingDomain is returned when no domain is supplied. The NTLMv2 response
+// key is derived from the user name and the domain, so it is not optional.
+var ErrMissingDomain = errors.New("ntlm: a domain is required")
+
+type exchangeState int
+
+const (
+	stateNew exchangeState = iota
+	stateNegotiated
+	stateComplete
+)
+
+// Negotiator implements go-ldap's NTLMNegotiator for a single NTLMv2 bind
+// carrying a channel binding token.
+//
+// It is single-use and stateful: go-ldap splits the exchange across two
+// callbacks and passes the domain only to the first, so the domain and the
+// exact NEGOTIATE bytes must be carried across. It is created and owned by one
+// NTLMChallengeBind call and is not safe for concurrent use.
+//
+// Callers cannot match on the errors returned here. go-ldap v3.4.14 renders
+// negotiator failures with %s, not %w (bind.go:514 and :633), so error
+// identity is destroyed before NTLMChallengeBind returns. Do not build
+// errors.Is checks on ErrInvalidExchangeState or ErrMissingDomain outside this
+// package; %w preservation is part of the upstreaming request.
+type Negotiator struct {
+	state          exchangeState
+	cbt            [16]byte
+	userDomain     string
+	negotiateBytes []byte
+	layout         layout
+
+	now   func() time.Time
+	nonce func([]byte) error
+}
+
+// Option adjusts a Negotiator at construction. The clock and nonce hooks exist
+// so tests can pin the two non-deterministic inputs.
+type Option func(*Negotiator)
+
+// WithClock replaces the timestamp source used when the server supplies none.
+func WithClock(now func() time.Time) Option {
+	return func(n *Negotiator) { n.now = now }
+}
+
+// WithNonceSource replaces the client challenge source.
+func WithNonceSource(read func([]byte) error) Option {
+	return func(n *Negotiator) { n.nonce = read }
+}
+
+// WithVersion controls whether the 8-byte VERSION field is emitted. Turning it
+// off moves the MIC from offset 72 to 64 and the payload base from 88 to 80.
+//
+// Exists so the header layout can be measured against a real domain
+// controller. Production code must not call it; see the deviation note in the
+// plan.
+func WithVersion(on bool) Option {
+	return func(n *Negotiator) { n.layout.version = on }
+}
+
+// WithMIC controls whether a message integrity code is emitted and whether the
+// MsvAvFlags MIC-present bit is set. Same caveat as WithVersion.
+func WithMIC(on bool) Option {
+	return func(n *Negotiator) { n.layout.mic = on }
+}
+
+// ErrNoChannelBinding is returned when the negotiator is constructed with the
+// all-zero token, which means "no channel binding" on the wire. A caller that
+// cannot derive a real token must fail the bind rather than send an unbound
+// one that a permissive DC might accept.
+var ErrNoChannelBinding = errors.New("ntlm: refusing to bind with an all-zero channel binding token")
+
+// NewNegotiator returns a single-use negotiator that binds the exchange to the
+// TLS channel described by cbt.
+func NewNegotiator(cbt [16]byte, options ...Option) (*Negotiator, error) {
+	if cbt == ([16]byte{}) {
+		return nil, ErrNoChannelBinding
+	}
+
+	n := &Negotiator{
+		cbt:    cbt,
+		layout: layout{version: true, mic: true},
+		now:    time.Now,
+		nonce: func(b []byte) error {
+			_, err := rand.Read(b)
+			return err
+		},
+	}
+	for _, option := range options {
+		option(n)
+	}
+	return n, nil
+}
+
+// Negotiate returns the NEGOTIATE message and records the domain the response
+// key will be derived from. go-ldap always passes an empty workstation.
+func (n *Negotiator) Negotiate(domain, workstation string) ([]byte, error) {
+	if n.state != stateNew {
+		return nil, ErrInvalidExchangeState
+	}
+	if domain == "" {
+		return nil, ErrMissingDomain
+	}
+
+	n.userDomain = domain
+	n.negotiateBytes = buildNegotiate(n.layout)
+	n.state = stateNegotiated
+
+	return bytes.Clone(n.negotiateBytes), nil
+}
+
+// ChallengeResponse returns the AUTHENTICATE message answering challengeBytes.
+//
+// hash is the hex-encoded NT hash go-ldap derived from the bind password; this
+// package never hashes the password itself and never accepts a caller-supplied
+// hash, so pass-the-hash stays unreachable.
+func (n *Negotiator) ChallengeResponse(challengeBytes []byte, username, hash string) ([]byte, error) {
+	if n.state != stateNegotiated {
+		return nil, ErrInvalidExchangeState
+	}
+
+	ntHash, err := hex.DecodeString(hash)
+	if err != nil {
+		return nil, fmt.Errorf("ntlm: NT hash is not valid hex: %w", err)
+	}
+	if len(ntHash) != 16 {
+		return nil, fmt.Errorf("ntlm: NT hash is %d bytes, expected 16", len(ntHash))
+	}
+
+	parsed, err := parseChallenge(challengeBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolved once here so the flag word, the version field, the MIC offset
+	// and patchMIC below all agree on the same layout.
+	effective, err := effectiveLayout(n.layout, parsed.Flags)
+	if err != nil {
+		return nil, err
+	}
+
+	in := authenticateInput{
+		NTHash:    ntHash,
+		User:      username,
+		Domain:    n.userDomain,
+		Challenge: parsed,
+		CBT:       n.cbt,
+		Now:       n.now(),
+		Layout:    effective,
+	}
+	if err := n.nonce(in.ClientNonce[:]); err != nil {
+		return nil, fmt.Errorf("ntlm: cannot read a client challenge: %w", err)
+	}
+
+	authenticate, sessionKey, err := buildAuthenticate(in)
+	if err != nil {
+		return nil, err
+	}
+	if err := patchMIC(effective, authenticate, n.negotiateBytes, challengeBytes, sessionKey); err != nil {
+		return nil, err
+	}
+
+	n.state = stateComplete
+	return authenticate, nil
+}

--- a/pkg/auth/providers/common/ldap/ntlm/negotiator.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiator.go
@@ -63,19 +63,19 @@ func WithNonceSource(read func([]byte) error) Option {
 	return func(n *Negotiator) { n.nonce = read }
 }
 
-// WithVersion controls whether the 8-byte VERSION field is emitted. Turning it
+// withVersion controls whether the 8-byte VERSION field is emitted. Turning it
 // off moves the MIC from offset 72 to 64 and the payload base from 88 to 80.
 //
 // Exists so the header layout can be measured against a real domain
 // controller. Production code must not call it; see the deviation note in the
 // plan.
-func WithVersion(on bool) Option {
+func withVersion(on bool) Option {
 	return func(n *Negotiator) { n.layout.version = on }
 }
 
-// WithMIC controls whether a message integrity code is emitted and whether the
-// MsvAvFlags MIC-present bit is set. Same caveat as WithVersion.
-func WithMIC(on bool) Option {
+// withMIC controls whether a message integrity code is emitted and whether the
+// MsvAvFlags MIC-present bit is set. Same caveat as withVersion.
+func withMIC(on bool) Option {
 	return func(n *Negotiator) { n.layout.mic = on }
 }
 

--- a/pkg/auth/providers/common/ldap/ntlm/negotiator.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiator.go
@@ -33,11 +33,11 @@ const (
 // exact NEGOTIATE bytes must be carried across. It is created and owned by one
 // NTLMChallengeBind call and is not safe for concurrent use.
 //
-// Callers cannot match on the errors returned here. go-ldap v3.4.14 renders
-// negotiator failures with %s, not %w (bind.go:514 and :633), so error
-// identity is destroyed before NTLMChallengeBind returns. Do not build
+// Callers cannot match on the errors returned here. go-ldap (v3.4.14) renders
+// negotiator failures with %s, not %w, so error identity is destroyed before
+// NTLMChallengeBind returns. Do not build
 // errors.Is checks on ErrInvalidExchangeState or ErrMissingDomain outside this
-// package; %w preservation is part of the upstreaming request.
+// package; that only becomes possible if go-ldap starts preserving %w itself.
 type Negotiator struct {
 	state          exchangeState
 	cbt            [16]byte
@@ -67,8 +67,7 @@ func WithNonceSource(read func([]byte) error) Option {
 // off moves the MIC from offset 72 to 64 and the payload base from 88 to 80.
 //
 // Exists so the header layout can be measured against a real domain
-// controller. Production code must not call it; see the deviation note in the
-// plan.
+// controller during development. Production code must not call it.
 func withVersion(on bool) Option {
 	return func(n *Negotiator) { n.layout.version = on }
 }

--- a/pkg/auth/providers/common/ldap/ntlm/negotiator_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiator_test.go
@@ -1,0 +1,298 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	ldapv3 "github.com/go-ldap/ldap/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testCBT is a non-zero placeholder token. NewNegotiator rejects the all-zero
+// value, so no test other than TestNewNegotiatorRejectsTheZeroToken may
+// construct a negotiator with it.
+var testCBT = [16]byte{0xCC, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F}
+
+func testNegotiator(t *testing.T, cbt [16]byte, extra ...Option) *Negotiator {
+	t.Helper()
+
+	require.NotEqual(t, [16]byte{}, cbt, "the constructor rejects the zero token; use testCBT")
+
+	options := append([]Option{
+		WithClock(func() time.Time { return time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC) }),
+		WithNonceSource(func(b []byte) error {
+			for i := range b {
+				b[i] = 0xAA
+			}
+			return nil
+		}),
+	}, extra...)
+
+	n, err := NewNegotiator(cbt, options...)
+	require.NoError(t, err)
+	return n
+}
+
+func TestNegotiatorHappyPath(t *testing.T) {
+	t.Parallel()
+
+	n := testNegotiator(t, [16]byte{0xCC})
+
+	negotiate, err := n.Negotiate(specDomain, "")
+	require.NoError(t, err)
+	assert.Equal(t, buildNegotiate(layout{version: true, mic: true}), negotiate)
+
+	challengeBytes := buildTestChallenge(testChallengeFlags(), [8]byte{1, 2, 3, 4, 5, 6, 7, 8}, eolTerminated())
+
+	authenticate, err := n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+	require.NoError(t, err)
+	shipping := layout{version: true, mic: true}
+	require.GreaterOrEqual(t, len(authenticate), shipping.authenticateHeaderSize())
+	assert.Equal(t, uint32(messageTypeAuthenticate), binary.LittleEndian.Uint32(authenticate[8:12]))
+	assert.NotEqual(t, make([]byte, 16), authenticate[shipping.micOffset():shipping.micOffset()+16], "the MIC is filled in")
+
+	domain, err := readVarField(authenticate, 28, "domain")
+	require.NoError(t, err)
+	assert.Equal(t, utf16LE(specDomain), domain, "the domain from Negotiate is used")
+}
+
+func TestNegotiatorReturnsACopyOfTheNegotiateBytes(t *testing.T) {
+	t.Parallel()
+
+	n := testNegotiator(t, testCBT)
+
+	negotiate, err := n.Negotiate(specDomain, "")
+	require.NoError(t, err)
+
+	// A caller mutating the returned slice must not change what the MIC covers.
+	negotiate[0] = 'X'
+
+	challengeBytes := buildTestChallenge(testChallengeFlags(), [8]byte{1}, eolTerminated())
+	authenticate, err := n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+	require.NoError(t, err)
+
+	fresh := testNegotiator(t, testCBT)
+	_, err = fresh.Negotiate(specDomain, "")
+	require.NoError(t, err)
+	expected, err := fresh.ChallengeResponse(challengeBytes, specUser, specNTHash)
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, authenticate)
+}
+
+func TestNegotiatorStateMachine(t *testing.T) {
+	t.Parallel()
+
+	challengeBytes := buildTestChallenge(testChallengeFlags(), [8]byte{1}, eolTerminated())
+
+	t.Run("challenge response before negotiate", func(t *testing.T) {
+		t.Parallel()
+
+		n := testNegotiator(t, testCBT)
+		_, err := n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+		require.ErrorIs(t, err, ErrInvalidExchangeState)
+	})
+
+	t.Run("second negotiate", func(t *testing.T) {
+		t.Parallel()
+
+		n := testNegotiator(t, testCBT)
+		_, err := n.Negotiate(specDomain, "")
+		require.NoError(t, err)
+
+		_, err = n.Negotiate(specDomain, "")
+		require.ErrorIs(t, err, ErrInvalidExchangeState)
+	})
+
+	t.Run("second challenge response", func(t *testing.T) {
+		t.Parallel()
+
+		n := testNegotiator(t, testCBT)
+		_, err := n.Negotiate(specDomain, "")
+		require.NoError(t, err)
+		_, err = n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+		require.NoError(t, err)
+
+		_, err = n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+		require.ErrorIs(t, err, ErrInvalidExchangeState)
+	})
+
+	t.Run("negotiate after challenge response", func(t *testing.T) {
+		t.Parallel()
+
+		n := testNegotiator(t, testCBT)
+		_, err := n.Negotiate(specDomain, "")
+		require.NoError(t, err)
+		_, err = n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+		require.NoError(t, err)
+
+		_, err = n.Negotiate(specDomain, "")
+		require.ErrorIs(t, err, ErrInvalidExchangeState)
+	})
+}
+
+func TestNegotiateRequiresADomain(t *testing.T) {
+	t.Parallel()
+
+	n := testNegotiator(t, testCBT)
+	_, err := n.Negotiate("", "")
+	require.ErrorIs(t, err, ErrMissingDomain)
+}
+
+func TestNegotiatorDomainChangesTheResponse(t *testing.T) {
+	t.Parallel()
+
+	challengeBytes := buildTestChallenge(testChallengeFlags(), [8]byte{1}, eolTerminated())
+
+	respond := func(domain string) []byte {
+		n := testNegotiator(t, testCBT)
+		_, err := n.Negotiate(domain, "")
+		require.NoError(t, err)
+		out, err := n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+		require.NoError(t, err)
+		return out
+	}
+
+	assert.NotEqual(t, respond("ALPHA"), respond("BETA"),
+		"the domain feeds the response key, so identical credentials under two domains differ on the wire")
+}
+
+func TestChallengeResponseRejectsABadHash(t *testing.T) {
+	t.Parallel()
+
+	n := testNegotiator(t, testCBT)
+	_, err := n.Negotiate(specDomain, "")
+	require.NoError(t, err)
+
+	challengeBytes := buildTestChallenge(testChallengeFlags(), [8]byte{1}, eolTerminated())
+
+	_, err = n.ChallengeResponse(challengeBytes, specUser, "not hex")
+	require.Error(t, err)
+	assert.False(t, errors.Is(err, ErrInvalidExchangeState))
+}
+
+func TestChallengeResponseRejectsAMalformedChallenge(t *testing.T) {
+	t.Parallel()
+
+	n := testNegotiator(t, testCBT)
+	_, err := n.Negotiate(specDomain, "")
+	require.NoError(t, err)
+
+	_, err = n.ChallengeResponse([]byte("garbage"), specUser, specNTHash)
+	require.Error(t, err)
+}
+
+func TestNewNegotiatorRejectsTheZeroToken(t *testing.T) {
+	t.Parallel()
+
+	// The all-zero token means "no channel binding" on the wire. A permissive
+	// domain controller would accept such a bind, which is precisely the
+	// outcome this feature exists to prevent, so it is refused at construction
+	// rather than left to the caller to avoid.
+	_, err := NewNegotiator([16]byte{})
+	require.ErrorIs(t, err, ErrNoChannelBinding)
+}
+
+func TestNegotiatorCarriesTheTokenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	cbt := [16]byte{0xDE, 0xAD, 0xBE, 0xEF}
+	n := testNegotiator(t, cbt)
+	_, err := n.Negotiate(specDomain, "")
+	require.NoError(t, err)
+
+	challengeBytes := buildTestChallenge(testChallengeFlags(), [8]byte{1}, eolTerminated())
+	authenticate, err := n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+	require.NoError(t, err)
+
+	ntResponse, err := readVarField(authenticate, 20, "nt response")
+	require.NoError(t, err)
+	pairs, err := parseTargetInfo(ntResponse[16+clientChallengeHeaderSize : len(ntResponse)-4])
+	require.NoError(t, err)
+	value, ok := findAVPair(pairs, avChannelBindings)
+	require.True(t, ok)
+	assert.Equal(t, cbt[:], value, "the token reaches the wire byte for byte")
+}
+
+func TestNegotiatorLayouts(t *testing.T) {
+	t.Parallel()
+
+	// All four header layouts must build and stay self-consistent. Only
+	// version=true, mic=true ships; the rest exist for the Task 8A gate, and
+	// they are unit-tested here so the spike measures working code rather than
+	// discovering the layout surface at the domain controller.
+	tests := []struct {
+		name              string
+		version, mic      bool
+		wantMICOffset     int
+		wantHeaderSize    int
+		wantNegotiateSize int
+	}{
+		{name: "version and mic", version: true, mic: true, wantMICOffset: 72, wantHeaderSize: 88, wantNegotiateSize: 40},
+		{name: "neither", version: false, mic: false, wantMICOffset: 64, wantHeaderSize: 64, wantNegotiateSize: 32},
+		{name: "mic only", version: false, mic: true, wantMICOffset: 64, wantHeaderSize: 80, wantNegotiateSize: 32},
+		{name: "version only", version: true, mic: false, wantMICOffset: 72, wantHeaderSize: 72, wantNegotiateSize: 40},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := layout{version: test.version, mic: test.mic}
+			assert.Equal(t, test.wantMICOffset, l.micOffset())
+			assert.Equal(t, test.wantHeaderSize, l.authenticateHeaderSize())
+			assert.Equal(t, test.wantNegotiateSize, l.negotiateHeaderSize())
+
+			n := testNegotiator(t, [16]byte{0x01}, WithVersion(test.version), WithMIC(test.mic))
+
+			negotiate, err := n.Negotiate(specDomain, "")
+			require.NoError(t, err)
+			require.Len(t, negotiate, test.wantNegotiateSize)
+
+			challengeBytes := buildTestChallenge(testChallengeFlags(), [8]byte{1}, eolTerminated())
+			authenticate, err := n.ChallengeResponse(challengeBytes, specUser, specNTHash)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, len(authenticate), test.wantHeaderSize)
+
+			// Every payload sits at or after the header, so no payload byte can
+			// land on the MIC field.
+			for name, at := range map[string]int{
+				"lm response": 12, "nt response": 20, "domain": 28,
+				"user": 36, "workstation": 44, "session key": 52,
+			} {
+				offset := binary.LittleEndian.Uint32(authenticate[at+4 : at+8])
+				assert.GreaterOrEqualf(t, int(offset), test.wantHeaderSize, "%s offset", name)
+			}
+
+			micField := authenticate[l.micOffset() : l.micOffset()+16]
+			if test.mic {
+				assert.NotEqual(t, make([]byte, 16), micField, "the MIC is filled in")
+			}
+
+			hasVersionFlag := binary.LittleEndian.Uint32(authenticate[60:64])&flagVersion != 0
+			assert.Equal(t, test.version, hasVersionFlag)
+
+			// The MsvAvFlags MIC-present bit must agree with the layout.
+			ntResponse, err := readVarField(authenticate, 20, "nt response")
+			require.NoError(t, err)
+			pairs, err := parseTargetInfo(ntResponse[16+clientChallengeHeaderSize : len(ntResponse)-4])
+			require.NoError(t, err)
+			avFlagsValue, ok := findAVPair(pairs, avFlags)
+			require.True(t, ok)
+			micBitSet := binary.LittleEndian.Uint32(avFlagsValue)&avFlagMICPresent != 0
+			assert.Equal(t, test.mic, micBitSet, "MsvAvFlags must not claim a MIC the message does not carry")
+		})
+	}
+}
+
+func TestNegotiatorSatisfiesGoLdapInterface(t *testing.T) {
+	t.Parallel()
+
+	n, err := NewNegotiator([16]byte{0x01})
+	require.NoError(t, err)
+
+	var _ ldapv3.NTLMNegotiator = n
+}

--- a/pkg/auth/providers/common/ldap/ntlm/negotiator_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiator_test.go
@@ -221,9 +221,9 @@ func TestNegotiatorLayouts(t *testing.T) {
 	t.Parallel()
 
 	// All four header layouts must build and stay self-consistent. Only
-	// version=true, mic=true ships; the rest exist for the Task 8A gate, and
-	// they are unit-tested here so the spike measures working code rather than
-	// discovering the layout surface at the domain controller.
+	// version=true, mic=true ships; the rest exist so the layout a real domain
+	// controller accepts can be measured against known-working code, instead of
+	// discovering the layout surface at the domain controller from scratch.
 	tests := []struct {
 		name              string
 		version, mic      bool

--- a/pkg/auth/providers/common/ldap/ntlm/negotiator_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/negotiator_test.go
@@ -246,7 +246,7 @@ func TestNegotiatorLayouts(t *testing.T) {
 			assert.Equal(t, test.wantHeaderSize, l.authenticateHeaderSize())
 			assert.Equal(t, test.wantNegotiateSize, l.negotiateHeaderSize())
 
-			n := testNegotiator(t, [16]byte{0x01}, WithVersion(test.version), WithMIC(test.mic))
+			n := testNegotiator(t, [16]byte{0x01}, withVersion(test.version), withMIC(test.mic))
 
 			negotiate, err := n.Negotiate(specDomain, "")
 			require.NoError(t, err)

--- a/pkg/auth/providers/common/ldap/ntlm/targetinfo.go
+++ b/pkg/auth/providers/common/ldap/ntlm/targetinfo.go
@@ -1,0 +1,167 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// AV_PAIR identifiers, MS-NLMP 2.2.2.1.
+const (
+	avEOL             uint16 = 0x0000
+	avNbComputerName  uint16 = 0x0001
+	avNbDomainName    uint16 = 0x0002
+	avDNSComputerName uint16 = 0x0003
+	avDNSDomainName   uint16 = 0x0004
+	avDNSTreeName     uint16 = 0x0005
+	avFlags           uint16 = 0x0006
+	avTimestamp       uint16 = 0x0007
+	avSingleHost      uint16 = 0x0008
+	avTargetName      uint16 = 0x0009
+	avChannelBindings uint16 = 0x000A
+)
+
+// avFlagMICPresent is the MsvAvFlags bit stating the AUTHENTICATE message
+// carries a MIC. Bit 0x00000004 (the client supplied an unverified target
+// name) is deliberately never set: no SPN is supplied at all.
+const avFlagMICPresent uint32 = 0x00000002
+
+// avPair is one AV_PAIR from a TargetInfo buffer. The terminating MsvAvEOL is
+// not represented; it is implied by the buffer and re-emitted on serialize.
+type avPair struct {
+	ID    uint16
+	Value []byte
+}
+
+// securitySensitiveAVIDs may appear at most once in a server's TargetInfo. A
+// duplicate would let a parser that keeps the first occurrence and one that
+// keeps the last disagree about the channel binding in force.
+var securitySensitiveAVIDs = map[uint16]bool{
+	avFlags:           true,
+	avTimestamp:       true,
+	avTargetName:      true,
+	avChannelBindings: true,
+}
+
+// parseTargetInfo decodes an AV_PAIR sequence, requiring it to end in exactly
+// one MsvAvEOL with nothing after it.
+func parseTargetInfo(buf []byte) ([]avPair, error) {
+	pairs := []avPair{}
+	seen := map[uint16]bool{}
+
+	for offset := 0; ; {
+		if len(buf)-offset < 4 {
+			return nil, fmt.Errorf("ntlm: target info ends after %d bytes without an MsvAvEOL", offset)
+		}
+
+		id := binary.LittleEndian.Uint16(buf[offset : offset+2])
+		length := int(binary.LittleEndian.Uint16(buf[offset+2 : offset+4]))
+		offset += 4
+
+		if id == avEOL {
+			if length != 0 {
+				return nil, fmt.Errorf("ntlm: MsvAvEOL declares a %d byte value", length)
+			}
+			if offset != len(buf) {
+				return nil, fmt.Errorf("ntlm: %d bytes follow the MsvAvEOL", len(buf)-offset)
+			}
+			return pairs, nil
+		}
+
+		if length > len(buf)-offset {
+			return nil, fmt.Errorf("ntlm: AV pair 0x%04x declares %d bytes but only %d remain", id, length, len(buf)-offset)
+		}
+		if securitySensitiveAVIDs[id] && seen[id] {
+			return nil, fmt.Errorf("ntlm: AV pair 0x%04x appears more than once", id)
+		}
+		seen[id] = true
+
+		value := make([]byte, length)
+		copy(value, buf[offset:offset+length])
+		pairs = append(pairs, avPair{ID: id, Value: value})
+		offset += length
+	}
+}
+
+// serializeTargetInfo encodes pairs followed by exactly one MsvAvEOL.
+//
+// An AV pair's length is a 16-bit field, so an oversized value is an error
+// rather than a truncation: a truncated length would produce a buffer that
+// re-parses into different pairs than the ones written.
+func serializeTargetInfo(pairs []avPair) ([]byte, error) {
+	size := 4
+	for _, p := range pairs {
+		if len(p.Value) > maxVarFieldLen {
+			return nil, fmt.Errorf("ntlm: AV pair 0x%04x value of %d bytes exceeds the %d byte limit", p.ID, len(p.Value), maxVarFieldLen)
+		}
+		size += 4 + len(p.Value)
+	}
+
+	out := make([]byte, 0, size)
+	for _, p := range pairs {
+		out = binary.LittleEndian.AppendUint16(out, p.ID)
+		out = binary.LittleEndian.AppendUint16(out, uint16(len(p.Value)))
+		out = append(out, p.Value...)
+	}
+	return append(out, 0x00, 0x00, 0x00, 0x00), nil
+}
+
+// findAVPair returns the value of the first pair with the given id.
+func findAVPair(pairs []avPair, id uint16) ([]byte, bool) {
+	for _, p := range pairs {
+		if p.ID == id {
+			return p.Value, true
+		}
+	}
+	return nil, false
+}
+
+// upsertAVPair replaces the value of an existing pair, preserving its
+// position, or appends a new one.
+func upsertAVPair(pairs []avPair, id uint16, value []byte) []avPair {
+	for i := range pairs {
+		if pairs[i].ID == id {
+			pairs[i].Value = value
+			return pairs
+		}
+	}
+	return append(pairs, avPair{ID: id, Value: value})
+}
+
+// transformTargetInfo returns the TargetInfo the client sends back inside its
+// NTLMv2 response: the server's pairs, preserved in order, with the channel
+// binding token, an empty target name and the MsvAvFlags value upserted.
+//
+// It parses and re-serializes rather than appending. A well-formed TargetInfo
+// ends in an MsvAvEOL, and a pair written after it is invisible to any parser
+// that stops there, which would produce a bind carrying no effective channel
+// binding at all.
+//
+// The empty MsvAvTargetName is the MS-NLMP 3.1.5.1.2 ClientSuppliedTargetName
+// == NULL branch. It is not the same as omitting the pair.
+// serverPairs must be the already-parsed server TargetInfo. It is passed in
+// rather than re-parsed so there is exactly one parse of the buffer per
+// exchange and no way for two parses to disagree.
+func transformTargetInfo(serverPairs []avPair, cbt [16]byte, withMIC bool) ([]byte, error) {
+	pairs := make([]avPair, len(serverPairs))
+	copy(pairs, serverPairs)
+
+	var flags uint32
+	if existing, ok := findAVPair(pairs, avFlags); ok {
+		if len(existing) != 4 {
+			return nil, fmt.Errorf("ntlm: MsvAvFlags has %d bytes, expected 4", len(existing))
+		}
+		flags = binary.LittleEndian.Uint32(existing)
+	}
+	if withMIC {
+		flags |= avFlagMICPresent
+	}
+
+	encodedFlags := make([]byte, 4)
+	binary.LittleEndian.PutUint32(encodedFlags, flags)
+
+	pairs = upsertAVPair(pairs, avFlags, encodedFlags)
+	pairs = upsertAVPair(pairs, avTargetName, []byte{})
+	pairs = upsertAVPair(pairs, avChannelBindings, cbt[:])
+
+	return serializeTargetInfo(pairs)
+}

--- a/pkg/auth/providers/common/ldap/ntlm/targetinfo.go
+++ b/pkg/auth/providers/common/ldap/ntlm/targetinfo.go
@@ -83,10 +83,7 @@ func parseTargetInfo(buf []byte) ([]avPair, error) {
 }
 
 // serializeTargetInfo encodes pairs followed by exactly one MsvAvEOL.
-//
-// An AV pair's length is a 16-bit field, so an oversized value is an error
-// rather than a truncation: a truncated length would produce a buffer that
-// re-parses into different pairs than the ones written.
+// An oversized value is an error, not a truncation (see putVarField).
 func serializeTargetInfo(pairs []avPair) ([]byte, error) {
 	size := 4
 	for _, p := range pairs {

--- a/pkg/auth/providers/common/ldap/ntlm/targetinfo_test.go
+++ b/pkg/auth/providers/common/ldap/ntlm/targetinfo_test.go
@@ -1,0 +1,255 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func encodeAVPairs(pairs ...avPair) []byte {
+	out := []byte{}
+	for _, p := range pairs {
+		out = binary.LittleEndian.AppendUint16(out, p.ID)
+		out = binary.LittleEndian.AppendUint16(out, uint16(len(p.Value)))
+		out = append(out, p.Value...)
+	}
+	return out
+}
+
+func eolTerminated(pairs ...avPair) []byte {
+	return append(encodeAVPairs(pairs...), 0x00, 0x00, 0x00, 0x00)
+}
+
+// mustParseTargetInfo is the bridge for tests that build a wire buffer but call
+// a function taking parsed pairs.
+func mustParseTargetInfo(t *testing.T, buf []byte) []avPair {
+	t.Helper()
+
+	pairs, err := parseTargetInfo(buf)
+	require.NoError(t, err)
+	return pairs
+}
+
+func TestParseTargetInfo(t *testing.T) {
+	t.Parallel()
+
+	buf := eolTerminated(
+		avPair{ID: avNbDomainName, Value: utf16LE("FOO")},
+		avPair{ID: avTimestamp, Value: make([]byte, 8)},
+	)
+
+	pairs, err := parseTargetInfo(buf)
+	require.NoError(t, err)
+	require.Len(t, pairs, 2, "the terminating EOL is not returned as a pair")
+	assert.Equal(t, avNbDomainName, pairs[0].ID)
+	assert.Equal(t, utf16LE("FOO"), pairs[0].Value)
+	assert.Equal(t, avTimestamp, pairs[1].ID)
+}
+
+func TestParseTargetInfoRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		buf  []byte
+	}{
+		{name: "empty", buf: nil},
+		{name: "missing eol", buf: encodeAVPairs(avPair{ID: avNbDomainName, Value: utf16LE("FOO")})},
+		{name: "truncated pair header", buf: []byte{0x02, 0x00, 0x06}},
+		{
+			name: "length past end",
+			buf:  []byte{0x02, 0x00, 0xFF, 0xFF, 0x41, 0x42},
+		},
+		{
+			name: "trailing bytes after eol",
+			buf:  append(eolTerminated(), 0x41),
+		},
+		{
+			name: "duplicate channel bindings",
+			buf: eolTerminated(
+				avPair{ID: avChannelBindings, Value: make([]byte, 16)},
+				avPair{ID: avChannelBindings, Value: make([]byte, 16)},
+			),
+		},
+		{
+			name: "duplicate flags",
+			buf: eolTerminated(
+				avPair{ID: avFlags, Value: []byte{0, 0, 0, 0}},
+				avPair{ID: avFlags, Value: []byte{2, 0, 0, 0}},
+			),
+		},
+		{
+			name: "duplicate target name",
+			buf: eolTerminated(
+				avPair{ID: avTargetName, Value: utf16LE("a")},
+				avPair{ID: avTargetName, Value: utf16LE("b")},
+			),
+		},
+		{
+			name: "duplicate timestamp",
+			buf: eolTerminated(
+				avPair{ID: avTimestamp, Value: make([]byte, 8)},
+				avPair{ID: avTimestamp, Value: make([]byte, 8)},
+			),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseTargetInfo(test.buf)
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestParseTargetInfoAllowsDuplicateUnknownPairs(t *testing.T) {
+	t.Parallel()
+
+	buf := eolTerminated(
+		avPair{ID: avDNSComputerName, Value: utf16LE("dc1")},
+		avPair{ID: avDNSComputerName, Value: utf16LE("dc2")},
+	)
+
+	pairs, err := parseTargetInfo(buf)
+	require.NoError(t, err)
+	assert.Len(t, pairs, 2)
+}
+
+func TestTransformTargetInfoUpserts(t *testing.T) {
+	t.Parallel()
+
+	cbt := [16]byte{0xAA, 0xBB}
+	server := mustParseTargetInfo(t, eolTerminated(
+		avPair{ID: avNbDomainName, Value: utf16LE("FOO")},
+		avPair{ID: avTimestamp, Value: []byte{1, 2, 3, 4, 5, 6, 7, 8}},
+	))
+
+	got, err := transformTargetInfo(server, cbt, true)
+	require.NoError(t, err)
+
+	pairs, err := parseTargetInfo(got)
+	require.NoError(t, err)
+
+	counts := map[uint16]int{}
+	for _, p := range pairs {
+		counts[p.ID]++
+	}
+	assert.Equal(t, 1, counts[avChannelBindings])
+	assert.Equal(t, 1, counts[avTargetName])
+	assert.Equal(t, 1, counts[avFlags])
+	assert.Equal(t, 1, counts[avNbDomainName], "unmodified pairs are preserved")
+	assert.Equal(t, 1, counts[avTimestamp], "the server timestamp is preserved")
+
+	// The server's pairs keep their original order at the front.
+	assert.Equal(t, avNbDomainName, pairs[0].ID)
+	assert.Equal(t, utf16LE("FOO"), pairs[0].Value)
+	assert.Equal(t, avTimestamp, pairs[1].ID)
+
+	value, ok := findAVPair(pairs, avChannelBindings)
+	require.True(t, ok)
+	assert.Equal(t, cbt[:], value)
+
+	value, ok = findAVPair(pairs, avTargetName)
+	require.True(t, ok)
+	assert.Empty(t, value, "no SPN is supplied, so the target name is present with a zero length value")
+
+	value, ok = findAVPair(pairs, avFlags)
+	require.True(t, ok)
+	require.Len(t, value, 4)
+	flags := binary.LittleEndian.Uint32(value)
+	assert.Equal(t, avFlagMICPresent, flags&avFlagMICPresent, "the MIC present bit is set")
+	assert.Zero(t, flags&0x00000004, "the unverified target name bit is never set")
+
+	// Exactly one EOL, and it terminates the buffer.
+	assert.Equal(t, []byte{0, 0, 0, 0}, got[len(got)-4:])
+}
+
+func TestTransformTargetInfoWithoutMIC(t *testing.T) {
+	t.Parallel()
+
+	got, err := transformTargetInfo(nil, [16]byte{}, false)
+	require.NoError(t, err)
+
+	pairs, err := parseTargetInfo(got)
+	require.NoError(t, err)
+
+	value, ok := findAVPair(pairs, avFlags)
+	require.True(t, ok)
+	assert.Zero(t, binary.LittleEndian.Uint32(value)&avFlagMICPresent)
+}
+
+func TestTransformTargetInfoReplacesExistingPairs(t *testing.T) {
+	t.Parallel()
+
+	cbt := [16]byte{0x11}
+	server := mustParseTargetInfo(t, eolTerminated(
+		avPair{ID: avTargetName, Value: utf16LE("ldap/dc1.example.com")},
+		avPair{ID: avFlags, Value: []byte{0x01, 0x00, 0x00, 0x00}},
+		avPair{ID: avChannelBindings, Value: make([]byte, 16)},
+	))
+
+	got, err := transformTargetInfo(server, cbt, true)
+	require.NoError(t, err)
+
+	pairs, err := parseTargetInfo(got)
+	require.NoError(t, err)
+	require.Len(t, pairs, 3, "each pair is replaced in place, not duplicated")
+
+	value, _ := findAVPair(pairs, avTargetName)
+	assert.Empty(t, value)
+	value, _ = findAVPair(pairs, avChannelBindings)
+	assert.Equal(t, cbt[:], value)
+	value, _ = findAVPair(pairs, avFlags)
+	assert.Equal(t, uint32(0x01)|avFlagMICPresent, binary.LittleEndian.Uint32(value),
+		"existing flag bits are preserved and the MIC bit is added")
+}
+
+func TestSerializeTargetInfoRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	pairs := []avPair{
+		{ID: avNbDomainName, Value: utf16LE("FOO")},
+		{ID: avTargetName, Value: []byte{}},
+	}
+
+	encoded, err := serializeTargetInfo(pairs)
+	require.NoError(t, err)
+
+	got, err := parseTargetInfo(encoded)
+	require.NoError(t, err)
+	assert.Equal(t, pairs, got)
+}
+
+func TestSerializeTargetInfoRejectsAnOversizedValue(t *testing.T) {
+	t.Parallel()
+
+	_, err := serializeTargetInfo([]avPair{
+		{ID: avNbDomainName, Value: make([]byte, maxVarFieldLen+1)},
+	})
+	require.Error(t, err, "a 16-bit length cannot describe the value, so it must not be truncated")
+}
+
+func FuzzParseTargetInfo(f *testing.F) {
+	f.Add(eolTerminated(avPair{ID: avNbDomainName, Value: utf16LE("FOO")}))
+	f.Add([]byte{0, 0, 0, 0})
+	f.Add([]byte{})
+
+	f.Fuzz(func(t *testing.T, buf []byte) {
+		pairs, err := parseTargetInfo(buf)
+		if err != nil {
+			return
+		}
+		// A buffer that parses must re-serialize to the same bytes.
+		got, err := serializeTargetInfo(pairs)
+		if err != nil {
+			t.Fatalf("a buffer that parsed failed to re-serialize: %v", err)
+		}
+		if string(got) != string(buf) {
+			t.Fatalf("round trip changed the buffer: %x -> %x", buf, got)
+		}
+	})
+}

--- a/pkg/auth/providers/common/ldap/ntlm/wire.go
+++ b/pkg/auth/providers/common/ldap/ntlm/wire.go
@@ -1,0 +1,152 @@
+package ntlm
+
+import (
+	"encoding/binary"
+	"fmt"
+	"time"
+	"unicode/utf16"
+)
+
+const (
+	ntlmSignature = "NTLMSSP\x00"
+
+	messageTypeNegotiate    = 1
+	messageTypeChallenge    = 2
+	messageTypeAuthenticate = 3
+
+	// maxVarFieldLen is the largest payload an MS-NLMP security buffer can
+	// describe. The length is a 16-bit field, so anything larger cannot be
+	// represented and must be an error rather than a silent truncation.
+	maxVarFieldLen = 65535
+)
+
+// MS-NLMP 2.2.2.5 NEGOTIATE flags.
+const (
+	flagUnicode                 uint32 = 0x00000001
+	flagRequestTarget           uint32 = 0x00000004
+	flagNegotiateSign           uint32 = 0x00000010
+	flagNegotiateSeal           uint32 = 0x00000020
+	flagLMKey                   uint32 = 0x00000080
+	flagNTLM                    uint32 = 0x00000200
+	flagAlwaysSign              uint32 = 0x00008000
+	flagExtendedSessionSecurity uint32 = 0x00080000
+	flagTargetInfo              uint32 = 0x00800000
+	flagVersion                 uint32 = 0x02000000
+	flagKeyExch                 uint32 = 0x40000000
+)
+
+// baseFlags is the set Rancher offers regardless of layout. Signing and
+// sealing are omitted because the exchange always runs inside TLS, and key
+// exchange is omitted so the exported session key is the session base key.
+const baseFlags = flagUnicode |
+	flagRequestTarget |
+	flagNTLM |
+	flagAlwaysSign |
+	flagExtendedSessionSecurity |
+	flagTargetInfo
+
+// requiredChallengeFlags are the flags a CHALLENGE must return for this
+// package to answer it at all.
+//
+// REQUEST_TARGET is deliberately absent. MS-NLMP 2.2.2.5 defines it as a
+// request for the CHALLENGE TargetName; the channel binding token travels in
+// TargetInfo, which NEGOTIATE_TARGET_INFO governs. Refusing a challenge for
+// withholding REQUEST_TARGET would reject a server that is perfectly capable
+// of the bind. It stays in baseFlags as an offer and is simply not asserted
+// back if the server does not return it.
+const requiredChallengeFlags = flagUnicode |
+	flagNTLM |
+	flagExtendedSessionSecurity |
+	flagTargetInfo
+
+func (l layout) flags() uint32 {
+	if l.version {
+		return baseFlags | flagVersion
+	}
+	return baseFlags
+}
+
+// versionStructure is the MS-NLMP 2.2.2.10 VERSION field: Windows 6.1 build
+// 7601, NTLM revision 15. It is documented as debug information only. It is
+// sent because the AUTHENTICATE header is positional, and a MIC is only found
+// at its canonical offset when the version field precedes it.
+var versionStructure = [8]byte{0x06, 0x01, 0xB1, 0x1D, 0x00, 0x00, 0x00, 0x0F}
+
+// utf16LE encodes s as UTF-16 little-endian, the representation MS-NLMP uses
+// for every string field once NTLMSSP_NEGOTIATE_UNICODE is set.
+func utf16LE(s string) []byte {
+	codes := utf16.Encode([]rune(s))
+	out := make([]byte, 0, len(codes)*2)
+	for _, c := range codes {
+		out = binary.LittleEndian.AppendUint16(out, c)
+	}
+	return out
+}
+
+// fileTime converts t to a Windows FILETIME: 100-nanosecond intervals since
+// 1601-01-01 UTC.
+func fileTime(t time.Time) uint64 {
+	const unixToFiletimeSeconds = 11644473600
+	t = t.UTC()
+	seconds := t.Unix()
+	nanos := int64(t.Nanosecond())
+	intervals := (seconds+unixToFiletimeSeconds)*10000000 + nanos/100
+	return uint64(intervals)
+}
+
+// putVarField writes an MS-NLMP security buffer descriptor (length, maximum
+// length, payload offset) at dst.
+//
+// It errors rather than truncating. The length field is 16 bits while the
+// payloads it describes are built from server-supplied data, so an unchecked
+// cast would silently emit a message whose descriptors disagree with its
+// bytes — rejected by the domain controller as bad credentials, with nothing
+// on the client indicating why.
+func putVarField(dst []byte, length, offset int, name string) error {
+	if length < 0 || length > maxVarFieldLen {
+		return fmt.Errorf("ntlm: %s payload of %d bytes exceeds the %d byte security buffer limit", name, length, maxVarFieldLen)
+	}
+	binary.LittleEndian.PutUint16(dst[0:2], uint16(length))
+	binary.LittleEndian.PutUint16(dst[2:4], uint16(length))
+	binary.LittleEndian.PutUint32(dst[4:8], uint32(offset))
+	return nil
+}
+
+// layout selects which optional AUTHENTICATE header fields are present. The
+// header is positional, so the two flags move every payload offset and the MIC
+// with them.
+//
+// The shipping configuration is both true. The other three combinations exist
+// only so Task 8A can measure which one a real domain controller accepts; see
+// the deviation note at the top of the plan.
+type layout struct {
+	version bool
+	mic     bool
+}
+
+func (l layout) negotiateHeaderSize() int {
+	if l.version {
+		return 40
+	}
+	return 32
+}
+
+// micOffset is where the MIC begins, immediately after the version field when
+// one is present. Only meaningful when l.mic is set.
+func (l layout) micOffset() int {
+	if l.version {
+		return 72
+	}
+	return 64
+}
+
+func (l layout) authenticateHeaderSize() int {
+	size := 64
+	if l.version {
+		size += 8
+	}
+	if l.mic {
+		size += 16
+	}
+	return size
+}

--- a/pkg/auth/providers/common/ldap/ntlm/wire.go
+++ b/pkg/auth/providers/common/ldap/ntlm/wire.go
@@ -14,9 +14,8 @@ const (
 	messageTypeChallenge    = 2
 	messageTypeAuthenticate = 3
 
-	// maxVarFieldLen is the largest payload an MS-NLMP security buffer can
-	// describe. The length is a 16-bit field, so anything larger cannot be
-	// represented and must be an error rather than a silent truncation.
+	// maxVarFieldLen is the largest payload an MS-NLMP security buffer's
+	// 16-bit length field can describe.
 	maxVarFieldLen = 65535
 )
 
@@ -117,8 +116,8 @@ func putVarField(dst []byte, length, offset int, name string) error {
 // with them.
 //
 // The shipping configuration is both true. The other three combinations exist
-// only so Task 8A can measure which one a real domain controller accepts; see
-// the deviation note at the top of the plan.
+// only so withVersion and withMIC can measure which one a real domain
+// controller accepts during development.
 type layout struct {
 	version bool
 	mic     bool

--- a/pkg/client/generated/management/v3/zz_generated_active_directory_config.go
+++ b/pkg/client/generated/management/v3/zz_generated_active_directory_config.go
@@ -5,6 +5,7 @@ const (
 	ActiveDirectoryConfigFieldAccessMode                   = "accessMode"
 	ActiveDirectoryConfigFieldAllowedPrincipalIDs          = "allowedPrincipalIds"
 	ActiveDirectoryConfigFieldAnnotations                  = "annotations"
+	ActiveDirectoryConfigFieldBindMechanism                = "bindMechanism"
 	ActiveDirectoryConfigFieldCertificate                  = "certificate"
 	ActiveDirectoryConfigFieldConnectionTimeout            = "connectionTimeout"
 	ActiveDirectoryConfigFieldCreated                      = "created"
@@ -49,6 +50,7 @@ type ActiveDirectoryConfig struct {
 	AccessMode                   string            `json:"accessMode,omitempty" yaml:"accessMode,omitempty"`
 	AllowedPrincipalIDs          []string          `json:"allowedPrincipalIds,omitempty" yaml:"allowedPrincipalIds,omitempty"`
 	Annotations                  map[string]string `json:"annotations,omitempty" yaml:"annotations,omitempty"`
+	BindMechanism                string            `json:"bindMechanism,omitempty" yaml:"bindMechanism,omitempty"`
 	Certificate                  string            `json:"certificate,omitempty" yaml:"certificate,omitempty"`
 	ConnectionTimeout            int64             `json:"connectionTimeout,omitempty" yaml:"connectionTimeout,omitempty"`
 	Created                      string            `json:"created,omitempty" yaml:"created,omitempty"`


### PR DESCRIPTION
## Issue: #52891

## Problem

Active Directory domain controllers can enforce LDAP channel binding (LdapEnforceChannelBinding = Always). Under that policy the simple LDAP binds are rejected and authentication against the directory fails. A channel binding token can only be carried by an NTLM or Kerberos bind, and no available Go library produces one.

## Solution

The Active Directory provider gains an opt-in bindMechanism setting.
The default, simple, keeps the existing behavior unchanged.
The ntlm mechanism performs an NTLMv2 bind carrying an RFC 5929 `tls-server-end-point` channel binding token derived from the server certificate on each connection, and requires TLS or StartTLS.
The protocol messages are built by a new package that depends only on the standard library, validated against a Windows Server 2019 domain controller with enforcement on.

Every bind in the provider now dispatches on the configured mechanism from a single place.
A rejection caused by channel binding arrives from the directory as invalid credentials; it is recognized and reported with its likely causes instead of reading as a wrong password.
User principal names are not supported by NTLM and are refused before any
directory lookup.
Principal search reports these faults instead of returning an empty result, while every other failure keeps its historic handling.

### Note:

- Principal search and single-principal lookup can now return an error. Before, they always reported success, even when the search quietly found nothing because the bind had failed. They still do that for ordinary failures; only the two cases the domain controller rejected the channel binding, or rejected our message as malformed come back as errors now.
- The provider extended so it can be tested without a real directory server: two function fields that tests can swap out (one for opening the connection, one for loading the stored config), and five small functions split out of bigger ones so a test can reach them.
- When a bind fails for a reason worth explaining, the explanation goes in the error's message field, not in its cause field. Rancher's API error type logs the cause but never sends it to the caller, and the type cannot be unwrapped, so an explanation stored there would be invisible.
