### PR TITLE
Treat a garbage-collected ConfigMap as a successful ext Kubeconfig delete

### DIFF
--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"net/url"
 	"reflect"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1105,6 +1106,29 @@ func (s *Store) secretOwnerRef(tokenName string) (metav1.OwnerReference, error) 
 	}, nil
 }
 
+// isTokenOwnerRef reports whether the owner reference names one of the given
+// tokens and is of a kind that backs a kubeconfig token: the Secret behind an
+// ext token, or a v3 Token recorded before the migration to ext tokens. The
+// garbage collector resolves both, so it deletes the ConfigMap once such an
+// owner is gone. An ext token's backing Secret is named after the token, and a
+// v3 Token owner reference names the token itself, so a token ID and its owner
+// reference name are the same string.
+func isTokenOwnerRef(ref metav1.OwnerReference, tokenIDs []string) bool {
+	isTokenKind := (ref.APIVersion == "v1" && ref.Kind == "Secret") ||
+		(ref.APIVersion == "management.cattle.io/v3" && ref.Kind == "Token")
+	return isTokenKind && slices.Contains(tokenIDs, ref.Name)
+}
+
+// ownedByToken reports whether one of the given tokens owns the ConfigMap.
+func ownedByToken(configMap *corev1.ConfigMap, tokenIDs []string) bool {
+	for _, ref := range configMap.OwnerReferences {
+		if isTokenOwnerRef(ref, tokenIDs) {
+			return true
+		}
+	}
+	return false
+}
+
 // getConfigMap retrieves a ConfigMap by name, optionally using the cache.
 func (s *Store) getConfigMap(name string, options *metav1.GetOptions, useCache bool) (*corev1.ConfigMap, error) {
 	var (
@@ -1441,8 +1465,7 @@ func printKubeconfig(kubeconfig *ext.Kubeconfig, options printers.GenerateOption
 
 	var ownedTokenCount int
 	for _, ref := range kubeconfig.OwnerReferences {
-		if (ref.Kind == "Secret" && ref.APIVersion == "v1") ||
-			(ref.Kind == "Token" && ref.APIVersion == "management.cattle.io/v3") {
+		if isTokenOwnerRef(ref, kubeconfig.Status.Tokens) {
 			ownedTokenCount++
 		}
 	}
@@ -1678,6 +1701,12 @@ func (s *Store) delete(
 	err := s.configMapClient.Delete(namespace, configMap.Name, options)
 	if err != nil {
 		mapped := mapBackingError(err, configMap.Name)
+		if apierrors.IsNotFound(mapped) && tokensDeleteAttempted && ownedByToken(configMap, kubeconfig.Status.Tokens) {
+			// Deleting the tokens above also lets the garbage collector remove the
+			// ConfigMap they own. If it did so before this call, the kubeconfig is
+			// already gone and the delete has succeeded.
+			return kubeconfig, true, nil
+		}
 		if apierrors.IsConflict(mapped) && tokensDeleteAttempted {
 			return nil, false, apierrors.NewConflict(gvr.GroupResource(), configMap.Name,
 				fmt.Errorf("%s; this attempt has already revoked the kubeconfig's tokens and the delete should be retried to remove the record", genericregistry.OptimisticLockErrorMsg))

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -3804,6 +3804,182 @@ func TestStoreDelete(t *testing.T) {
 		assert.Contains(t, err.Error(), "the object has been modified", "error must include the standard optimistic-lock message")
 		assert.Contains(t, err.Error(), "already revoked", "error must mention that tokens are already revoked")
 	})
+	t.Run("configmap already garbage-collected after token deletion reports success", func(t *testing.T) {
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["token-gone"]`
+		cm.OwnerReferences = append(cm.OwnerReferences, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       "token-gone",
+			UID:        uuid.NewUUID(),
+		})
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cm.Name),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		obj, deleted, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.NoError(t, err, "the garbage collector deleting the configmap must not surface as an error")
+		assert.True(t, deleted)
+		assert.Equal(t, kc, obj)
+	})
+	t.Run("configmap garbage-collected through a legacy token owner reports success", func(t *testing.T) {
+		// Kubeconfigs created before the migration to ext tokens are owned by a
+		// v3 Token, which the garbage collector follows just as well.
+		cm := configMap.DeepCopy()
+		tokenName := cm.OwnerReferences[0].Name
+		require.Equal(t, "Token", cm.OwnerReferences[0].Kind, "fixture must carry the legacy Token owner reference")
+		cm.Data[StatusTokensField] = `["` + tokenName + `"]`
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cm.Name),
+		).Times(1)
+
+		// A token that exists only as a v3 Token is not found in the ext store,
+		// which is what sends the delete down the v3 fallback.
+		extTokenStore := &fakeTokenStore{deleteFunc: func(name string, _ *metav1.DeleteOptions) error {
+			return apierrors.NewNotFound(gvr.GroupResource(), name)
+		}}
+		v3TokenClient := fake.NewMockNonNamespacedClientInterface[*v3.Token, *v3.TokenList](ctrl)
+		v3TokenClient.EXPECT().Delete(tokenName, gomock.Any()).Return(nil).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      extTokenStore,
+			v3Tokens:        v3TokenClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, deleted, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.NoError(t, err)
+		assert.True(t, deleted)
+	})
+	t.Run("configmap owned by an unrelated token reports not found", func(t *testing.T) {
+		// The owner is of the right kind but names a token this call did not
+		// delete, so it cannot have been collected on this call's account.
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["token-mine"]`
+		require.NotEqual(t, "token-mine", cm.OwnerReferences[0].Name)
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cm.Name),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err), "must be NotFound, got %v", err)
+	})
+	t.Run("configmap missing without a token owner reports not found", func(t *testing.T) {
+		// A kubeconfig that lists tokens but records no owner for them, because
+		// the owner reference could not be read when it was created, has nothing
+		// the garbage collector can act on. A missing ConfigMap there is
+		// somebody else's delete, not this one's.
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["token-unowned"]`
+		cm.OwnerReferences = nil
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cm.Name),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err), "must be NotFound, got %v", err)
+	})
+	t.Run("dry-run delete of a missing configmap reports not found", func(t *testing.T) {
+		// A dry run deletes no tokens, so nothing can have been collected and
+		// the success shortcut must not apply.
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["token-dry"]`
+		cm.OwnerReferences = append(cm.OwnerReferences, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       "token-dry",
+			UID:        uuid.NewUUID(),
+		})
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cm.Name),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{
+			DryRun: []string{metav1.DryRunAll},
+		})
+		require.Error(t, err)
+		assert.True(t, apierrors.IsNotFound(err), "must be NotFound, got %v", err)
+	})
+	t.Run("configmap missing without token deletion reports not found", func(t *testing.T) {
+		cm := configMap.DeepCopy()
+		require.NotContains(t, cm.Data, StatusTokensField, "fixture must list no tokens")
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Delete(namespace, cm.Name, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, cm.Name),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		kc, convErr := store.fromConfigMap(cm)
+		require.NoError(t, convErr)
+		_, _, err := store.delete(context.Background(), kc, cm, nil, &metav1.DeleteOptions{})
+		require.Error(t, err, "a kubeconfig with no tokens has no owner to be collected by")
+		assert.True(t, apierrors.IsNotFound(err), "must be NotFound, got %v", err)
+	})
 	t.Run("user can't delete other user's kubeconfig", func(t *testing.T) {
 		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
 		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).DoAndReturn(func(namespace, name string, options metav1.GetOptions) (*corev1.ConfigMap, error) {
@@ -4031,6 +4207,46 @@ func TestStoreDeleteCollection(t *testing.T) {
 		assert.Equal(t, kubeconfigID2, list.Items[0].Name)
 	})
 
+	t.Run("reports an item garbage-collected after its tokens were deleted", func(t *testing.T) {
+		deleteOptions := &metav1.DeleteOptions{}
+		listOptions := &metainternalversion.ListOptions{}
+
+		cm := configMap.DeepCopy()
+		cm.Data[StatusTokensField] = `["token-collected"]`
+		cm.OwnerReferences = append(cm.OwnerReferences, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "Secret",
+			Name:       "token-collected",
+			UID:        uuid.NewUUID(),
+		})
+
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().List(namespace, gomock.Any()).Return(&corev1.ConfigMapList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "2"},
+			Items:    []corev1.ConfigMap{*cm},
+		}, nil).Times(1)
+		configMapClient.EXPECT().Delete(namespace, kubeconfigID, gomock.Any()).Return(
+			apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, kubeconfigID),
+		).Times(1)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			tokenStore:      &fakeTokenStore{},
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		ctx := userContext(adminID, "")
+
+		obj, err := store.DeleteCollection(ctx, nil, deleteOptions, listOptions)
+		require.NoError(t, err)
+		require.IsType(t, &ext.KubeconfigList{}, obj)
+		list := obj.(*ext.KubeconfigList)
+		require.Len(t, list.Items, 1, "this call deleted the kubeconfig, so it belongs in the result")
+		assert.Equal(t, kubeconfigID, list.Items[0].Name)
+	})
+
 	t.Run("surfaces genuine error unchanged", func(t *testing.T) {
 		deleteOptions := &metav1.DeleteOptions{}
 		listOptions := &metainternalversion.ListOptions{}
@@ -4181,6 +4397,16 @@ func TestPrintKubeconfig(t *testing.T) {
 		assert.Equal(t, kubeconfig.Labels[UserIDLabel], row.Cells[5].(string))
 		assert.Equal(t, "c-m-tbgzfbgf,c-m-bxn2p7w6", row.Cells[6].(string))
 		assert.Equal(t, kubeconfig.Spec.Description, row.Cells[7].(string))
+	})
+	t.Run("owner reference for an unlisted token is not counted", func(t *testing.T) {
+		kubeconfig := kubeconfig.DeepCopy()
+		kubeconfig.OwnerReferences[0].Name = "kubeconfig-u-w7drcnotmine"
+
+		rows, err := printKubeconfig(kubeconfig, printers.GenerateOptions{})
+		require.NoError(t, err)
+		require.Len(t, rows, 1)
+		assert.Equal(t, "0/2", rows[0].Cells[2].(string),
+			"the count must agree with what delete treats as an owner")
 	})
 	t.Run("missing age and status", func(t *testing.T) {
 		kubeconfig := kubeconfig.DeepCopy()


### PR DESCRIPTION
## Issue: #57065 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

Deleting an ext Kubeconfig removes its token Secrets first and then the backing ConfigMap. The ConfigMap is owned by those Secrets, so the garbage collector can remove it in the gap between the two steps. When it wins, the ConfigMap delete returns NotFound and the caller gets a 404 for a delete that fully succeeded. The same race applies to kubeconfigs created before the ext token migration, whose ConfigMaps are owned by a v3.Token.
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

A NotFound from the ConfigMap delete is now reported as success when this call deleted tokens and the ConfigMap carried an owner reference naming one of them, of either the Secret or the v3.Token kind. Dry runs, kubeconfigs with no tokens, and ConfigMaps with no matching owner still return 404. The token count shown in table output applies the same ownership rule as the delete path. DeleteCollection lists the affected item in its result instead of skipping it.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests