### PR TITLE
Align SAML principalID creation from LDAP search with saml login

### DIFF
--- a/pkg/auth/providers/ldap/ldap_client.go
+++ b/pkg/auth/providers/ldap/ldap_client.go
@@ -489,9 +489,9 @@ func (p *ldapProvider) searchLdap(query string, scope string, config *v3.LdapCon
 					externalID = userLoginValues[0] // only support first
 				}
 			} else {
-				groupDNValues := ldap.GetAttributeValuesByName(entry.Attributes, config.GroupDNAttribute)
-				if len(groupDNValues) > 0 {
-					externalID = groupDNValues[0] // only support first
+				groupSearchValues := ldap.GetAttributeValuesByName(entry.Attributes, config.GroupSearchAttribute)
+				if len(groupSearchValues) > 0 {
+					externalID = groupSearchValues[0] // only support first
 				}
 			}
 		}

--- a/pkg/auth/providers/ldap/ldap_provider.go
+++ b/pkg/auth/providers/ldap/ldap_provider.go
@@ -366,7 +366,7 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 		filter := fmt.Sprintf(
 			"(&(%s=%s)(%s=%s))",
 			ObjectClass, ldap.SanitizeAttr(config.GroupObjectClass),
-			config.GroupDNAttribute, ldapv3.EscapeFilter(externalID),
+			ldap.SanitizeAttr(config.GroupSearchAttribute), ldapv3.EscapeFilter(externalID),
 		)
 
 		searchRequest = ldap.NewWholeSubtreeSearchRequest(
@@ -396,9 +396,9 @@ func (p *ldapProvider) samlSearchGetPrincipal(
 			externalID = userLoginValues[0] // only support first
 		}
 	} else {
-		groupDNValues := ldap.GetAttributeValuesByName(entry.Attributes, config.GroupDNAttribute)
-		if len(groupDNValues) > 0 {
-			externalID = groupDNValues[0] // only support first
+		groupSearchValues := ldap.GetAttributeValuesByName(entry.Attributes, config.GroupSearchAttribute)
+		if len(groupSearchValues) > 0 {
+			externalID = groupSearchValues[0] // only support first
 		}
 	}
 


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here --> #57084 
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem 
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 SAML provider with LDAP search stores group principal IDs in full DN format that don't match at login with short CN format provided by auth provider, so users of a group can't login and are left out with a 403 error 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->
 Align principal ID creation from LDAP search with how it is being used at SAML-client login, store the short group name / common name in auth-config
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
manually verified the fix, after the change the new groups added will be added with the short group name and users in that group get access correctly
```➜  rancher git:(saml-groupdn) ✗ kubectl get authconfig shibboleth -o yaml | yq '.allowedPrincipalIds'              
[
  "shibboleth_user://samladmin",
  "shibboleth_group://rancher2_consult"
]
```
### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_