### PR TITLE
Inherited fleet rules reconciliation bug

### DIFF
--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -58,6 +58,7 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 		clusters:                management.Wrangler.Mgmt.Cluster(),
 		clusterManager:          clusterManager,
 		crClient:                management.Wrangler.RBAC.ClusterRole(),
+		crLister:                management.Wrangler.RBAC.ClusterRole().Cache(),
 		nsCache:                 management.Wrangler.Core.Namespace().Cache(),
 		rLister:                 management.Wrangler.RBAC.Role().Cache(),
 		rClient:                 management.Wrangler.RBAC.Role(),
@@ -73,6 +74,7 @@ type globalRoleLifecycle struct {
 	clusters                mgmtv3.ClusterClient
 	clusterManager          *clustermanager.Manager
 	crClient                wrbacv1.ClusterRoleClient
+	crLister                wrbacv1.ClusterRoleCache
 	nsCache                 wcorev1.NamespaceCache
 	rLister                 wrbacv1.RoleCache
 	rClient                 wrbacv1.RoleClient
@@ -147,6 +149,11 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, lo
 		Type: ClusterRoleExists,
 	}
 
+	grLabels := map[string]string{
+		globalRoleLabel: "true",
+		grOwnerLabel:    globalRole.Name,
+	}
+
 	desiredClusterRole := &rbacv1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: crName,
@@ -158,17 +165,12 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, lo
 					UID:        globalRole.UID,
 				},
 			},
-			Labels: map[string]string{
-				globalRoleLabel: "true",
-				grOwnerLabel:    globalRole.Name,
-			},
+			Labels: grLabels,
 		},
 		Rules: globalRole.Rules,
 	}
 
-	clusterRoles, err := gr.crClient.List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s,%s=true", grOwnerLabel, globalRole.Name, globalRoleLabel),
-	})
+	clusterRoles, err := gr.crLister.List(labels.SelectorFromSet(grLabels))
 	if err != nil {
 		err = fmt.Errorf("couldn't list ClusterRoles for globalRole %v: %w", globalRole.Name, err)
 		gr.status.AddCondition(localConditions, condition, FailedToReconcileClusterRole, err)
@@ -176,7 +178,7 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, lo
 	}
 
 	// Delete any ClusterRoles that were created for this GlobalRole but have the wrong name.
-	for _, clusterRole := range clusterRoles.Items {
+	for _, clusterRole := range clusterRoles {
 		if clusterRole.Name != crName {
 			if err := rbac.DeleteResource(clusterRole.Name, gr.crClient); err != nil {
 				err = fmt.Errorf("couldn't delete ClusterRole %v for globalRole %v: %w", clusterRole.Name, globalRole.Name, err)

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -167,7 +167,7 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, lo
 	}
 
 	clusterRoles, err := gr.crClient.List(metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s", grOwnerLabel, globalRole.Name),
+		LabelSelector: fmt.Sprintf("%s=%s,%s=true", grOwnerLabel, globalRole.Name, globalRoleLabel),
 	})
 	if err != nil {
 		err = fmt.Errorf("couldn't list ClusterRoles for globalRole %v: %w", globalRole.Name, err)

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler.go
@@ -58,7 +58,6 @@ func newGlobalRoleLifecycle(management *config.ManagementContext, clusterManager
 		clusters:                management.Wrangler.Mgmt.Cluster(),
 		clusterManager:          clusterManager,
 		crClient:                management.Wrangler.RBAC.ClusterRole(),
-		crLister:                management.Wrangler.RBAC.ClusterRole().Cache(),
 		nsCache:                 management.Wrangler.Core.Namespace().Cache(),
 		rLister:                 management.Wrangler.RBAC.Role().Cache(),
 		rClient:                 management.Wrangler.RBAC.Role(),
@@ -74,7 +73,6 @@ type globalRoleLifecycle struct {
 	clusters                mgmtv3.ClusterClient
 	clusterManager          *clustermanager.Manager
 	crClient                wrbacv1.ClusterRoleClient
-	crLister                wrbacv1.ClusterRoleCache
 	nsCache                 wcorev1.NamespaceCache
 	rLister                 wrbacv1.RoleCache
 	rClient                 wrbacv1.RoleClient
@@ -170,7 +168,9 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, lo
 		Rules: globalRole.Rules,
 	}
 
-	clusterRoles, err := gr.crLister.List(labels.SelectorFromSet(grLabels))
+	clusterRoles, err := gr.crClient.List(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(grLabels).String(),
+	})
 	if err != nil {
 		err = fmt.Errorf("couldn't list ClusterRoles for globalRole %v: %w", globalRole.Name, err)
 		gr.status.AddCondition(localConditions, condition, FailedToReconcileClusterRole, err)
@@ -178,7 +178,7 @@ func (gr *globalRoleLifecycle) reconcileGlobalRole(globalRole *v3.GlobalRole, lo
 	}
 
 	// Delete any ClusterRoles that were created for this GlobalRole but have the wrong name.
-	for _, clusterRole := range clusterRoles {
+	for _, clusterRole := range clusterRoles.Items {
 		if clusterRole.Name != crName {
 			if err := rbac.DeleteResource(clusterRole.Name, gr.crClient); err != nil {
 				err = fmt.Errorf("couldn't delete ClusterRole %v for globalRole %v: %w", clusterRole.Name, globalRole.Name, err)

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -151,6 +151,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 	type controllers struct {
 		crController *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]
+		crLister     *fake.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]
 	}
 	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}, "clusterRole")
 	tests := []struct {
@@ -164,7 +165,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "no changes to clusterRole",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{readPodCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -177,7 +178,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "clusterRole is updated",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{readConfigCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 			},
@@ -191,7 +192,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "update clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{readConfigCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
@@ -205,7 +206,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "create clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return(nil, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
@@ -219,7 +220,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "clusterRole is created",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return(nil, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -234,7 +235,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "missing grOwnerLabel in clusterRole triggers update",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingLabelCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{missingLabelCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingLabelCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -248,7 +249,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "missing OwnerReference in clusterRole triggers update",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingOwnerRefCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{missingOwnerRefCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingOwnerRefCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -262,9 +263,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "stale primary ClusterRole is deleted while Fleet backing ClusterRoles are retained",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(metav1.ListOptions{
-					LabelSelector: fmt.Sprintf("%s=%s,%s=true", grOwnerLabel, defaultGR.Name, globalRoleLabel),
-				}).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{staleNamedCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
@@ -279,13 +278,11 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "Fleet backing ClusterRoles are excluded from primary ClusterRole cleanup",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).DoAndReturn(func(options metav1.ListOptions) (*rbacv1.ClusterRoleList, error) {
-					selector, err := labels.Parse(options.LabelSelector)
-					require.NoError(t, err)
+				c.crLister.EXPECT().List(gomock.Any()).DoAndReturn(func(selector labels.Selector) ([]*rbacv1.ClusterRole, error) {
 					assert.False(t, selector.Matches(labels.Set{
 						grOwnerLabel: defaultGR.Name,
 					}), "Fleet backing ClusterRoles must be excluded from primary ClusterRole cleanup")
-					return &rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil
+					return []*rbacv1.ClusterRole{readPodCR.DeepCopy()}, nil
 				})
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -299,7 +296,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "stale-named ClusterRole already gone is not an error",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{staleNamedCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(notFoundErr)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
@@ -314,7 +311,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "deleting a stale-named ClusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{staleNamedCR.DeepCopy()}, nil)
 				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -327,7 +324,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "listing ClusterRoles fails",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
+				c.crLister.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
@@ -343,6 +340,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			controllers := controllers{
 				crController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl),
+				crLister:     fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl),
 			}
 			if test.setupControllers != nil {
 				test.setupControllers(controllers)
@@ -350,6 +348,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 			grLifecycle := globalRoleLifecycle{
 				crClient: controllers.crController,
+				crLister: controllers.crLister,
 				status:   status.NewStatus(),
 			}
 			localConditions := []metav1.Condition{}

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -151,7 +151,6 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 	type controllers struct {
 		crController *fake.MockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList]
-		crLister     *fake.MockNonNamespacedCacheInterface[*rbacv1.ClusterRole]
 	}
 	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterroles"}, "clusterRole")
 	tests := []struct {
@@ -165,7 +164,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "no changes to clusterRole",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{readPodCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -178,7 +177,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "clusterRole is updated",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{readConfigCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 			},
@@ -192,7 +191,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "update clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{readConfigCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readConfigCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readConfigCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
@@ -206,7 +205,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "create clusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
@@ -220,7 +219,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "clusterRole is created",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -235,7 +234,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "missing grOwnerLabel in clusterRole triggers update",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{missingLabelCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingLabelCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingLabelCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -249,7 +248,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "missing OwnerReference in clusterRole triggers update",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{missingOwnerRefCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*missingOwnerRefCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(missingOwnerRefCR.DeepCopy(), nil)
 				c.crController.EXPECT().Update(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -261,9 +260,9 @@ func TestReconcileGlobalRole(t *testing.T) {
 			},
 		},
 		{
-			name: "stale primary ClusterRole is deleted while Fleet backing ClusterRoles are retained",
+			name: "stale primary ClusterRole is deleted and the correct one is created",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{staleNamedCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
@@ -278,11 +277,19 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "Fleet backing ClusterRoles are excluded from primary ClusterRole cleanup",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).DoAndReturn(func(selector labels.Selector) ([]*rbacv1.ClusterRole, error) {
+				c.crController.EXPECT().List(gomock.Any()).DoAndReturn(func(options metav1.ListOptions) (*rbacv1.ClusterRoleList, error) {
+					selector, err := labels.Parse(options.LabelSelector)
+					require.NoError(t, err)
+					assert.True(t, selector.Matches(labels.Set{
+						grOwnerLabel:    defaultGR.Name,
+						globalRoleLabel: "true",
+					}), "selector must match when globalRoleLabel is present")
+
 					assert.False(t, selector.Matches(labels.Set{
-						grOwnerLabel: defaultGR.Name,
-					}), "Fleet backing ClusterRoles must be excluded from primary ClusterRole cleanup")
-					return []*rbacv1.ClusterRole{readPodCR.DeepCopy()}, nil
+						grOwnerLabel:       defaultGR.Name,
+						"some-other-label": "true",
+					}), "selector must not match without globalRoleLabel")
+					return &rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil
 				})
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
@@ -296,7 +303,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "stale-named ClusterRole already gone is not an error",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{staleNamedCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(notFoundErr)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
@@ -311,7 +318,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "deleting a stale-named ClusterRole fails",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRole{staleNamedCR.DeepCopy()}, nil)
+				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
@@ -324,7 +331,7 @@ func TestReconcileGlobalRole(t *testing.T) {
 		{
 			name: "listing ClusterRoles fails",
 			setupControllers: func(c controllers) {
-				c.crLister.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
+				c.crController.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("error"))
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  true,
@@ -340,7 +347,6 @@ func TestReconcileGlobalRole(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			controllers := controllers{
 				crController: fake.NewMockNonNamespacedControllerInterface[*rbacv1.ClusterRole, *rbacv1.ClusterRoleList](ctrl),
-				crLister:     fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRole](ctrl),
 			}
 			if test.setupControllers != nil {
 				test.setupControllers(controllers)
@@ -348,7 +354,6 @@ func TestReconcileGlobalRole(t *testing.T) {
 
 			grLifecycle := globalRoleLifecycle{
 				crClient: controllers.crController,
-				crLister: controllers.crLister,
 				status:   status.NewStatus(),
 			}
 			localConditions := []metav1.Condition{}

--- a/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrole_handler_test.go
@@ -260,12 +260,34 @@ func TestReconcileGlobalRole(t *testing.T) {
 			},
 		},
 		{
-			name: "stale-named ClusterRole is deleted and the correct one is created",
+			name: "stale primary ClusterRole is deleted while Fleet backing ClusterRoles are retained",
 			setupControllers: func(c controllers) {
-				c.crController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
+				c.crController.EXPECT().List(metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("%s=%s,%s=true", grOwnerLabel, defaultGR.Name, globalRoleLabel),
+				}).Return(&rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*staleNamedCR.DeepCopy()}}, nil)
 				c.crController.EXPECT().Delete(staleNamedCR.Name, &metav1.DeleteOptions{}).Return(nil)
 				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(nil, notFoundErr)
 				c.crController.EXPECT().Create(gomock.Any()).Return(readPodCR.DeepCopy(), nil)
+			},
+			globalRole: defaultGR.DeepCopy(),
+			wantError:  false,
+			condition: reducedCondition{
+				reason: ClusterRoleExists,
+				status: metav1.ConditionTrue,
+			},
+		},
+		{
+			name: "Fleet backing ClusterRoles are excluded from primary ClusterRole cleanup",
+			setupControllers: func(c controllers) {
+				c.crController.EXPECT().List(gomock.Any()).DoAndReturn(func(options metav1.ListOptions) (*rbacv1.ClusterRoleList, error) {
+					selector, err := labels.Parse(options.LabelSelector)
+					require.NoError(t, err)
+					assert.False(t, selector.Matches(labels.Set{
+						grOwnerLabel: defaultGR.Name,
+					}), "Fleet backing ClusterRoles must be excluded from primary ClusterRole cleanup")
+					return &rbacv1.ClusterRoleList{Items: []rbacv1.ClusterRole{*readPodCR.DeepCopy()}}, nil
+				})
+				c.crController.EXPECT().Get(gomock.Any(), gomock.Any()).Return(readPodCR.DeepCopy(), nil)
 			},
 			globalRole: defaultGR.DeepCopy(),
 			wantError:  false,

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -412,7 +412,9 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 		},
 	}
 
-	clusterRoleBindings, err := l.crbLister.List(labels.SelectorFromSet(grbLabels))
+	clusterRoleBindings, err := l.crbClient.List(metav1.ListOptions{
+		LabelSelector: labels.SelectorFromSet(grbLabels).String(),
+	})
 	if err != nil {
 		err = fmt.Errorf("couldn't list ClusterRoleBindings for globalRoleBinding %v: %w", globalRoleBinding.Name, err)
 		l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)
@@ -420,7 +422,7 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 	}
 
 	// Delete any ClusterRoleBindings that were created for this GlobalRoleBinding but have the wrong name.
-	for _, clusterRoleBinding := range clusterRoleBindings {
+	for _, clusterRoleBinding := range clusterRoleBindings.Items {
 		if clusterRoleBinding.Name != crbName {
 			if err := rbac.DeleteResource(clusterRoleBinding.Name, l.crbClient); err != nil {
 				err = fmt.Errorf("couldn't delete ClusterRoleBinding %v for globalRoleBinding %v: %w", clusterRoleBinding.Name, globalRoleBinding.Name, err)

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler.go
@@ -388,8 +388,8 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 	}
 	globalRoleBinding.Annotations[crbNameAnnotation] = crbName
 
-	grLabels := map[string]string{grbOwnerLabel: globalRoleBinding.Name}
-	maps.Copy(grLabels, globalRoleBindingLabel)
+	grbLabels := map[string]string{grbOwnerLabel: globalRoleBinding.Name}
+	maps.Copy(grbLabels, globalRoleBindingLabel)
 
 	desiredCRB := &rbacv1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
@@ -402,7 +402,7 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 					UID:        globalRoleBinding.UID,
 				},
 			},
-			Labels: grLabels,
+			Labels: grbLabels,
 		},
 		Subjects: []rbacv1.Subject{rbac.GetGRBSubject(globalRoleBinding)},
 		RoleRef: rbacv1.RoleRef{
@@ -412,7 +412,7 @@ func (l *globalRoleBindingLifecycle) reconcileGlobalRoleBinding(globalRoleBindin
 		},
 	}
 
-	clusterRoleBindings, err := l.crbLister.List(labels.SelectorFromSet(map[string]string{grbOwnerLabel: globalRoleBinding.Name}))
+	clusterRoleBindings, err := l.crbLister.List(labels.SelectorFromSet(grbLabels))
 	if err != nil {
 		err = fmt.Errorf("couldn't list ClusterRoleBindings for globalRoleBinding %v: %w", globalRoleBinding.Name, err)
 		l.status.AddCondition(localConditions, condition, failedToUpdateClusterRoleBinding, err)

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -644,6 +644,21 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			wantAnnotation: getCRBName("test-grb"),
 		},
 		{
+			name: "Fleet ClusterRoleBindings are excluded from primary ClusterRoleBinding cleanup",
+			setupControllers: func(c controllers) {
+				c.crbCache.EXPECT().List(gomock.Any()).DoAndReturn(func(selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+					assert.False(t, selector.Matches(labels.Set{
+						grbOwnerLabel: wrangler.SafeConcatName(testGRB.Name),
+					}), "Fleet ClusterRoleBindings must be excluded from primary ClusterRoleBinding cleanup")
+					return []*rbacv1.ClusterRoleBinding{expectedCRB.DeepCopy()}, nil
+				})
+				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(expectedCRB.DeepCopy(), nil)
+			},
+			inputObject:    testGRB.DeepCopy(),
+			wantError:      false,
+			wantAnnotation: getCRBName("test-grb"),
+		},
+		{
 			name: "stale-named ClusterRoleBinding already gone is not an error",
 			setupControllers: func(c controllers) {
 				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)

--- a/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
+++ b/pkg/controllers/management/auth/globalroles/globalrolebinding_handler_test.go
@@ -494,7 +494,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "create new clusterRoleBinding",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(&expectedCRB, nil)
 			},
@@ -505,7 +505,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "clusterRoleBinding creation fails",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(nil, fmt.Errorf("server unavailable"))
 			},
@@ -516,7 +516,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 			name: "clusterRoleBinding already exists no update needed",
 			setupControllers: func(c controllers) {
 				existingCRB := expectedCRB.DeepCopy()
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*existingCRB}}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 			},
 			inputObject:    testGRB.DeepCopy(),
@@ -534,7 +534,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 						APIGroup: rbacv1.GroupName,
 					},
 				}
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*existingCRB}}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				updatedCRB := expectedCRB.DeepCopy()
 				c.crbController.EXPECT().Update(updatedCRB).Return(updatedCRB, nil)
@@ -550,7 +550,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*existingCRB}}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
@@ -573,7 +573,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*existingCRB}}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
@@ -589,7 +589,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*existingCRB}}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("server unavailable"))
 			},
@@ -604,7 +604,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 					Name: "old-role",
 					Kind: clusterRoleKind,
 				}
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*existingCRB}}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				c.crbController.EXPECT().Delete(existingCRB.Name, &metav1.DeleteOptions{}).Return(nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(nil, fmt.Errorf("server unavailable"))
@@ -623,7 +623,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 						APIGroup: rbacv1.GroupName,
 					},
 				}
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{existingCRB}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*existingCRB}}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(existingCRB, nil)
 				updatedCRB := expectedCRB.DeepCopy()
 				c.crbController.EXPECT().Update(updatedCRB).Return(nil, fmt.Errorf("server unavailable"))
@@ -634,7 +634,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "stale-named ClusterRoleBinding is deleted and the correct one is created",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*staleNamedCRB.DeepCopy()}}, nil)
 				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
@@ -646,11 +646,19 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "Fleet ClusterRoleBindings are excluded from primary ClusterRoleBinding cleanup",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).DoAndReturn(func(selector labels.Selector) ([]*rbacv1.ClusterRoleBinding, error) {
+				c.crbController.EXPECT().List(gomock.Any()).DoAndReturn(func(options metav1.ListOptions) (*rbacv1.ClusterRoleBindingList, error) {
+					selector, err := labels.Parse(options.LabelSelector)
+					require.NoError(t, err)
+					assert.True(t, selector.Matches(labels.Set{
+						grbOwnerLabel: testGRB.Name,
+						"authz.management.cattle.io/globalrolebinding": "true",
+					}), "selector must match when globalRoleBindingLabel is present")
+
 					assert.False(t, selector.Matches(labels.Set{
-						grbOwnerLabel: wrangler.SafeConcatName(testGRB.Name),
-					}), "Fleet ClusterRoleBindings must be excluded from primary ClusterRoleBinding cleanup")
-					return []*rbacv1.ClusterRoleBinding{expectedCRB.DeepCopy()}, nil
+						grbOwnerLabel:      testGRB.Name,
+						"some-other-label": "true",
+					}), "selector must not match without globalRoleBindingLabel")
+					return &rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*expectedCRB.DeepCopy()}}, nil
 				})
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(expectedCRB.DeepCopy(), nil)
 			},
@@ -661,7 +669,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "stale-named ClusterRoleBinding already gone is not an error",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*staleNamedCRB.DeepCopy()}}, nil)
 				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(apierrors.NewNotFound(schema.GroupResource{Group: "rbac.authorization.k8s.io", Resource: "clusterrolebindings"}, staleNamedCRB.Name))
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				c.crbController.EXPECT().Create(expectedCRB.DeepCopy()).Return(expectedCRB.DeepCopy(), nil)
@@ -673,7 +681,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "deleting a stale-named ClusterRoleBinding fails",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).Return([]*rbacv1.ClusterRoleBinding{staleNamedCRB.DeepCopy()}, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{Items: []rbacv1.ClusterRoleBinding{*staleNamedCRB.DeepCopy()}}, nil)
 				c.crbController.EXPECT().Delete(staleNamedCRB.Name, &metav1.DeleteOptions{}).Return(fmt.Errorf("server unavailable"))
 			},
 			inputObject: testGRB.DeepCopy(),
@@ -682,7 +690,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "listing ClusterRoleBindings fails",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("server unavailable"))
+				c.crbController.EXPECT().List(gomock.Any()).Return(nil, fmt.Errorf("server unavailable"))
 			},
 			inputObject: testGRB.DeepCopy(),
 			wantError:   true,
@@ -690,7 +698,7 @@ func TestReconcileGlobalRoleBinding(t *testing.T) {
 		{
 			name: "group principal binding",
 			setupControllers: func(c controllers) {
-				c.crbCache.EXPECT().List(gomock.Any()).Return(nil, nil)
+				c.crbController.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 				c.crbCache.EXPECT().Get(getCRBName("test-grb")).Return(nil, nil)
 				groupCRB := expectedCRB.DeepCopy()
 				groupCRB.Subjects = []rbacv1.Subject{
@@ -1350,12 +1358,12 @@ func Test_globalRoleBindingLifecycle_Create(t *testing.T) {
 		// reconcileGlobalRoleBinding: List existing ClusterRoleBindings owned by this GRB, then check if the
 		// correctly-named one already exists
 		crbLister := fake.NewMockNonNamespacedCacheInterface[*rbacv1.ClusterRoleBinding](ctrl)
-		crbLister.EXPECT().List(gomock.Any()).Return(nil, nil)
 		crbLister.EXPECT().Get(gomock.Any()).Return(nil, apierrors.NewNotFound(rbacv1.Resource("clusterrolebinding"), "test"))
 
 		// reconcileGlobalRoleBinding: Create a ClusterRoleBinding to bind the user to the GlobalRole's ClusterRole
 		// This grants the user global-level permissions (e.g., cluster management, global resource access)
 		crbClient := fake.NewMockNonNamespacedClientInterface[*rbacv1.ClusterRoleBinding, *rbacv1.ClusterRoleBindingList](ctrl)
+		crbClient.EXPECT().List(gomock.Any()).Return(&rbacv1.ClusterRoleBindingList{}, nil)
 		crbClient.EXPECT().Create(gomock.Any()).Return(&rbacv1.ClusterRoleBinding{}, nil)
 
 		// reconcileNamespacedRoleBindings: Look up namespaces referenced in the GlobalRole's NamespacedRules


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/57047
 
## Problem
When a global role with inherited fleet permissions is created, the cluster role used to provide those permissions is constantly being created and deleted. The same issue happens with the cluster role binding if you assign the GR to a user.
 
The global role reconciler lists cluster roles owned by this global role and then deletes any that don't use the right naming convention. The issue is that the fleet permission cluster roles are owned by the global role, but they have different names than expected.

## Solution
The fix is to use a more narrow list operation to select only the relevant cluster roles. The primary cluster role and the fleet cluster roles have ownership labels, but the primary cluster role also has the label `"authz.management.cattle.io/globalrole"=true` set which the fleet cluster roles do not have. By including this label in the check, we can ensure that only incorrect/old primary cluster roles get removed.

An alternative would be to modify the check to include the primary cluster role's name and the fleet cluster roles' names. While that would work, I prefer not to maintain a list of names.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
Create a global role with `inheritedFleetWorkspacePermissions` set and see that the logs are not spammed with deletions/creations of the cluster role. If you then bind the global role to a user, there is no log spam for cluster role binding deletions/creations.

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit

Summary: Added a new test to check that the list operation includes both labels, not just the ownership label. Also updated some other tests because the list is slightly different now.

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_