### PR TITLE
[v2.15] Select the first Ready ACE control-plane node as kubeconfig current context

### DIFF
--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -668,8 +668,8 @@ func (s *Store) Create(
 						User:    clusterName,
 					})
 
-					if !isCurrentContextSet && currentContext == cluster.Name {
-						data.CurrentContext = nodeName // Set the current context to the first control plane node.
+					if !isCurrentContextSet && currentContext == cluster.Name && v3node.IsMachineReady(node) {
+						data.CurrentContext = nodeName // Set the current context to the first ready control plane node.
 						isCurrentContextSet = true
 					}
 				}

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -435,6 +435,12 @@ func TestStoreCreate(t *testing.T) {
 							Addresses: []corev1.NodeAddress{
 								{Type: corev1.NodeExternalIP, Address: "172.20.0.3"},
 							},
+							Conditions: []corev1.NodeCondition{
+								{
+									Type:   corev1.NodeReady,
+									Status: corev1.ConditionTrue,
+								},
+							},
 						},
 					},
 				},
@@ -1452,6 +1458,230 @@ func TestStoreCreate(t *testing.T) {
 		require.Len(t, tokenManager.clusterTokenKeys, 1)
 
 		assert.Equal(t, "downstream2-cp", config.CurrentContext)
+	})
+	t.Run("select first ready control plane node as current context", func(t *testing.T) {
+		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		})
+
+		var configMap *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			configMap.CreationTimestamp = metav1.NewTime(time.Now())
+			configMap.Name = names.SimpleNameGenerator.GenerateName(configMap.GenerateName)
+			return configMap, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			return configMap, nil
+		}).Times(1)
+
+		tokenManager := &fakeTokenManager{}
+
+		nodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
+		nodeCache.EXPECT().List(downstream2, labels.Everything()).Return([]*v3.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "cp1"},
+				Spec: v3.NodeSpec{
+					RequestedHostname: "cp1",
+					ControlPlane:      true,
+				},
+				Status: v3.NodeStatus{
+					InternalNodeStatus: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeExternalIP,
+								Address: "172.20.0.3",
+							},
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionUnknown,
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "cp2"},
+				Spec: v3.NodeSpec{
+					RequestedHostname: "cp2",
+					ControlPlane:      true,
+				},
+				Status: v3.NodeStatus{
+					InternalNodeStatus: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeExternalIP,
+								Address: "172.20.0.4",
+							},
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				},
+			},
+		}, nil).Times(1)
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters:            []string{downstream2},
+				IncludeDefaultEntry: ptr.To(false),
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.NoError(t, err)
+
+		created := obj.(*ext.Kubeconfig)
+		assert.Equal(t, StatusSummaryComplete, created.Status.Summary)
+
+		config, err := clientcmd.Load([]byte(created.Status.Value))
+		require.NoError(t, err)
+
+		assert.Equal(t, "downstream2-cp2", config.CurrentContext)
+	})
+	t.Run("fall back to proxy context when all control plane nodes are not ready", func(t *testing.T) {
+		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+			return authorizer.DecisionAllow, "", nil
+		})
+
+		var configMap *corev1.ConfigMap
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Create(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			configMap.CreationTimestamp = metav1.NewTime(time.Now())
+			configMap.Name = names.SimpleNameGenerator.GenerateName(configMap.GenerateName)
+			return configMap, nil
+		}).Times(1)
+		configMapClient.EXPECT().Update(gomock.Any()).DoAndReturn(func(obj *corev1.ConfigMap) (*corev1.ConfigMap, error) {
+			configMap = obj.DeepCopy()
+			return configMap, nil
+		}).Times(1)
+
+		tokenManager := &fakeTokenManager{}
+
+		nodeCache := fake.NewMockCacheInterface[*v3.Node](ctrl)
+		nodeCache.EXPECT().List(downstream2, labels.Everything()).Return([]*v3.Node{
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "cp1"},
+				Spec: v3.NodeSpec{
+					RequestedHostname: "cp1",
+					ControlPlane:      true,
+				},
+				Status: v3.NodeStatus{
+					InternalNodeStatus: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeExternalIP,
+								Address: "172.20.0.3",
+							},
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionUnknown,
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{Name: "cp2"},
+				Spec: v3.NodeSpec{
+					RequestedHostname: "cp2",
+					ControlPlane:      true,
+				},
+				Status: v3.NodeStatus{
+					InternalNodeStatus: corev1.NodeStatus{
+						Addresses: []corev1.NodeAddress{
+							{
+								Type:    corev1.NodeExternalIP,
+								Address: "172.20.0.4",
+							},
+						},
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				},
+			},
+		}, nil).Times(1)
+
+		store := &Store{
+			mcmEnabled:          true,
+			authorizer:          allowAuthorizer,
+			nsCache:             nsCache,
+			configMapClient:     configMapClient,
+			userCache:           userCache,
+			tokenStore:          tokenStore,
+			clusterCache:        clusterCache,
+			nodeCache:           nodeCache,
+			tokenMgr:            tokenManager,
+			getCACert:           func() string { return rancherCACert },
+			getDefaultTTL:       getDefaultTTL,
+			getServerURL:        getServerURL,
+			shouldGenerateToken: shouldGenerateToken,
+		}
+
+		ctx := request.WithUser(context.Background(), &k8suser.DefaultInfo{
+			Name: userID,
+			Extra: map[string][]string{
+				common.ExtraRequestTokenID: {authTokenID},
+			},
+		})
+
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters:            []string{downstream2},
+				IncludeDefaultEntry: ptr.To(false),
+			},
+		}
+
+		obj, err := store.Create(ctx, kubeconfig, nil, options)
+		require.NoError(t, err)
+
+		created := obj.(*ext.Kubeconfig)
+		assert.Equal(t, StatusSummaryComplete, created.Status.Summary)
+
+		config, err := clientcmd.Load([]byte(created.Status.Value))
+		require.NoError(t, err)
+
+		assert.Equal(t, "downstream2", config.CurrentContext)
+		assert.Contains(t, config.Contexts, "downstream2-cp1")
+		assert.Contains(t, config.Contexts, "downstream2-cp2")
 	})
 	t.Run("exclude default entry with mixed clusters", func(t *testing.T) {
 		allowAuthorizer := authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56749 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->

Backport of #56206
 
## Problem
This change updates kubeconfig generation for ACE clusters to select the first Ready control-plane node as the current context.

Previously, Rancher selected the first control-plane node returned by the node cache regardless of its readiness.
In environments with multiple control-plane nodes, this could result in the generated kubeconfig defaulting to an unavailable node even when another healthy control-plane node was available.


<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
With this change, Rancher now skips control-plane nodes that are not Ready and selects the first Ready node as the current context.

<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
