### PR TITLE
[main] Improve CI Testing workflow

### DIFF
--- a/.github/scripts/provisioning-test-scopes.yaml
+++ b/.github/scripts/provisioning-test-scopes.yaml
@@ -166,6 +166,7 @@ scopes:
         substrings:
           - 'CATTLE_SYSTEM_UPGRADE_CONTROLLER_CHART_VERSION'
           - 'CATTLE_K3S_VERSION'
+      - path: '^trigger-basic-ci$' # created by the 'Create CI Testing PR' workflow
     tests:
       - { dist: k3s, regex: '^Test_Provisioning_(SetA|Custom_SetA)_.*$', parallelism: 3 }
       - { dist: rke2, regex: '^Test_(General|Provisioning_SetA|Provisioning_Custom_SetA|Fleet)_.*$', parallelism: 3 }
@@ -179,6 +180,8 @@ scopes:
       - '^pkg/operations/'
       - '^tests/v2prov/tests/custom/'                 # also basic
       - '^tests/v2prov/tests/machineprovisioning/'    # also basic
+    file-paths:
+      - path: '^trigger-operations-ci$' # created by the 'Create CI Testing PR' workflow
     tests:
       - { dist: k3s,  regex: '^Test_Operation_.*$' } # k3s runs all ops in one instance. This shard is too heavily to parallelize at the moment.
       - { dist: rke2, regex: '^Test_Operation_SetA_.*$' }
@@ -192,6 +195,8 @@ scopes:
       - '^pkg/controllers/capr/etcdmgmt/'             # also operations
       - '^pkg/capr/configserver/'                     # also basic
       - '^tests/v2prov/tests/imported/'
+    file-paths:
+      - path: '^trigger-imported-ci$' # created by the 'Create CI Testing PR' workflow
     tests:
       - { dist: k3s,  regex: '^Test_Imported_Operation_SetD_(ImportedETCDSnapshotSave|ImportedETCDSnapshotRestore)$', cpus: 8 }
       - { dist: k3s,  regex: '^Test_Imported_Operation_SetD_(ImportedDisableSingleNode|ImportedDisableMultiNode)$', cpus: 8 }
@@ -202,6 +207,8 @@ scopes:
     package-paths:
       - '^pkg/provisioningv2/prebootstrap/'
       - '^tests/v2prov/tests/prebootstrap/'
+    file-paths:
+      - path: '^trigger-prebootstrap-ci$' # created by the 'Create CI Testing PR' workflow
     tests:
       - { dist: rke2, regex: '^Test_PreBootstrap_.*$', features: 'provisioningprebootstrap=true', cpus: 8 }
       - { dist: k3s,  regex: '^Test_PreBootstrap_.*$', features: 'provisioningprebootstrap=true', cpus: 8 }
@@ -231,7 +238,7 @@ full:
   - '^tests/v2prov/(clients|cluster|defaults|namespace|nodeconfig|objectstore|operations|registry|systemdnode|utils|wait)/' # framework (everything under tests/v2prov except 'tests/'. Individual tests are included in more specific scopes above)
   - '^scripts/provisioning-tests$'                    # the runner
   - '^\.github/workflows/provisioning-tests\.ya?ml$'
-  - '^trigger_ci$' # created by the 'Create CI Testing PR' workflow
+  - '^trigger-full-ci$' # created by the 'Create CI Testing PR' workflow
 
 # Mainly here for documentation, these directories are provisioning related but don't
 # actually have any existing test coverage in the provv2 test suite. They're listed here

--- a/.github/workflows/ci-testing-create-pr.yml
+++ b/.github/workflows/ci-testing-create-pr.yml
@@ -19,7 +19,10 @@ on:
         description: 'Patterns to exclude from failure detection (URL encode special chars: %2C for comma, %27 for single quote)'
         required: false
         default: 'Failed to save: Unable to reserve cache with key docker.io,Failed to restore: "/usr/bin/tar" failed with error: The process,echo "Error: Failed to load image from tarball!",H4sIAAAAAAAA'
-
+      provisioning_test_scope:
+        description: 'The desired scope (basic, operations, prebootstrap, imported, full) that should be run when executing the provisioning tests. An empty value is interpreted as "full".'
+        required: false
+        default: 'full'
 permissions:
   contents: write
   pull-requests: write
@@ -79,10 +82,22 @@ jobs:
       - name: Create and push empty commit
         env:
           BRANCH: ${{ steps.branch-setup.outputs.branch }}
+          PROVISIONING_TEST_SCOPE: ${{ inputs.provisioning_test_scope }}
+          SCOPES_CONFIG: .github/scripts/provisioning-test-scopes.yaml
         run: |
-          touch trigger_ci
-          git add trigger_ci
-          git commit -m "Add trigger_ci file for CI testing"
+          # identify the correct trigger file to create based on the requested provisioning scope
+          scope="${PROVISIONING_TEST_SCOPE:-full}"
+          [ "$scope" = "full" ] && paths_expr='.full' || paths_expr=".scopes.$scope.file-paths"
+          trigger_file="trigger-${scope}-ci"
+          expected_trigger_path="^${trigger_file}$"
+          if ! yq -r "${paths_expr}[] | (.path // .)" "$SCOPES_CONFIG" | grep -Fxq -- "$expected_trigger_path"; then
+            echo "Invalid or misconfigured scope '$scope' (no '$expected_trigger_path' entry in $SCOPES_CONFIG). Valid scopes: $(yq -r '.scopes | keys | join(" ")' "$SCOPES_CONFIG") full" >&2
+            exit 1
+          fi
+
+          touch "$trigger_file"
+          git add "$trigger_file"
+          git commit -m "Add ${trigger_file} file for CI testing"
           git push origin "$BRANCH"
 
       - name: Create draft PR

--- a/.github/workflows/retry-failed-jobs.yml
+++ b/.github/workflows/retry-failed-jobs.yml
@@ -39,7 +39,7 @@ jobs:
     if: >-
       github.event.workflow_run.name == 'Nightly Provisioning Tests' &&
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.event == 'schedule' &&
+      github.event.workflow_run.event == 'workflow_dispatch' &&
       github.event.workflow_run.run_attempt < 3
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Improves the 'Create CI Testing PR' to better integrate with the new provisioning test scopes work. A new input is introduced which lets you manually specify what scope should be executed during the test, allowing us to collect metrics on the stability of specific test scopes. 

This improvement comes with the minor cost of having to track a new file within each scope, which the 'Create CI Testing PR' will create to trigger the run. The CI testing workflow was updated to print an error message if the provided scope is invalid or if the appropriate file isn't tracked by that scope, so it should be pretty obvious when one is missing.

If we want even more flexibility in the future, the workflow could be further expanded to allow for users to specify a test matrix manually, without computing it from the pre-existing scopes. This would let us run any test combination we want, but would be cumbersome as (afaik) you would need to pass properly formatted json blobs.

---

This PR also fixes a problem with how the existing retry-failed-jobs workflow restarts the nightly provisioning test suite. The recent refactoring to support older release lines changed the github event from `schedule` to `workflow_dispatch`, so the latest nightly run didn't get restarted as expected. This PR updates that workflow to properly restart the nightly tests. This comes with a minor side effect of the workflow being restarted when initiated by the github UI. AFAIK there isn't a way to avoid this, as both the CLI and UI use the same event type. 