### PR TITLE
Do not send a scope parameter in the OIDC token exchange

### DIFF
--- a/pkg/auth/providers/oidc/oidc_provider.go
+++ b/pkg/auth/providers/oidc/oidc_provider.go
@@ -589,9 +589,7 @@ func (o *OpenIDCProvider) getUserInfoFromAuthCode(rw http.ResponseWriter, req *h
 	oauthConfig := ConfigToOauthConfig(provider.Endpoint(), config)
 	var verifier = provider.Verifier(&oidc.Config{ClientID: config.ClientID})
 
-	opts := []oauth2.AuthCodeOption{
-		oauth2.SetAuthURLParam("scope", strings.Join(oauthConfig.Scopes, " ")),
-	}
+	var opts []oauth2.AuthCodeOption
 
 	if config.PKCEMethod != "" {
 		pkceVerifier := getPKCEVerifier(req)

--- a/pkg/auth/providers/oidc/oidc_provider_test.go
+++ b/pkg/auth/providers/oidc/oidc_provider_test.go
@@ -1390,6 +1390,14 @@ func mockOIDCServer(listener net.Listener, resp oidcResponses) *http.Server {
 		w.Write([]byte(resp.user))
 	})
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
+		// The authorization_code grant has no scope parameter (RFC 6749,
+		// section 4.1.3). Reject it like RFC-strict providers do.
+		if r.FormValue("scope") != "" {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			w.Write([]byte(`{"error":"invalid_scope"}`))
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(resp.token)
 	})


### PR DESCRIPTION
## Issue:
https://github.com/rancher/rancher/issues/56987

## Problem
The generic OIDC provider sends a `scope` parameter with the authorization_code token exchange. RFC 6749 section 4.1.3 defines no such parameter, and RFC-strict providers reject the exchange with `invalid_scope`, so login fails after a successful authentication on the IdP.

## Solution
Drop the parameter from the exchange options. The scopes are already sent where they belong, on the authorization request.

## Testing
Repro steps in the issue are valid.

## Engineering Testing
### Manual Testing
Reproduced against an RFC-strict provider: login fails with `invalid_scope` before the change; replaying the same exchange without the parameter returns tokens.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: the mock OIDC server's token endpoint now rejects requests carrying a scope parameter, like RFC-strict providers do; every TestGetUserInfoFromAuthCode case fails without the fix.

## QA Testing Considerations
Login through generic OIDC and keycloak-oidc (shared code path), against a provider that tolerates the parameter (Keycloak) and one that rejects it.

### Regressions Considerations
A provider that requires scope on the token endpoint would break; RFC 6749 defines none, and the parameter has been sent since the provider's origin without documented need.

Existing / newly added automated tests that provide evidence there are no regressions:
* TestGetUserInfoFromAuthCode (all cases now exercise the strict token endpoint)
