### PR TITLE
OIDC Provider middleware fix

### DIFF
--- a/pkg/oidc/provider/configuration_test.go
+++ b/pkg/oidc/provider/configuration_test.go
@@ -1,23 +1,103 @@
 package provider
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
+	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 func TestOpenIDConfigurationEndpoint(t *testing.T) {
+	const redirectURI = "https://client.example/callback"
+	ctrl := gomock.NewController(t)
+	oidcClientCache := fake.NewMockNonNamespacedCacheInterface[*v3.OIDCClient](ctrl)
+	oidcClientCache.EXPECT().List(labels.Everything()).Return([]*v3.OIDCClient{
+		{
+			Spec: v3.OIDCClientSpec{
+				RedirectURIs: []string{redirectURI},
+			},
+		},
+	}, nil)
+	provider := Provider{
+		authHandler: &authorizeHandler{
+			oidcClientCache: oidcClientCache,
+		},
+	}
+	mux := http.NewServeMux()
+	provider.RegisterOIDCProviderHandles(mux)
 	rec := httptest.NewRecorder()
 	err := settings.ServerURL.Set("https://rancher.com")
 	assert.NoError(t, err)
 
-	openIDConfigurationEndpoint(rec, &http.Request{})
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "https://client.example/oidc/.well-known/openid-configuration", nil))
+
+	assertOpenIDConfigurationResponse(t, rec)
+	assert.Equal(t, http.Header{
+		"Access-Control-Allow-Methods": []string{"GET, POST"},
+		"Access-Control-Allow-Origin":  []string{redirectURI},
+		"Content-Type":                 []string{"application/json"},
+		"Referrer-Policy":              []string{"strict-origin-when-cross-origin"},
+		"Strict-Transport-Security":    []string{"max-age=31536000"},
+		"X-Content-Type-Options":       []string{"nosniff"},
+		"X-Frame-Options":              []string{"SAMEORIGIN"},
+	}, rec.Header())
+}
+
+func TestOpenIDConfigurationEndpointWithoutOIDCClients(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	oidcClientCache := fake.NewMockNonNamespacedCacheInterface[*v3.OIDCClient](ctrl)
+	oidcClientCache.EXPECT().List(labels.Everything()).Return(nil, nil)
+	err := settings.ServerURL.Set("https://rancher.com")
+	assert.NoError(t, err)
+
+	provider := Provider{
+		authHandler: &authorizeHandler{
+			oidcClientCache: oidcClientCache,
+		},
+	}
+	mux := http.NewServeMux()
+	provider.RegisterOIDCProviderHandles(mux)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/oidc/.well-known/openid-configuration", nil))
+
+	assertOpenIDConfigurationResponse(t, rec)
+	assert.Equal(t, http.Header{
+		// Does not contain Access-Control-Allow-Origin header because there are no OIDC clients configured.
+		"Access-Control-Allow-Methods": []string{"GET, POST"},
+		"Content-Type":                 []string{"application/json"},
+		"Referrer-Policy":              []string{"strict-origin-when-cross-origin"},
+		"Strict-Transport-Security":    []string{"max-age=31536000"},
+		"X-Content-Type-Options":       []string{"nosniff"},
+		"X-Frame-Options":              []string{"SAMEORIGIN"},
+	}, rec.Header())
+}
+
+func assertOpenIDConfigurationResponse(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
 
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
-	assert.JSONEq(t, `{"issuer":"https://rancher.com/oidc","authorization_endpoint":"https://rancher.com/oidc/authorize","token_endpoint":"https://rancher.com/oidc/token","userinfo_endpoint":"https://rancher.com/oidc/userinfo","jwks_uri":"https://rancher.com/oidc/.well-known/jwks.json","response_types_supported":["code"],"subject_types_supported":["public"],"id_token_signing_alg_values_supported":["RS256"],"code_challenge_methods_supported":["S256"],"scopes_supported":["openid","profile","offline_access"],"grant_types_supported":["authorization_code","refresh_token"]}`, strings.TrimSpace(rec.Body.String()))
+
+	var response OpenIDConfiguration
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+	assert.Equal(t, "https://rancher.com/oidc", response.Issuer)
+	assert.Equal(t, "https://rancher.com/oidc/authorize", response.AuthorizationEndpoint)
+	assert.Equal(t, "https://rancher.com/oidc/token", response.TokenEndpoint)
+	assert.Equal(t, "https://rancher.com/oidc/userinfo", response.UserInfoEndpoint)
+	assert.Equal(t, "https://rancher.com/oidc/.well-known/jwks.json", response.JWKSURI)
+	assert.Equal(t, []string{"code"}, response.ResponseTypesSupported)
+	assert.Equal(t, []string{"public"}, response.SubjectTypesSupported)
+	assert.Equal(t, []string{"RS256"}, response.IDTokenSigningAlgsValuesSupported)
+	assert.Equal(t, []string{"S256"}, response.CodeChallengeMethodsSupported)
+	assert.Equal(t, []string{"openid", "profile", "offline_access"}, response.ScopesSupported)
+	assert.Equal(t, []string{"authorization_code", "refresh_token"}, response.GrantTypesSupported)
 }

--- a/pkg/oidc/provider/jwks_test.go
+++ b/pkg/oidc/provider/jwks_test.go
@@ -3,6 +3,7 @@ package provider
 import (
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"net/http"
@@ -10,13 +11,16 @@ import (
 	"strings"
 	"testing"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	corecontrollers "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -154,6 +158,91 @@ func TestJWKSEndpoint(t *testing.T) {
 			assert.JSONEq(t, test.expectedBody, strings.TrimSpace(rec.Body.String()))
 		})
 	}
+}
+
+func TestJWKSEndpointHeaders(t *testing.T) {
+	const redirectURI = "https://client.example/callback"
+	ctrl := gomock.NewController(t)
+	oidcClientCache := fake.NewMockNonNamespacedCacheInterface[*v3.OIDCClient](ctrl)
+	oidcClientCache.EXPECT().List(labels.Everything()).Return([]*v3.OIDCClient{
+		{
+			Spec: v3.OIDCClientSpec{
+				RedirectURIs: []string{redirectURI},
+			},
+		},
+	}, nil)
+	provider := newJWKSRouteTestProvider(ctrl, oidcClientCache)
+	mux := http.NewServeMux()
+	provider.RegisterOIDCProviderHandles(mux)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "https://client.example/oidc/.well-known/jwks.json", nil))
+
+	assertJWKSResponse(t, rec)
+	assert.Equal(t, http.Header{
+		"Access-Control-Allow-Methods": []string{"GET, POST"},
+		"Access-Control-Allow-Origin":  []string{redirectURI},
+		"Content-Type":                 []string{"application/json"},
+		"Referrer-Policy":              []string{"strict-origin-when-cross-origin"},
+		"Strict-Transport-Security":    []string{"max-age=31536000"},
+		"X-Content-Type-Options":       []string{"nosniff"},
+		"X-Frame-Options":              []string{"SAMEORIGIN"},
+	}, rec.Header())
+}
+
+func TestJWKSEndpointWithoutOIDCClients(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	oidcClientCache := fake.NewMockNonNamespacedCacheInterface[*v3.OIDCClient](ctrl)
+	oidcClientCache.EXPECT().List(labels.Everything()).Return(nil, nil)
+	provider := newJWKSRouteTestProvider(ctrl, oidcClientCache)
+	mux := http.NewServeMux()
+	provider.RegisterOIDCProviderHandles(mux)
+	rec := httptest.NewRecorder()
+
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/oidc/.well-known/jwks.json", nil))
+
+	assertJWKSResponse(t, rec)
+	assert.Equal(t, http.Header{
+		// Does not contain Access-Control-Allow-Origin header because there are no OIDC clients configured.
+		"Access-Control-Allow-Methods": []string{"GET, POST"},
+		"Content-Type":                 []string{"application/json"},
+		"Referrer-Policy":              []string{"strict-origin-when-cross-origin"},
+		"Strict-Transport-Security":    []string{"max-age=31536000"},
+		"X-Content-Type-Options":       []string{"nosniff"},
+		"X-Frame-Options":              []string{"SAMEORIGIN"},
+	}, rec.Header())
+}
+
+func newJWKSRouteTestProvider(ctrl *gomock.Controller, oidcClientCache *fake.MockNonNamespacedCacheInterface[*v3.OIDCClient]) Provider {
+	secretCache := fake.NewMockCacheInterface[*v1.Secret](ctrl)
+	secretCache.EXPECT().Get(keySecretNamespace, keySecretName).Return(&v1.Secret{
+		Data: map[string][]byte{
+			"key.pub": []byte(publicKey),
+		},
+	}, nil)
+
+	return Provider{
+		jwksHandler: &jwksHandler{secretCache: secretCache},
+		authHandler: &authorizeHandler{
+			oidcClientCache: oidcClientCache,
+		},
+	}
+}
+
+func assertJWKSResponse(t *testing.T, rec *httptest.ResponseRecorder) {
+	t.Helper()
+
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "application/json", rec.Header().Get("Content-Type"))
+
+	var response JWKS
+	require.NoError(t, json.NewDecoder(rec.Body).Decode(&response))
+	require.Len(t, response.Keys, 1)
+	assert.Equal(t, "RSA", response.Keys[0].Kty)
+	assert.Equal(t, "sig", response.Keys[0].Use)
+	assert.Equal(t, "key", response.Keys[0].Kid)
+	assert.NotEmpty(t, response.Keys[0].N)
+	assert.Equal(t, "AQAB", response.Keys[0].E)
 }
 
 func TestGetSigningKey(t *testing.T) {

--- a/pkg/oidc/provider/provider.go
+++ b/pkg/oidc/provider/provider.go
@@ -95,7 +95,7 @@ func ensureNamespaceWithRetry(ctx context.Context, namespaceClient corecontrolle
 	})
 }
 
-// middleware adds security headers, and returns not found if there aren't any OIDCClients
+// middleware adds security and CORS headers.
 func (p *Provider) middleware(next http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Content-Type-Options", "nosniff")
@@ -103,16 +103,12 @@ func (p *Provider) middleware(next http.HandlerFunc) http.HandlerFunc {
 		w.Header().Set("Referrer-Policy", "strict-origin-when-cross-origin")
 		w.Header().Set("Strict-Transport-Security", "max-age=31536000")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST")
+
 		oidcClients, err := p.authHandler.oidcClientCache.List(labels.Everything())
 		if err != nil {
 			oidcerror.WriteError(oidcerror.ServerError, "failed to list OIDCCLients", http.StatusInternalServerError, w)
 			return
 		}
-		if len(oidcClients) == 0 {
-			oidcerror.WriteError(oidcerror.ServerError, "no OIDCClients configured", http.StatusInternalServerError, w)
-			return
-		}
-
 		for _, oidcClient := range oidcClients {
 			for _, redirectURI := range oidcClient.Spec.RedirectURIs {
 				url, err := url.Parse(redirectURI)

--- a/pkg/oidc/provider/provider_test.go
+++ b/pkg/oidc/provider/provider_test.go
@@ -2,15 +2,16 @@ package provider
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"k8s.io/apimachinery/pkg/labels"
-	"net/http"
-	"net/http/httptest"
-	"net/url"
-	"testing"
 )
 
 func TestMiddleware(t *testing.T) {
@@ -112,10 +113,8 @@ func TestMiddleware(t *testing.T) {
 				"Referrer-Policy":              []string{"strict-origin-when-cross-origin"},
 				"Strict-Transport-Security":    []string{"max-age=31536000"},
 				"Access-Control-Allow-Methods": []string{"GET, POST"},
-				"Content-Type":                 []string{"application/json"},
 			},
-			expectedCallNext: false,
-			expectedBody:     `{"error":"server_error","error_description":"no OIDCClients configured"}`,
+			expectedCallNext: true,
 		},
 	}
 


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/56837
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
The public API endpoints for the OIDC provider return 500 responses when there are no OIDC clients.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
This modifies the OIDC Provider middleware to not return a 500 when there are no OIDC Clients.

No Access-Control-Allow-Origin header is added in this case.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_