### PR TITLE
Accept skipped checks in auto-approval

### DIFF
--- a/.github/workflows/auto-approve-bot-prs.yml
+++ b/.github/workflows/auto-approve-bot-prs.yml
@@ -93,7 +93,7 @@ jobs:
               echo "Could not read checks for PR #$pr_number."
               continue
             fi
-            if ! jq -e 'length > 0 and all(.[]; .bucket == "pass")' <<<"$check_buckets" >/dev/null; then
+            if ! jq -e 'length > 0 and all(.[]; .bucket == "pass" or .bucket == "skipping")' <<<"$check_buckets" >/dev/null; then
               echo "PR #$pr_number does not have all checks green."
               continue
             fi


### PR DESCRIPTION
Treat GitHub check bucket `skipping` as successful for Renovate PR eligibility while continuing to reject failed and pending checks.

Deal with prs like [this](https://github.com/rancher/rancher/pull/56847) where GitHub reports all checks passed but it is still not approved.