### PR TITLE
Keep client-facing status codes on ext.Kubeconfig backing errors

### DIFF
--- a/pkg/ext/stores/kubeconfig/errors.go
+++ b/pkg/ext/stores/kubeconfig/errors.go
@@ -3,12 +3,12 @@ package kubeconfig
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 	registry "k8s.io/apiserver/pkg/registry/generic/registry"
 )
 
@@ -48,17 +48,24 @@ func mapBackingError(err error, resource string) error {
 		return rebuilt
 	case apierrors.IsInvalid(err):
 		logrus.Warnf("kubeconfig: invalid backing object for kubeconfig %s: %v", resource, err)
-		var errs field.ErrorList
-		if details := statusDetails(err); details != nil {
+		rebuilt := apierrors.NewInvalid(schema.GroupKind{Group: gvr.Group, Kind: Kind}, resource, nil)
+		if details := statusDetails(err); details != nil && len(details.Causes) > 0 {
+			// Causes are copied as-is: their messages are already rendered by
+			// the backing store, and an admission denial carries a cause with no
+			// Type or Field, which field.Error would render as an "unhandled
+			// error code" placeholder.
+			rebuilt.ErrStatus.Details.Causes = details.Causes
+			messages := make([]string, 0, len(details.Causes))
 			for _, c := range details.Causes {
-				errs = append(errs, &field.Error{
-					Type:   field.ErrorType(c.Type),
-					Field:  c.Field,
-					Detail: c.Message,
-				})
+				if c.Field != "" {
+					messages = append(messages, c.Field+": "+c.Message)
+				} else {
+					messages = append(messages, c.Message)
+				}
 			}
+			rebuilt.ErrStatus.Message += ": " + strings.Join(messages, ", ")
 		}
-		return apierrors.NewInvalid(schema.GroupKind{Group: gvr.Group, Kind: Kind}, resource, errs)
+		return rebuilt
 	case apierrors.IsBadRequest(err):
 		logrus.Warnf("kubeconfig: bad request on backing object for kubeconfig %s: %v", resource, err)
 		return apierrors.NewBadRequest(fmt.Sprintf("invalid request for kubeconfig %s", resource))

--- a/pkg/ext/stores/kubeconfig/errors.go
+++ b/pkg/ext/stores/kubeconfig/errors.go
@@ -102,6 +102,19 @@ func apiStatusOrInternalError(err error) error {
 	return apierrors.NewInternalError(err)
 }
 
+// validationError returns the status error carried by err, unwrapped, so an
+// admission decision keeps its code, and otherwise reports a plain validation
+// failure for the verb as a 400. The name is left out when not yet known.
+func validationError(err error, verb, name string) error {
+	if statusErr := asAPIStatus(err); statusErr != nil {
+		return statusErr
+	}
+	if name == "" {
+		return apierrors.NewBadRequest(fmt.Sprintf("%s validation failed for kubeconfig: %s", verb, err))
+	}
+	return apierrors.NewBadRequest(fmt.Sprintf("%s validation for kubeconfig %s failed: %s", verb, name, err))
+}
+
 // causeMessages renders status causes for a message, prefixing each with its
 // field when it has one.
 func causeMessages(causes []metav1.StatusCause) string {

--- a/pkg/ext/stores/kubeconfig/errors.go
+++ b/pkg/ext/stores/kubeconfig/errors.go
@@ -44,6 +44,7 @@ func mapBackingError(err error, resource string) error {
 		rebuilt := apierrors.NewForbidden(gvr.GroupResource(), resource, errors.New("backing store denied the request"))
 		if details := statusDetails(err); details != nil && len(details.Causes) > 0 {
 			rebuilt.ErrStatus.Details.Causes = details.Causes
+			rebuilt.ErrStatus.Message += ": " + causeMessages(details.Causes)
 		}
 		return rebuilt
 	case apierrors.IsInvalid(err):
@@ -55,15 +56,7 @@ func mapBackingError(err error, resource string) error {
 			// Type or Field, which field.Error would render as an "unhandled
 			// error code" placeholder.
 			rebuilt.ErrStatus.Details.Causes = details.Causes
-			messages := make([]string, 0, len(details.Causes))
-			for _, c := range details.Causes {
-				if c.Field != "" {
-					messages = append(messages, c.Field+": "+c.Message)
-				} else {
-					messages = append(messages, c.Message)
-				}
-			}
-			rebuilt.ErrStatus.Message += ": " + strings.Join(messages, ", ")
+			rebuilt.ErrStatus.Message += ": " + causeMessages(details.Causes)
 		}
 		return rebuilt
 	case apierrors.IsBadRequest(err):
@@ -85,14 +78,40 @@ func mapBackingError(err error, resource string) error {
 	}
 }
 
-// apiStatusOrInternalError returns the status error carried by err, unwrapped,
-// so a deliberate 4xx keeps its code, and wraps anything else as an
-// InternalError. Unwrapping matters: the apiserver derives the HTTP code with a
-// type switch and would report a wrapped status error as a 500.
+// asAPIStatus returns the status error carried anywhere in err's chain,
+// unwrapped, or nil when there is none. Unwrapping matters: the apiserver
+// derives the HTTP code with a type switch and would report a wrapped status
+// error as a 500.
+func asAPIStatus(err error) error {
+	var status apierrors.APIStatus
+	if !errors.As(err, &status) {
+		return nil
+	}
+	if statusErr, ok := status.(error); ok {
+		return statusErr
+	}
+	return nil
+}
+
+// apiStatusOrInternalError returns the status error carried by err so a
+// deliberate 4xx keeps its code, and wraps anything else as an InternalError.
 func apiStatusOrInternalError(err error) error {
-	var statusErr *apierrors.StatusError
-	if errors.As(err, &statusErr) {
+	if statusErr := asAPIStatus(err); statusErr != nil {
 		return statusErr
 	}
 	return apierrors.NewInternalError(err)
+}
+
+// causeMessages renders status causes for a message, prefixing each with its
+// field when it has one.
+func causeMessages(causes []metav1.StatusCause) string {
+	messages := make([]string, 0, len(causes))
+	for _, c := range causes {
+		if c.Field != "" {
+			messages = append(messages, c.Field+": "+c.Message)
+		} else {
+			messages = append(messages, c.Message)
+		}
+	}
+	return strings.Join(messages, ", ")
 }

--- a/pkg/ext/stores/kubeconfig/errors.go
+++ b/pkg/ext/stores/kubeconfig/errors.go
@@ -85,12 +85,14 @@ func mapBackingError(err error, resource string) error {
 	}
 }
 
-// apiStatusOrInternalError returns err unchanged when it already carries an
-// APIStatus (so a deliberate 4xx keeps its code) and wraps anything else as an
-// InternalError.
+// apiStatusOrInternalError returns the status error carried by err, unwrapped,
+// so a deliberate 4xx keeps its code, and wraps anything else as an
+// InternalError. Unwrapping matters: the apiserver derives the HTTP code with a
+// type switch and would report a wrapped status error as a 500.
 func apiStatusOrInternalError(err error) error {
-	if _, ok := err.(apierrors.APIStatus); ok {
-		return err
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr
 	}
 	return apierrors.NewInternalError(err)
 }

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -279,10 +279,7 @@ func (s *Store) Create(
 
 	if createValidation != nil {
 		if err := createValidation(ctx, obj); err != nil {
-			if statusErr := asAPIStatus(err); statusErr != nil {
-				return nil, statusErr
-			}
-			return nil, apierrors.NewBadRequest(fmt.Sprintf("create validation failed for kubeconfig: %s", err))
+			return nil, validationError(err, "create", "")
 		}
 	}
 
@@ -1542,10 +1539,7 @@ func (s *Store) DeleteCollection(
 		}
 		if deleteValidation != nil {
 			if err := deleteValidation(ctx, kubeconfig); err != nil {
-				if statusErr := asAPIStatus(err); statusErr != nil {
-					return nil, statusErr
-				}
-				return nil, apierrors.NewBadRequest(fmt.Sprintf("delete validation for kubeconfig %s failed: %s", configMap.Name, err))
+				return nil, validationError(err, "delete", configMap.Name)
 			}
 		}
 		// Pass nil deleteValidation: validation already ran above, so an IsNotFound
@@ -1650,12 +1644,8 @@ func (s *Store) delete(
 	options *metav1.DeleteOptions,
 ) (runtime.Object, bool, error) {
 	if deleteValidation != nil {
-		err := deleteValidation(ctx, kubeconfig)
-		if err != nil {
-			if statusErr := asAPIStatus(err); statusErr != nil {
-				return nil, false, statusErr
-			}
-			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("delete validation for kubeconfig %s failed: %s", configMap.Name, err))
+		if err := deleteValidation(ctx, kubeconfig); err != nil {
+			return nil, false, validationError(err, "delete", configMap.Name)
 		}
 	}
 
@@ -1769,12 +1759,8 @@ func (s *Store) Update(
 	}
 
 	if updateValidation != nil {
-		err = updateValidation(ctx, newKubeconfig, oldKubeconfig)
-		if err != nil {
-			if statusErr := asAPIStatus(err); statusErr != nil {
-				return nil, false, statusErr
-			}
-			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("update validation for kubeconfig %s failed: %s", name, err))
+		if err := updateValidation(ctx, newKubeconfig, oldKubeconfig); err != nil {
+			return nil, false, validationError(err, "update", name)
 		}
 	}
 

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -1129,7 +1129,8 @@ func ownedByToken(configMap *corev1.ConfigMap, tokenIDs []string) bool {
 	return false
 }
 
-// getConfigMap retrieves a ConfigMap by name, optionally using the cache.
+// getConfigMap retrieves a ConfigMap by name, optionally using the cache. Any
+// error is an [apierrors.APIStatus] scoped to the Kubeconfig resource.
 func (s *Store) getConfigMap(name string, options *metav1.GetOptions, useCache bool) (*corev1.ConfigMap, error) {
 	var (
 		configMap *corev1.ConfigMap
@@ -1142,10 +1143,7 @@ func (s *Store) getConfigMap(name string, options *metav1.GetOptions, useCache b
 		configMap, err = s.configMapClient.Get(namespace, name, *options)
 	}
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, apierrors.NewNotFound(gvr.GroupResource(), name)
-		}
-		return nil, fmt.Errorf("error getting configmap %s: %w", name, err)
+		return nil, mapBackingError(err, name)
 	}
 
 	if configMap.Labels[KindLabel] != KindLabelValue {
@@ -1751,7 +1749,9 @@ func (s *Store) Update(
 
 	newObj, err := objInfo.UpdatedObject(ctx, oldKubeconfig)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting updated object for kubeconfig %s: %v", name, err))
+		// For a PATCH the apiserver applies the patch and runs admission in
+		// here, so the error may already carry a client-facing status code.
+		return nil, false, apiStatusOrInternalError(err)
 	}
 
 	newKubeconfig, ok := newObj.(*ext.Kubeconfig)

--- a/pkg/ext/stores/kubeconfig/store.go
+++ b/pkg/ext/stores/kubeconfig/store.go
@@ -279,8 +279,8 @@ func (s *Store) Create(
 
 	if createValidation != nil {
 		if err := createValidation(ctx, obj); err != nil {
-			if _, ok := err.(apierrors.APIStatus); ok {
-				return nil, err
+			if statusErr := asAPIStatus(err); statusErr != nil {
+				return nil, statusErr
 			}
 			return nil, apierrors.NewBadRequest(fmt.Sprintf("create validation failed for kubeconfig: %s", err))
 		}
@@ -1542,8 +1542,8 @@ func (s *Store) DeleteCollection(
 		}
 		if deleteValidation != nil {
 			if err := deleteValidation(ctx, kubeconfig); err != nil {
-				if _, ok := err.(apierrors.APIStatus); ok {
-					return nil, err
+				if statusErr := asAPIStatus(err); statusErr != nil {
+					return nil, statusErr
 				}
 				return nil, apierrors.NewBadRequest(fmt.Sprintf("delete validation for kubeconfig %s failed: %s", configMap.Name, err))
 			}
@@ -1652,8 +1652,8 @@ func (s *Store) delete(
 	if deleteValidation != nil {
 		err := deleteValidation(ctx, kubeconfig)
 		if err != nil {
-			if _, ok := err.(apierrors.APIStatus); ok {
-				return nil, false, err
+			if statusErr := asAPIStatus(err); statusErr != nil {
+				return nil, false, statusErr
 			}
 			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("delete validation for kubeconfig %s failed: %s", configMap.Name, err))
 		}
@@ -1771,8 +1771,8 @@ func (s *Store) Update(
 	if updateValidation != nil {
 		err = updateValidation(ctx, newKubeconfig, oldKubeconfig)
 		if err != nil {
-			if _, ok := err.(apierrors.APIStatus); ok {
-				return nil, false, err
+			if statusErr := asAPIStatus(err); statusErr != nil {
+				return nil, false, statusErr
 			}
 			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("update validation for kubeconfig %s failed: %s", name, err))
 		}

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -2471,6 +2471,31 @@ func TestStoreGet(t *testing.T) {
 		assert.Equal(t, ext.KubeconfigResourceName, statusErr.Status().Details.Kind)
 		assert.Equal(t, "non-existing", statusErr.Status().Details.Name)
 	})
+
+	t.Run("backing forbidden keeps its status code and names the kubeconfig", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).Return(nil,
+			apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, kubeconfigID, errors.New("denied")))
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		obj, err := store.Get(ctx, kubeconfigID, &metav1.GetOptions{ResourceVersion: "1"})
+		require.Error(t, err)
+		require.Nil(t, obj)
+		assert.True(t, apierrors.IsForbidden(err), "backing 403 must stay 403, got %v", err)
+		assert.NotContains(t, err.Error(), "configmap")
+
+		statusErr, ok := err.(*apierrors.StatusError)
+		require.True(t, ok)
+		assert.Equal(t, gvr.Group, statusErr.Status().Details.Group)
+		assert.Equal(t, ext.KubeconfigResourceName, statusErr.Status().Details.Kind)
+		assert.Equal(t, kubeconfigID, statusErr.Status().Details.Name)
+	})
 }
 
 func TestStoreList(t *testing.T) {
@@ -3447,6 +3472,48 @@ func TestStoreUpdate(t *testing.T) {
 		assert.Equal(t, 1, updatedCount, "expected exactly one Updated condition, got %d", updatedCount)
 		assert.True(t, ts2.After(ts1.Time), "Updated condition LastTransitionTime must advance on each update (ts1=%v ts2=%v)", ts1, ts2)
 	})
+	t.Run("backing forbidden on get keeps its status code", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).Return(nil,
+			apierrors.NewForbidden(schema.GroupResource{Resource: "configmaps"}, kubeconfigID, errors.New("denied")))
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
+		require.NoError(t, err)
+		objInfo := &fakeUpdatedObjectInfo{obj: oldKubeconfig.DeepCopy()}
+
+		obj, isCreated, err := store.Update(userContext(userID, ""), kubeconfigID, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.False(t, isCreated)
+		assert.True(t, apierrors.IsForbidden(err), "backing 403 must stay 403, got %v", err)
+		assert.NotContains(t, err.Error(), "configmap")
+	})
+	t.Run("status error from updated object keeps its status code", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).Return(oldConfigMap.DeepCopy(), nil)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		objInfo := &fakeUpdatedObjectInfo{err: apierrors.NewBadRequest("malformed patch")}
+
+		obj, isCreated, err := store.Update(userContext(userID, ""), kubeconfigID, objInfo, nil, nil, false, &metav1.UpdateOptions{})
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.False(t, isCreated)
+		assert.True(t, apierrors.IsBadRequest(err), "patch 400 must stay 400, got %v", err)
+	})
 }
 
 func TestMapBackingError(t *testing.T) {
@@ -3546,6 +3613,21 @@ func TestMapBackingError(t *testing.T) {
 	assert.Equal(t, "kc-1", invalidDetails.Name)
 	require.NotEmpty(t, invalidDetails.Causes, "field-level causes must be preserved")
 	assert.Equal(t, "data.foo", invalidDetails.Causes[0].Field)
+
+	// A ValidatingAdmissionPolicy denial is an Invalid error whose single cause
+	// has no Type and no Field. The cause message must reach the client as
+	// written, not as apimachinery's "unhandled error code" placeholder.
+	denial := "ValidatingAdmissionPolicy 'block-delete' with binding 'block-delete' denied request: blocked"
+	admissionDenied := apierrors.NewInvalid(schema.GroupKind{Group: "core", Kind: "ConfigMap"}, "cc-x", nil)
+	admissionDenied.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: denial}}
+	gotDenied := mapBackingError(admissionDenied, "kc-1")
+	require.True(t, apierrors.IsInvalid(gotDenied), "admission denial must remain Invalid")
+	deniedStatus, ok := gotDenied.(apierrors.APIStatus)
+	require.True(t, ok)
+	assert.Contains(t, deniedStatus.Status().Message, denial)
+	assert.NotContains(t, deniedStatus.Status().Message, "unhandled error code")
+	require.Len(t, deniedStatus.Status().Details.Causes, 1)
+	assert.Equal(t, denial, deniedStatus.Status().Details.Causes[0].Message)
 
 	// R4-F2: wrapped status errors must be classified and have their details extracted
 	// the same as unwrapped ones; the Is* predicates see through wrapping, so statusDetails

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -1989,6 +1989,26 @@ func TestStoreCreate(t *testing.T) {
 		assert.Equal(t, string(tokensValue), stored.Data[StatusTokensField],
 			"the token must be recorded so deleting the kubeconfig still revokes it")
 	})
+	t.Run("wrapped status error from create validation keeps its status code", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		store := newStore(configMapClient, tokenStore, tokenManager)
+
+		kubeconfig := &ext.Kubeconfig{
+			Spec: ext.KubeconfigSpec{
+				Clusters:       []string{downstream1},
+				CurrentContext: downstream1,
+			},
+		}
+		createValidation := func(ctx context.Context, obj runtime.Object) error {
+			return fmt.Errorf("admission: %w", apierrors.NewForbidden(gvr.GroupResource(), "", errors.New("denied")))
+		}
+
+		obj, err := store.Create(userContext(userID, authTokenID), kubeconfig, createValidation, options)
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsForbidden(err), "wrapped 403 must stay 403, got %v", err)
+	})
+
 }
 
 func TestMergeConfigMap(t *testing.T) {
@@ -3514,6 +3534,31 @@ func TestStoreUpdate(t *testing.T) {
 		assert.False(t, isCreated)
 		assert.True(t, apierrors.IsBadRequest(err), "patch 400 must stay 400, got %v", err)
 	})
+	t.Run("wrapped status error from update validation keeps its status code", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, kubeconfigID, gomock.Any()).Return(oldConfigMap.DeepCopy(), nil)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+
+		oldKubeconfig, err := store.fromConfigMap(oldConfigMap)
+		require.NoError(t, err)
+		update := oldKubeconfig.DeepCopy()
+		update.Spec.Description = "updated"
+		updateValidation := func(ctx context.Context, obj, old runtime.Object) error {
+			return fmt.Errorf("admission: %w", apierrors.NewForbidden(gvr.GroupResource(), kubeconfigID, errors.New("denied")))
+		}
+
+		obj, _, err := store.Update(userContext(userID, ""), kubeconfigID, &fakeUpdatedObjectInfo{obj: update}, nil, updateValidation, false, &metav1.UpdateOptions{})
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsForbidden(err), "wrapped 403 must stay 403, got %v", err)
+	})
+
 }
 
 func TestAPIStatusOrInternalError(t *testing.T) {
@@ -3528,7 +3573,19 @@ func TestAPIStatusOrInternalError(t *testing.T) {
 	assert.True(t, apierrors.IsBadRequest(got), "wrapped 400 must stay 400, got %v", got)
 	assert.IsType(t, &apierrors.StatusError{}, got)
 
+	// Any APIStatus implementation counts, not only *StatusError, since the
+	// apiserver matches on the interface.
+	custom := &customStatusError{code: 409}
+	assert.Same(t, custom, apiStatusOrInternalError(fmt.Errorf("wrapped: %w", custom)))
+
 	assert.True(t, apierrors.IsInternalError(apiStatusOrInternalError(errors.New("boom"))))
+}
+
+type customStatusError struct{ code int32 }
+
+func (e *customStatusError) Error() string { return "custom" }
+func (e *customStatusError) Status() metav1.Status {
+	return metav1.Status{Status: metav1.StatusFailure, Code: e.code, Reason: metav1.StatusReasonConflict}
 }
 
 func TestMapBackingError(t *testing.T) {
@@ -3607,6 +3664,7 @@ func TestMapBackingError(t *testing.T) {
 	require.NotNil(t, forbiddenDetails)
 	require.NotEmpty(t, forbiddenDetails.Causes, "field-level causes must be preserved")
 	assert.Equal(t, "spec.cpu", forbiddenDetails.Causes[0].Field)
+	assert.Contains(t, forbiddenStatus.Status().Message, "spec.cpu: cpu quota exceeded", "cause text must reach the message")
 
 	// F4: Invalid backing error with field-level causes must propagate non-empty
 	// Details.Causes and the error must be re-scoped to the Kubeconfig GroupKind.
@@ -4138,6 +4196,26 @@ func TestStoreDelete(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{metav1.DryRunAll}, tokenDryRun, "token store must receive DryRun")
 	})
+	t.Run("wrapped status error from delete validation keeps its status code", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().Get(namespace, gomock.Any(), gomock.Any()).Return(configMap.DeepCopy(), nil)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+		deleteValidation := func(ctx context.Context, obj runtime.Object) error {
+			return fmt.Errorf("admission: %w", apierrors.NewConflict(gvr.GroupResource(), kubeconfigID, errors.New("busy")))
+		}
+
+		obj, _, err := store.Delete(userContext(adminID, ""), kubeconfigID, deleteValidation, &metav1.DeleteOptions{})
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsConflict(err), "wrapped 409 must stay 409, got %v", err)
+	})
+
 }
 
 func TestStoreDeleteCollection(t *testing.T) {
@@ -4444,6 +4522,29 @@ func TestStoreDeleteCollection(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{metav1.DryRunAll}, tokenDryRun, "token store must receive DryRun")
 	})
+	t.Run("wrapped status error from delete validation keeps its status code", func(t *testing.T) {
+		configMapClient := fake.NewMockClientInterface[*corev1.ConfigMap, *corev1.ConfigMapList](ctrl)
+		configMapClient.EXPECT().List(namespace, gomock.Any()).Return(&corev1.ConfigMapList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+			Items:    []corev1.ConfigMap{*configMap.DeepCopy()},
+		}, nil)
+
+		store := &Store{
+			authorizer:      commonAuthorizer,
+			configMapClient: configMapClient,
+			userCache:       userCache,
+			tokenMgr:        tokenManager,
+		}
+		deleteValidation := func(ctx context.Context, obj runtime.Object) error {
+			return fmt.Errorf("admission: %w", apierrors.NewConflict(gvr.GroupResource(), kubeconfigID, errors.New("busy")))
+		}
+
+		obj, err := store.DeleteCollection(userContext(adminID, ""), deleteValidation, &metav1.DeleteOptions{}, &metainternalversion.ListOptions{})
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.True(t, apierrors.IsConflict(err), "wrapped 409 must stay 409, got %v", err)
+	})
+
 }
 
 func TestPrintKubeconfig(t *testing.T) {

--- a/pkg/ext/stores/kubeconfig/store_test.go
+++ b/pkg/ext/stores/kubeconfig/store_test.go
@@ -3516,6 +3516,21 @@ func TestStoreUpdate(t *testing.T) {
 	})
 }
 
+func TestAPIStatusOrInternalError(t *testing.T) {
+	t.Parallel()
+
+	bad := apierrors.NewBadRequest("malformed")
+	assert.Same(t, bad, apiStatusOrInternalError(bad))
+
+	// A wrapped status error must come back unwrapped: the apiserver derives
+	// the HTTP code with a type switch and would treat the wrapper as a 500.
+	got := apiStatusOrInternalError(fmt.Errorf("validation: %w", bad))
+	assert.True(t, apierrors.IsBadRequest(got), "wrapped 400 must stay 400, got %v", got)
+	assert.IsType(t, &apierrors.StatusError{}, got)
+
+	assert.True(t, apierrors.IsInternalError(apiStatusOrInternalError(errors.New("boom"))))
+}
+
 func TestMapBackingError(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Issue: #57108 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The ext.Kubeconfig store loses or garbles the status of errors from its backing objects:

- A ValidatingAdmissionPolicy denial on the backing ConfigMap comes back as a 422 whose message reads `Internal error: unhandled error code: <unknown error "">: please report this` ahead of the policy's own text. The cause from the apiserver has no type, and rebuilding it as a field error produces the placeholder.
- A Forbidden backing error keeps its causes only in the status details, so kubectl never shows the policy text.
- Any ConfigMap read error other than NotFound is returned without a status code and surfaces as a 500 naming the ConfigMap. Affects Get, Update, and Delete.
- Errors from applying a PATCH or from admission during Update are rewrapped as a 500.
- A status error wrapped by a validation callback is not recognized and is rewrapped as a 400. The apiserver derives the HTTP code with a type switch, so even a wrapped status error returned as-is becomes a 500.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Causes from Invalid and Forbidden backing errors are copied as returned and folded into the message.
- ConfigMap read errors go through the same mapping as the other backing calls, so 403, 409, 429, and 503 keep their codes and the message names the ext.Kubeconfig.
- Status errors from the update path and from the create, update, delete, and collection delete validation callbacks are unwrapped and returned with their code. Any error carrying a status counts, not only the concrete status error type. Plain validation errors stay 400.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests
