### PR TITLE
Fix mutable displayName vulnerability in Norman user store

### DIFF
--- a/pkg/auth/api/user/user_store.go
+++ b/pkg/auth/api/user/user_store.go
@@ -219,6 +219,7 @@ func (s *userStore) Update(apiContext *types.APIContext, schema *types.Schema, d
 
 	delete(data, client.UserFieldPrincipalIDs)
 	delete(data, client.UserFieldUsername)
+	delete(data, client.UserFieldName)
 
 	return s.Store.Update(apiContext, schema, data, id)
 }

--- a/pkg/auth/api/user/user_store_test.go
+++ b/pkg/auth/api/user/user_store_test.go
@@ -65,13 +65,23 @@ func TestUpdateStripsIdentityFields(t *testing.T) {
 			wantPresent: map[string]interface{}{client.UserFieldDescription: "some user"},
 		},
 		{
-			name: "strips both identity fields",
+			name: "strips displayName",
+			data: map[string]interface{}{
+				client.UserFieldName:        "Updated Display Name",
+				client.UserFieldDescription: "some user",
+			},
+			wantAbsent:  []string{client.UserFieldName},
+			wantPresent: map[string]interface{}{client.UserFieldDescription: "some user"},
+		},
+		{
+			name: "strips all identity fields",
 			data: map[string]interface{}{
 				client.UserFieldPrincipalIDs: []interface{}{"local://u-abc"},
 				client.UserFieldUsername:     "admin",
+				client.UserFieldName:         "Updated Display Name",
 				client.UserFieldEnabled:      true,
 			},
-			wantAbsent:  []string{client.UserFieldPrincipalIDs, client.UserFieldUsername},
+			wantAbsent:  []string{client.UserFieldPrincipalIDs, client.UserFieldUsername, client.UserFieldName},
 			wantPresent: map[string]interface{}{client.UserFieldEnabled: true},
 		},
 		{


### PR DESCRIPTION
## Problem
Issue: #56787

A recent security review highlighted that the `displayName`, `username`, and `principalIds` fields for `/v3/users` must be strictly immutable post-creation. While a previous fix successfully enforced immutability for `username` and `principalIds` at the Norman store layer, `displayName` was omitted from the strip list, allowing users to modify it via the Norman API.

## Solution
This PR adds `client.UserFieldName` (`displayName`) to the mutation strip list within `pkg/auth/api/user/user_store.go`. Any incoming PUT requests attempting to modify the `displayName` field via the Norman API will now have the field silently stripped from the payload prior to database storage, enforcing strict immutability. 

Unit tests in `user_store_test.go` have also been updated to explicitly verify that the `displayName` field is stripped on update.

**Note:** This PR only addresses the Norman API path. The Kube-API Admission Webhook path will still require a separate patch in the `rancher/webhook` repository to enforce equivalent immutability.

## Testing
- [x] Unit tests updated and passing (`go test -v ./pkg/auth/api/user/`)
- **Manual Verification (Norman API):**
  1. Create a standard user.
  2. Attempt to update the user via the Norman API using `PUT /v3/users/<user-id>` containing `{"name": "New Display Name"}`.
  3. Verify that the API returns 200, but the `displayName` remains unchanged in the database.