### PR TITLE
[main] Adjust retries in v2 Prov tests

### DIFF
--- a/.github/workflows/ci-testing-create-pr.yml
+++ b/.github/workflows/ci-testing-create-pr.yml
@@ -117,7 +117,7 @@ jobs:
           echo "This PR is for CI testing purposes only and can be ignored." > pr_body.txt
           echo "" >> pr_body.txt
           echo "MAX_CI_ATTEMPTS: \`$MAX_ATTEMPTS\`" >> pr_body.txt
-          echo "PROVISIONING_TESTS_SCOPE: \`$PROVISIONING_TEST_SCOPE\`" >> pr_body.txt
+          echo "PROVISIONING_TESTS_SCOPE: \`$PROVISIONING_TESTS_SCOPE\`" >> pr_body.txt
 
           if [[ -n "$INCLUDE_PATTERNS" ]]; then
             echo "INCLUDE_PATTERNS: \`$INCLUDE_PATTERNS\`" >> pr_body.txt

--- a/.github/workflows/ci-testing-create-pr.yml
+++ b/.github/workflows/ci-testing-create-pr.yml
@@ -80,6 +80,7 @@ jobs:
           echo "branch=$BRANCH_NAME" >> $GITHUB_OUTPUT
 
       - name: Create and push empty commit
+        id: push
         env:
           BRANCH: ${{ steps.branch-setup.outputs.branch }}
           PROVISIONING_TEST_SCOPE: ${{ inputs.provisioning_test_scope }}
@@ -94,6 +95,8 @@ jobs:
             echo "Invalid or misconfigured scope '$scope' (no '$expected_trigger_path' entry in $SCOPES_CONFIG). Valid scopes: $(yq -r '.scopes | keys | join(" ")' "$SCOPES_CONFIG") full" >&2
             exit 1
           fi
+          
+          echo "provisioning_tests_scope=$scope" >> $GITHUB_OUTPUT
 
           touch "$trigger_file"
           git add "$trigger_file"
@@ -109,10 +112,12 @@ jobs:
           MAX_ATTEMPTS: ${{ inputs.max_ci_attempts }}
           BASE_BRANCH: ${{ steps.branch-setup.outputs.base_branch }}
           BRANCH: ${{ steps.branch-setup.outputs.branch }}
+          PROVISIONING_TESTS_SCOPE: ${{ steps.push.outputs.provisioning_tests_scope }}
         run: |
           echo "This PR is for CI testing purposes only and can be ignored." > pr_body.txt
           echo "" >> pr_body.txt
           echo "MAX_CI_ATTEMPTS: \`$MAX_ATTEMPTS\`" >> pr_body.txt
+          echo "PROVISIONING_TESTS_SCOPE: \`$PROVISIONING_TEST_SCOPE\`" >> pr_body.txt
 
           if [[ -n "$INCLUDE_PATTERNS" ]]; then
             echo "INCLUDE_PATTERNS: \`$INCLUDE_PATTERNS\`" >> pr_body.txt

--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -38,8 +38,8 @@ var (
 	// ensures that minor delays in the creation of RBAC resources don't fail
 	// tests, while also minimizing wait time.
 	DownstreamClientsetRetry = wait.Backoff{
-		Steps:    10,
-		Duration: 1 * time.Second,
+		Steps:    30,
+		Duration: 3 * time.Second,
 		Factor:   1.0,
 		Jitter:   0.1,
 	}

--- a/tests/v2prov/defaults/defaults.go
+++ b/tests/v2prov/defaults/defaults.go
@@ -33,4 +33,14 @@ var (
 		Factor:   1.0,
 		Jitter:   0.1,
 	}
+	// DownstreamClientsetRetry is a wait.Backoff dedicated to getting
+	// the downstream kubernetes clientset. The increased frequency
+	// ensures that minor delays in the creation of RBAC resources don't fail
+	// tests, while also minimizing wait time.
+	DownstreamClientsetRetry = wait.Backoff{
+		Steps:    10,
+		Duration: 1 * time.Second,
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
 )

--- a/tests/v2prov/operations/downstream_kc.go
+++ b/tests/v2prov/operations/downstream_kc.go
@@ -53,7 +53,7 @@ func GetAndVerifyDownstreamClientset(clients *clients.Clients, c *v1.Cluster) (*
 		return err
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to verify downstream clientset: %v", err)
+		return nil, fmt.Errorf("failed to verify downstream clientset: %w", err)
 	}
 
 	return clientset, nil

--- a/tests/v2prov/operations/downstream_kc.go
+++ b/tests/v2prov/operations/downstream_kc.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"context"
+	"fmt"
 
 	v1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
 	"github.com/rancher/rancher/pkg/controllers/dashboardapi/settings"
@@ -9,8 +10,8 @@ import (
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/rancher/rancher/tests/v2prov/clients"
 	"github.com/rancher/rancher/tests/v2prov/defaults"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
@@ -42,15 +43,17 @@ func GetAndVerifyDownstreamClientset(clients *clients.Clients, c *v1.Cluster) (*
 	if err != nil {
 		return nil, err
 	}
-	// Try to continuously get the kubernetes default service
-	err = retry.OnError(defaults.DownstreamRetry, func(err error) bool {
-		return !apierrors.IsForbidden(err)
+
+	// Try to continuously get the default kubernetes service
+	err = retry.OnError(defaults.DownstreamClientsetRetry, func(err error) bool {
+		logrus.Warnf("[GetAndVerifyDownstreamClientset] failed to get the default kubernetes service, will retry: %v", err)
+		return true
 	}, func() error {
 		_, err = clientset.CoreV1().Services(corev1.NamespaceDefault).Get(context.TODO(), "kubernetes", metav1.GetOptions{})
 		return err
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to verify downstream clientset: %v", err)
 	}
 
 	return clientset, nil

--- a/tests/v2prov/tests/autoscaler/autoscaling_provisioning_test.go
+++ b/tests/v2prov/tests/autoscaler/autoscaling_provisioning_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/operations"
 	"github.com/rancher/rancher/tests/v2prov/wait"
 	"github.com/rancher/wrangler/v3/pkg/name"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -223,7 +224,10 @@ func deployLoadPods(t *testing.T, kc *kubernetes.Clientset) {
 		},
 	}
 
-	err := retry.OnError(defaults.DownstreamRetry, func(error) bool { return true }, func() error {
+	err := retry.OnError(defaults.DownstreamRetry, func(err error) bool {
+		logrus.Warnf("[deployLoadPods] failed to get '%s' deployment in default workspace, will retry: %v", deploy.Name, err)
+		return true
+	}, func() error {
 		_, err := kc.AppsV1().Deployments("default").Create(context.TODO(), deploy, metav1.CreateOptions{})
 		return err
 	})

--- a/tests/v2prov/tests/machineprovisioning/machine_test.go
+++ b/tests/v2prov/tests/machineprovisioning/machine_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rancher/rancher/tests/v2prov/nodeconfig"
 	"github.com/rancher/rancher/tests/v2prov/operations"
 	"github.com/rancher/rancher/tests/v2prov/wait"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	errgroup2 "golang.org/x/sync/errgroup"
@@ -188,7 +189,10 @@ func Test_Provisioning_SetA_MP_MultipleEtcdNodesScaledDownThenDelete(t *testing.
 	}
 
 	// wait for all nodes to be ready
-	err = retry.OnError(defaults.DownstreamRetry, func(error) bool { return true }, func() error {
+	err = retry.OnError(defaults.DownstreamRetry, func(err error) bool {
+		logrus.Warnf("failed to get downstream nodes for cluster '%s', will retry: %v", c.Name, err)
+		return true
+	}, func() error {
 		nodes, err := kc.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
## Issue: https://github.com/rancher/rancher/issues/55231

## Problem

We're consistently seeing that the rke2 Test_Operation_SetA tests fail due to RBAC errors when building the downstream client set. This error occurs most often in the certificate rotation tests, after a downstream cluster has been provisioned and the certificate rotation operation has been completed. However, it has also been observed in some etcd restore test cases, albeit much less frequently. 

In a test of ~20 total CI runs, this issue was the cause of 10 failures out of a total of 13 failures. It's difficult to determine definitively if this is occurring more often on `main` or not, as the same tests on older release lines are failing due to etcd errors that have been resolved on main (though AFAIK I haven't seen this error on older release lines previously).

## Solution

This PR adds a new backoff that's used exclusively when getting the downstream clientset, and removes the retry check which previously exited when we hit an unauthorized error. While the existing default backoff could be used, it waits ~30 seconds before attempts, which is likely much longer than we really need to resolve this specific issue.

While I don't have a root cause for why these RBAC resources are not immediately available at the moment, this change should help **reduce** the test failures while ensuring we properly log when we encounter this error. _This is not a complete fix for the current issue._
 
## Testing

The [run](https://github.com/rancher/rancher/actions/runs/33896525506/job/101102427081?pr=57076#step:9:698) for this PR shows that the new log message is printed when this error is encountered, and that it is reattempted up to the new backoff limit.

## Engineering Testing
### Manual Testing

