### PR TITLE
[main] Restore /etc/nsswitch.conf missing since SLES 16 bump

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -86,6 +86,9 @@ RUN /usr/bin/unshare --version && \
     /usr/bin/umount --version && \
     /usr/bin/nsenter --version
 
+# pkg/jailer expects /etc/nsswitch.conf; SLES 16 only ships it under /usr/etc.
+RUN cp /usr/etc/nsswitch.conf /etc/nsswitch.conf
+
 RUN useradd rancher && \
     groupadd jail-accessors && \
     usermod -aG jail-accessors rancher && \


### PR DESCRIPTION
## Summary
- `package/Dockerfile`'s `final` stage was bumped from `bci-micro:15.7` to `bci-micro:16.0` in #56732. SLES 16 ships its default `nsswitch.conf` under `/usr/etc/` instead of `/etc/` (usr-merge vendor-config convention); normally something like systemd-tmpfiles materializes the `/etc/` copy on first boot, but this image is built via an offline `zypper --installroot` chroot install with no init running, so that never happens. The result: `/etc/nsswitch.conf` is missing entirely from the shipped image.
- `pkg/jailer.CreateJail` shells out to `package/jailer.sh`, which does `cp /etc/nsswitch.conf /opt/jail/$NAME/etc/` under `set -e`. With the file missing, this fails outright: `[FATAL] error running the jail command: exit status 1`, crash-looping the Rancher pod on startup (any install that doesn't set `CATTLE_DEV_MODE`, which skips `CreateJail`'s real jailer.sh path entirely).
- Fix: after the chroot copy in the `base` stage, copy `/usr/etc/nsswitch.conf` to `/etc/nsswitch.conf` if the latter doesn't already exist.

Fixes #57014.

Verified locally:
```
$ docker buildx build --target server -f package/Dockerfile --load -t test .
$ docker run --rm --entrypoint /bin/bash test -c '/usr/bin/jailer.sh testjail; echo EXIT: $?'
EXIT: 0
```
Before this fix, the same repro fails with `cp: cannot stat '/etc/nsswitch.conf': No such file or directory` / `EXIT: 1`.