### PR TITLE
Keep client-facing status codes on ext.Token backing errors

### DIFF
--- a/pkg/ext/stores/tokens/errors.go
+++ b/pkg/ext/stores/tokens/errors.go
@@ -43,6 +43,7 @@ func mapBackingError(err error, resource string) error {
 		rebuilt := apierrors.NewForbidden(GVR.GroupResource(), resource, errors.New("backing store denied the request"))
 		if details := statusDetails(err); details != nil && len(details.Causes) > 0 {
 			rebuilt.ErrStatus.Details.Causes = details.Causes
+			rebuilt.ErrStatus.Message += ": " + causeMessages(details.Causes)
 		}
 		return rebuilt
 	case apierrors.IsInvalid(err):
@@ -54,15 +55,7 @@ func mapBackingError(err error, resource string) error {
 			// Type or Field, which field.Error would render as an "unhandled
 			// error code" placeholder.
 			rebuilt.ErrStatus.Details.Causes = details.Causes
-			messages := make([]string, 0, len(details.Causes))
-			for _, c := range details.Causes {
-				if c.Field != "" {
-					messages = append(messages, c.Field+": "+c.Message)
-				} else {
-					messages = append(messages, c.Message)
-				}
-			}
-			rebuilt.ErrStatus.Message += ": " + strings.Join(messages, ", ")
+			rebuilt.ErrStatus.Message += ": " + causeMessages(details.Causes)
 		}
 		return rebuilt
 	case apierrors.IsBadRequest(err):
@@ -84,14 +77,40 @@ func mapBackingError(err error, resource string) error {
 	}
 }
 
-// apiStatusOrInternalError returns the status error carried by err, unwrapped,
-// so a deliberate 4xx keeps its code, and wraps anything else as an
-// InternalError. Unwrapping matters: the apiserver derives the HTTP code with a
-// type switch and would report a wrapped status error as a 500.
+// asAPIStatus returns the status error carried anywhere in err's chain,
+// unwrapped, or nil when there is none. Unwrapping matters: the apiserver
+// derives the HTTP code with a type switch and would report a wrapped status
+// error as a 500.
+func asAPIStatus(err error) error {
+	var status apierrors.APIStatus
+	if !errors.As(err, &status) {
+		return nil
+	}
+	if statusErr, ok := status.(error); ok {
+		return statusErr
+	}
+	return nil
+}
+
+// apiStatusOrInternalError returns the status error carried by err so a
+// deliberate 4xx keeps its code, and wraps anything else as an InternalError.
 func apiStatusOrInternalError(err error) error {
-	var statusErr *apierrors.StatusError
-	if errors.As(err, &statusErr) {
+	if statusErr := asAPIStatus(err); statusErr != nil {
 		return statusErr
 	}
 	return apierrors.NewInternalError(err)
+}
+
+// causeMessages renders status causes for a message, prefixing each with its
+// field when it has one.
+func causeMessages(causes []metav1.StatusCause) string {
+	messages := make([]string, 0, len(causes))
+	for _, c := range causes {
+		if c.Field != "" {
+			messages = append(messages, c.Field+": "+c.Message)
+		} else {
+			messages = append(messages, c.Message)
+		}
+	}
+	return strings.Join(messages, ", ")
 }

--- a/pkg/ext/stores/tokens/errors.go
+++ b/pkg/ext/stores/tokens/errors.go
@@ -101,6 +101,16 @@ func apiStatusOrInternalError(err error) error {
 	return apierrors.NewInternalError(err)
 }
 
+// validationError returns the status error carried by err, unwrapped, so an
+// admission decision keeps its code, and otherwise reports a plain validation
+// failure for the verb as a 400.
+func validationError(err error, verb string) error {
+	if statusErr := asAPIStatus(err); statusErr != nil {
+		return statusErr
+	}
+	return apierrors.NewBadRequest(fmt.Sprintf("error validating %s: %s", verb, err))
+}
+
 // causeMessages renders status causes for a message, prefixing each with its
 // field when it has one.
 func causeMessages(causes []metav1.StatusCause) string {

--- a/pkg/ext/stores/tokens/errors.go
+++ b/pkg/ext/stores/tokens/errors.go
@@ -84,12 +84,14 @@ func mapBackingError(err error, resource string) error {
 	}
 }
 
-// apiStatusOrInternalError returns err unchanged when it already carries an
-// APIStatus (so a deliberate 4xx keeps its code) and wraps anything else as an
-// InternalError.
+// apiStatusOrInternalError returns the status error carried by err, unwrapped,
+// so a deliberate 4xx keeps its code, and wraps anything else as an
+// InternalError. Unwrapping matters: the apiserver derives the HTTP code with a
+// type switch and would report a wrapped status error as a 500.
 func apiStatusOrInternalError(err error) error {
-	if _, ok := err.(apierrors.APIStatus); ok {
-		return err
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr
 	}
 	return apierrors.NewInternalError(err)
 }

--- a/pkg/ext/stores/tokens/errors.go
+++ b/pkg/ext/stores/tokens/errors.go
@@ -1,0 +1,95 @@
+package tokens
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	registry "k8s.io/apiserver/pkg/registry/generic/registry"
+)
+
+// statusDetails extracts the StatusDetails from an API error, seeing through
+// wrapping via errors.As so that wrapped status errors are handled the same as
+// direct ones.
+func statusDetails(err error) *metav1.StatusDetails {
+	var status apierrors.APIStatus
+	if !errors.As(err, &status) {
+		return nil
+	}
+	return status.Status().Details
+}
+
+// mapBackingError re-scopes an error from the backing Secret to the Token
+// GroupResource, preserving the apierrors classification so clients see
+// 404/409/403/422 instead of an opaque 500. Every branch rebuilds the error: a
+// backing error passed through verbatim would leak the backing resource's
+// identity in its details and message. Unexpected errors are logged at Error
+// level; client-side errors (Invalid, BadRequest) at Warn level.
+func mapBackingError(err error, resource string) error {
+	switch {
+	case err == nil:
+		return nil
+	case apierrors.IsNotFound(err):
+		return apierrors.NewNotFound(GVR.GroupResource(), resource)
+	case apierrors.IsConflict(err):
+		return apierrors.NewConflict(GVR.GroupResource(), resource,
+			errors.New(registry.OptimisticLockErrorMsg))
+	case apierrors.IsAlreadyExists(err):
+		return apierrors.NewAlreadyExists(GVR.GroupResource(), resource)
+	case apierrors.IsForbidden(err):
+		rebuilt := apierrors.NewForbidden(GVR.GroupResource(), resource, errors.New("backing store denied the request"))
+		if details := statusDetails(err); details != nil && len(details.Causes) > 0 {
+			rebuilt.ErrStatus.Details.Causes = details.Causes
+		}
+		return rebuilt
+	case apierrors.IsInvalid(err):
+		logrus.Warnf("tokens: invalid backing object for token %s: %v", resource, err)
+		rebuilt := apierrors.NewInvalid(GVK.GroupKind(), resource, nil)
+		if details := statusDetails(err); details != nil && len(details.Causes) > 0 {
+			// Causes are copied as-is: their messages are already rendered by
+			// the backing store, and an admission denial carries a cause with no
+			// Type or Field, which field.Error would render as an "unhandled
+			// error code" placeholder.
+			rebuilt.ErrStatus.Details.Causes = details.Causes
+			messages := make([]string, 0, len(details.Causes))
+			for _, c := range details.Causes {
+				if c.Field != "" {
+					messages = append(messages, c.Field+": "+c.Message)
+				} else {
+					messages = append(messages, c.Message)
+				}
+			}
+			rebuilt.ErrStatus.Message += ": " + strings.Join(messages, ", ")
+		}
+		return rebuilt
+	case apierrors.IsBadRequest(err):
+		logrus.Warnf("tokens: bad request on backing object for token %s: %v", resource, err)
+		return apierrors.NewBadRequest(fmt.Sprintf("invalid request for token %s", resource))
+	case apierrors.IsTooManyRequests(err):
+		var retryAfter int32
+		if details := statusDetails(err); details != nil {
+			retryAfter = details.RetryAfterSeconds
+		}
+		logrus.Warnf("tokens: backing store throttled for token %s: %v", resource, err)
+		return apierrors.NewTooManyRequests(fmt.Sprintf("too many requests for token %s", resource), int(retryAfter))
+	case apierrors.IsServiceUnavailable(err):
+		logrus.Warnf("tokens: backing store unavailable for token %s: %v", resource, err)
+		return apierrors.NewServiceUnavailable(fmt.Sprintf("backing store unavailable for token %s", resource))
+	default:
+		logrus.Errorf("tokens: backing store error for token %s: %v", resource, err)
+		return apierrors.NewInternalError(errors.New("error accessing backing object for token " + resource))
+	}
+}
+
+// apiStatusOrInternalError returns err unchanged when it already carries an
+// APIStatus (so a deliberate 4xx keeps its code) and wraps anything else as an
+// InternalError.
+func apiStatusOrInternalError(err error) error {
+	if _, ok := err.(apierrors.APIStatus); ok {
+		return err
+	}
+	return apierrors.NewInternalError(err)
+}

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -288,10 +288,7 @@ func (t *Store) Create(
 	options *metav1.CreateOptions) (runtime.Object, error) {
 	if createValidation != nil {
 		if err := createValidation(ctx, obj); err != nil {
-			if statusErr := asAPIStatus(err); statusErr != nil {
-				return nil, statusErr
-			}
-			return nil, apierrors.NewBadRequest(fmt.Sprintf("error validating create: %s", err))
+			return nil, validationError(err, "create")
 		}
 	}
 
@@ -404,10 +401,7 @@ func (t *Store) deleteCore(
 	// ensure that deletion is possible
 	if deleteValidation != nil {
 		if err := deleteValidation(ctx, token); err != nil {
-			if statusErr := asAPIStatus(err); statusErr != nil {
-				return nil, false, statusErr
-			}
-			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("error validating delete: %s", err))
+			return nil, false, validationError(err, "delete")
 		}
 	}
 
@@ -591,10 +585,7 @@ func (t *Store) Update(
 
 	if updateValidation != nil {
 		if err := updateValidation(ctx, newObj, oldToken); err != nil {
-			if statusErr := asAPIStatus(err); statusErr != nil {
-				return nil, false, statusErr
-			}
-			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("error validating update: %s", err))
+			return nil, false, validationError(err, "update")
 		}
 	}
 

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -349,8 +349,7 @@ func (t *Store) DeleteCollection(
 			if apierrors.IsNotFound(err) {
 				continue
 			}
-			return nil, apierrors.NewInternalError(fmt.Errorf("error deleting token %s: %w",
-				secret.Name, err))
+			return nil, apiStatusOrInternalError(err)
 		}
 
 		list.Items = append(list.Items, *token)
@@ -563,18 +562,9 @@ func (t *Store) Update(
 		return nil, false, err
 	}
 
-	oldSecret, err := t.secretCache.Get(TokenNamespace, name)
+	oldSecret, err := t.GetSecret(name, nil, true)
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			// Rethrow the NotFound error with the correct group and resource information.
-			return nil, false, apierrors.NewNotFound(GVR.GroupResource(), name)
-		}
-		return nil, false, fmt.Errorf("error getting secret for token %s: %w", name, err)
-	}
-
-	// validate that secret is indeed holding an ext token
-	if oldSecret.Labels[SecretKindLabel] != SecretKindLabelValue {
-		return nil, false, apierrors.NewNotFound(GVR.GroupResource(), name)
+		return nil, false, err // The err is already an [apierrors.APIStatus].
 	}
 
 	oldToken, err := fromSecret(oldSecret)
@@ -585,7 +575,9 @@ func (t *Store) Update(
 
 	newObj, err := objInfo.UpdatedObject(ctx, oldToken)
 	if err != nil {
-		return nil, false, apierrors.NewInternalError(fmt.Errorf("error getting updated object: %w", err))
+		// For a PATCH the apiserver applies the patch and runs admission in
+		// here, so the error may already carry a client-facing status code.
+		return nil, false, apiStatusOrInternalError(err)
 	}
 
 	newToken, ok := newObj.(*ext.Token)
@@ -762,11 +754,7 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 
 	newSecret, err := t.secretClient.Create(secret)
 	if err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			// note: should not be possible due to the forced use of generateName
-			return nil, err
-		}
-		return nil, apierrors.NewInternalError(fmt.Errorf("failed to store token: %w", err))
+		return nil, mapBackingError(err, GeneratePrefix)
 	}
 
 	// Read changes back to return what was truly created, not what we thought we created
@@ -793,19 +781,10 @@ func (t *SystemStore) Create(ctx context.Context, group schema.GroupResource, to
 	return newToken, nil
 }
 
-// Delete is the core deletion method to remove a single named token
+// Delete is the core deletion method to remove a single named token. Any
+// error is an [apierrors.APIStatus] scoped to the Token resource.
 func (t *SystemStore) Delete(name string, options *metav1.DeleteOptions) error {
-	err := t.secretClient.Delete(TokenNamespace, name, options)
-	if err == nil {
-		return nil
-	}
-	if apierrors.IsNotFound(err) {
-		// Convert not found for secret to not found for token
-		// Returned to match k8s behaviour for resource deletion
-		return apierrors.NewNotFound(GVR.GroupResource(), name)
-	}
-
-	return apierrors.NewInternalError(fmt.Errorf("failed to delete token %s: %w", name, err))
+	return mapBackingError(t.secretClient.Delete(TokenNamespace, name, options), name)
 }
 
 // DeleteCollection is an internal bulk deletion method for use by other parts of Rancher.
@@ -850,7 +829,8 @@ func (t *SystemStore) Get(name, authTokenID string, options *metav1.GetOptions) 
 	return token, nil
 }
 
-// GetSecret retrieves the backing secret for an ext token, optionally using the cache.
+// GetSecret retrieves the backing secret for an ext token, optionally using the
+// cache. Any error is an [apierrors.APIStatus] scoped to the Token resource.
 func (t *SystemStore) GetSecret(name string, options *metav1.GetOptions, useCache bool) (*corev1.Secret, error) {
 	var err error
 	var currentSecret *corev1.Secret
@@ -861,10 +841,7 @@ func (t *SystemStore) GetSecret(name string, options *metav1.GetOptions, useCach
 		currentSecret, err = t.secretClient.Get(TokenNamespace, name, *options)
 	}
 	if err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil, apierrors.NewNotFound(GVR.GroupResource(), name)
-		}
-		return nil, apierrors.NewInternalError(fmt.Errorf("failed to retrieve token %s: %w", name, err))
+		return nil, mapBackingError(err, name)
 	}
 
 	if currentSecret.Labels[SecretKindLabel] != SecretKindLabelValue {
@@ -1053,7 +1030,7 @@ func (t *SystemStore) update(authTokenID string, fullPermission bool, oldToken, 
 
 	newSecret, err := t.secretClient.Update(secret)
 	if err != nil {
-		return nil, apierrors.NewInternalError(fmt.Errorf("failed to save updated token: %w", err))
+		return nil, mapBackingError(err, token.Name)
 	}
 
 	// Read changes back to return what was truly saved, not what we thought we saved

--- a/pkg/ext/stores/tokens/tokens.go
+++ b/pkg/ext/stores/tokens/tokens.go
@@ -287,9 +287,11 @@ func (t *Store) Create(
 	createValidation rest.ValidateObjectFunc,
 	options *metav1.CreateOptions) (runtime.Object, error) {
 	if createValidation != nil {
-		err := createValidation(ctx, obj)
-		if err != nil {
-			return obj, err
+		if err := createValidation(ctx, obj); err != nil {
+			if statusErr := asAPIStatus(err); statusErr != nil {
+				return nil, statusErr
+			}
+			return nil, apierrors.NewBadRequest(fmt.Sprintf("error validating create: %s", err))
 		}
 	}
 
@@ -401,9 +403,11 @@ func (t *Store) deleteCore(
 
 	// ensure that deletion is possible
 	if deleteValidation != nil {
-		err := deleteValidation(ctx, token)
-		if err != nil {
-			return nil, false, err
+		if err := deleteValidation(ctx, token); err != nil {
+			if statusErr := asAPIStatus(err); statusErr != nil {
+				return nil, false, statusErr
+			}
+			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("error validating delete: %s", err))
 		}
 	}
 
@@ -586,8 +590,10 @@ func (t *Store) Update(
 	}
 
 	if updateValidation != nil {
-		err = updateValidation(ctx, newObj, oldToken)
-		if err != nil {
+		if err := updateValidation(ctx, newObj, oldToken); err != nil {
+			if statusErr := asAPIStatus(err); statusErr != nil {
+				return nil, false, statusErr
+			}
 			return nil, false, apierrors.NewBadRequest(fmt.Sprintf("error validating update: %s", err))
 		}
 	}

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -2491,6 +2491,21 @@ func TestSystemStoreDelete(t *testing.T) {
 	}
 }
 
+func TestAPIStatusOrInternalError(t *testing.T) {
+	t.Parallel()
+
+	bad := apierrors.NewBadRequest("malformed")
+	assert.Same(t, bad, apiStatusOrInternalError(bad))
+
+	// A wrapped status error must come back unwrapped: the apiserver derives
+	// the HTTP code with a type switch and would treat the wrapper as a 500.
+	got := apiStatusOrInternalError(fmt.Errorf("validation: %w", bad))
+	assert.True(t, apierrors.IsBadRequest(got), "wrapped 400 must stay 400, got %v", got)
+	assert.IsType(t, &apierrors.StatusError{}, got)
+
+	assert.True(t, apierrors.IsInternalError(apiStatusOrInternalError(errors.New("boom"))))
+}
+
 func TestSystemStoreAddLabel(t *testing.T) {
 	t.Run("add label", func(t *testing.T) {
 		ctrl := gomock.NewController(t)

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"testing"
@@ -22,9 +23,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/authorization/authorizer"
+	registry "k8s.io/apiserver/pkg/registry/generic/registry"
+	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 )
@@ -175,6 +179,7 @@ var (
 	emptyNotFoundError      = apierrors.NewNotFound(GVR.GroupResource(), "")
 	createUserMismatch      = apierrors.NewBadRequest("unable to create token for other user")
 	helloAlreadyExistsError = apierrors.NewAlreadyExists(GVR.GroupResource(), "hello")
+	admissionDenialMessage  = "ValidatingAdmissionPolicy 'block' denied request: blocked"
 
 	parseBoolError error
 	parseIntError  error
@@ -398,6 +403,103 @@ func TestStoreDeleteCollection(t *testing.T) {
 	})
 }
 
+func TestStoreDeleteCollectionKeepsItemStatusCode(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	secretClient := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	secretClient.EXPECT().List(TokenNamespace, gomock.Any()).
+		Return(&corev1.SecretList{
+			ListMeta: metav1.ListMeta{ResourceVersion: "1"},
+			Items:    []corev1.Secret{*properSecret.DeepCopy()},
+		}, nil)
+	denied := apierrors.NewInvalid(schema.GroupKind{Kind: "Secret"}, "bogus", nil)
+	denied.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: admissionDenialMessage}}
+	secretClient.EXPECT().Delete(TokenNamespace, "bogus", gomock.Any()).Return(denied)
+	secretClient.EXPECT().Cache().Return(nil)
+	userClient := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+	userClient.EXPECT().Cache().Return(nil)
+	auth := NewMockauthHandler(ctrl)
+	auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(&mockUser{name: properUser}, false, true, nil)
+
+	store := New(nil, nil, nil, secretClient, userClient, nil, nil, nil, nil, auth)
+
+	obj, err := store.DeleteCollection(t.Context(), nil, &metav1.DeleteOptions{}, &metainternalversion.ListOptions{})
+	require.Error(t, err)
+	assert.Nil(t, obj)
+	assert.True(t, apierrors.IsInvalid(err), "admission denial must stay 422, got %v", err)
+	assert.Contains(t, err.Error(), admissionDenialMessage)
+	assert.NotContains(t, err.Error(), "secret")
+}
+
+type fakeUpdatedObjectInfo struct {
+	obj runtime.Object
+	err error
+}
+
+func (i *fakeUpdatedObjectInfo) Preconditions() *metav1.Preconditions {
+	return nil
+}
+
+func (i *fakeUpdatedObjectInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (runtime.Object, error) {
+	return i.obj, i.err
+}
+
+var _ rest.UpdatedObjectInfo = &fakeUpdatedObjectInfo{}
+
+func TestStoreUpdate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("forbidden secret keeps its status code", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+		auth := NewMockauthHandler(ctrl)
+
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&mockUser{name: properUser}, true, true, nil)
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().Get(TokenNamespace, "bogus").
+			Return(nil, apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "bogus", errors.New("denied")))
+
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
+		obj, created, err := store.Update(context.TODO(), "bogus", &fakeUpdatedObjectInfo{}, nil, nil, false, &metav1.UpdateOptions{})
+
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.False(t, created)
+		assert.True(t, apierrors.IsForbidden(err), "backing 403 must stay 403, got %v", err)
+		assert.NotContains(t, err.Error(), "secret")
+	})
+
+	t.Run("status error from updated object keeps its status code", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+		auth := NewMockauthHandler(ctrl)
+
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&mockUser{name: properUser}, true, true, nil)
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		scache.EXPECT().Get(TokenNamespace, "bogus").Return(properSecret.DeepCopy(), nil)
+
+		store := New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
+		objInfo := &fakeUpdatedObjectInfo{err: apierrors.NewBadRequest("malformed patch")}
+		obj, created, err := store.Update(context.TODO(), "bogus", objInfo, nil, nil, false, &metav1.UpdateOptions{})
+
+		require.Error(t, err)
+		assert.Nil(t, obj)
+		assert.False(t, created)
+		assert.True(t, apierrors.IsBadRequest(err), "patch 400 must stay 400, got %v", err)
+	})
+}
+
 func TestStoreDelete(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Delete
 	// Here we test the actions and checks done before delegation to the
@@ -419,8 +521,7 @@ func TestStoreDelete(t *testing.T) {
 		_, ok, err := store.Delete(context.TODO(), "bogus", nil, &metav1.DeleteOptions{})
 
 		assert.False(t, ok)
-		assert.Equal(t, apierrors.NewInternalError(fmt.Errorf("failed to retrieve token bogus: %w",
-			errSomeError)), err)
+		assert.Equal(t, apierrors.NewInternalError(errors.New("error accessing backing object for token bogus")), err)
 	})
 
 	t.Run("failed to get secret, not found", func(t *testing.T) {
@@ -1267,7 +1368,7 @@ func TestStoreCreate(t *testing.T) {
 		},
 		{
 			name: "failed to create secret - some error",
-			err:  apierrors.NewInternalError(fmt.Errorf("failed to store token: %w", errSomeError)),
+			err:  apierrors.NewInternalError(errors.New("error accessing backing object for token " + GeneratePrefix)),
 			tok: &ext.Token{
 				Spec: ext.TokenSpec{
 					UserID: "world",
@@ -1315,8 +1416,57 @@ func TestStoreCreate(t *testing.T) {
 			},
 		},
 		{
+			name: "failed to create secret - admission denied",
+			err: func() error {
+				denied := apierrors.NewInvalid(GVK.GroupKind(), GeneratePrefix, nil)
+				denied.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: admissionDenialMessage}}
+				denied.ErrStatus.Message += ": " + admissionDenialMessage
+				return denied
+			}(),
+			tok: &ext.Token{
+				Spec: ext.TokenSpec{
+					UserID: "world",
+				},
+			},
+			opts: &metav1.CreateOptions{},
+			storeSetup: func( // configure store backend clients
+				space *fake.MockNonNamespacedControllerInterface[*corev1.Namespace, *corev1.NamespaceList],
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				scache *fake.MockCacheInterface[*corev1.Secret],
+				users *fake.MockNonNamespacedCacheInterface[*v3.User],
+				token *fake.MockNonNamespacedCacheInterface[*v3.Token],
+				cluster *fake.MockNonNamespacedCacheInterface[*v3.Cluster],
+				timer *MocktimeHandler,
+				hasher *MockhashHandler,
+				auth *MockauthHandler) {
+
+				auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&mockUser{name: "world"}, false, true, nil)
+				auth.EXPECT().SessionID(gomock.Any()).
+					Return("session-token", nil)
+				token.EXPECT().Get("session-token").Return(&v3.Token{
+					AuthProvider: "local",
+					UserPrincipal: v3.Principal{
+						ObjectMeta: metav1.ObjectMeta{Name: "local://world"},
+					}}, nil)
+				users.EXPECT().Get("world").
+					Return(&v3.User{
+						DisplayName: "worldwide",
+						Username:    "wide",
+						Enabled:     ptr.To(true),
+					}, nil)
+				hasher.EXPECT().MakeAndHashSecret().Return("", "", nil)
+				timer.EXPECT().Now().Return("this is a fake now")
+
+				denied := apierrors.NewInvalid(schema.GroupKind{Kind: "Secret"}, "", nil)
+				denied.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: admissionDenialMessage}}
+				secrets.EXPECT().Create(gomock.Any()).
+					Return(nil, denied)
+			},
+		},
+		{
 			name: "failed to create secret - already exists",
-			err:  helloAlreadyExistsError,
+			err:  apierrors.NewAlreadyExists(GVR.GroupResource(), GeneratePrefix),
 			tok: &ext.Token{
 				Spec: ext.TokenSpec{
 					UserID: "world",
@@ -2229,7 +2379,8 @@ func TestSystemStoreDelete(t *testing.T) {
 		token      string                // name of token to delete
 		opts       *metav1.DeleteOptions // delete options
 		err        error                 // expected op result, error
-		storeSetup func(                 // configure store backend clients
+		check      func(t *testing.T, err error)
+		storeSetup func( // configure store backend clients
 			secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList])
 	}{
 		{
@@ -2248,7 +2399,7 @@ func TestSystemStoreDelete(t *testing.T) {
 			name:  "secret other error is fail",
 			token: "bogus",
 			opts:  &metav1.DeleteOptions{},
-			err:   apierrors.NewInternalError(fmt.Errorf("failed to delete token bogus: %w", errSomeError)),
+			err:   apierrors.NewInternalError(errors.New("error accessing backing object for token bogus")),
 			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
 				secrets.EXPECT().
 					Delete(TokenNamespace, "bogus", gomock.Any()).
@@ -2264,6 +2415,50 @@ func TestSystemStoreDelete(t *testing.T) {
 				secrets.EXPECT().
 					Delete(TokenNamespace, "bogus", gomock.Any()).
 					Return(nil)
+			},
+		},
+		{
+			name:  "admission denial on secret keeps its status code",
+			token: "bogus",
+			opts:  &metav1.DeleteOptions{},
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				denied := apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "bogus",
+					errors.New("ValidatingAdmissionPolicy 'block' denied request: blocked"))
+				denied.ErrStatus.Reason = metav1.StatusReasonInvalid
+				denied.ErrStatus.Code = 422
+				denied.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: "ValidatingAdmissionPolicy 'block' denied request: blocked"}}
+				secrets.EXPECT().
+					Delete(TokenNamespace, "bogus", gomock.Any()).
+					Return(denied)
+			},
+			check: func(t *testing.T, err error) {
+				require.True(t, apierrors.IsInvalid(err), "expected 422, got %v", err)
+				status, ok := err.(apierrors.APIStatus)
+				require.True(t, ok)
+				details := status.Status().Details
+				require.NotNil(t, details)
+				assert.Equal(t, GVR.Group, details.Group)
+				assert.Equal(t, GVK.Kind, details.Kind)
+				assert.Equal(t, "bogus", details.Name)
+				require.Len(t, details.Causes, 1)
+				assert.Equal(t, "ValidatingAdmissionPolicy 'block' denied request: blocked", details.Causes[0].Message)
+				assert.Contains(t, err.Error(), "ValidatingAdmissionPolicy 'block' denied request: blocked")
+				assert.NotContains(t, err.Error(), "secret")
+				assert.NotContains(t, err.Error(), "unhandled error code")
+			},
+		},
+		{
+			name:  "conflict on secret keeps its status code",
+			token: "bogus",
+			opts:  &metav1.DeleteOptions{},
+			storeSetup: func(secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList]) {
+				secrets.EXPECT().
+					Delete(TokenNamespace, "bogus", gomock.Any()).
+					Return(apierrors.NewConflict(schema.GroupResource{Resource: "secrets"}, "bogus", errors.New("uid mismatch")))
+			},
+			check: func(t *testing.T, err error) {
+				require.True(t, apierrors.IsConflict(err), "expected 409, got %v", err)
+				assert.NotContains(t, err.Error(), "secret")
 			},
 		},
 	}
@@ -2284,9 +2479,12 @@ func TestSystemStoreDelete(t *testing.T) {
 
 			// perform test and validate results
 			err := store.Delete(test.token, test.opts)
-			if test.err != nil {
+			switch {
+			case test.check != nil:
+				test.check(t, err)
+			case test.err != nil:
 				assert.Equal(t, test.err, err)
-			} else {
+			default:
 				assert.NoError(t, err)
 			}
 		})
@@ -2692,7 +2890,32 @@ func TestSystemStoreUpdate(t *testing.T) {
 					Update(gomock.Any()).
 					Return(nil, errSomeError)
 			},
-			err: apierrors.NewInternalError(fmt.Errorf("failed to save updated token: %w", errSomeError)),
+			err: apierrors.NewInternalError(errors.New("error accessing backing object for token bogus")),
+		},
+		{
+			name:     "update conflict keeps its status code",
+			fullPerm: true,
+			opts:     &metav1.UpdateOptions{},
+			old:      &properToken,
+			token: func() *ext.Token {
+				changed := properToken.DeepCopy()
+				changed.Spec.TTL = 2000
+				return changed
+			}(),
+			storeSetup: func(
+				secrets *fake.MockControllerInterface[*corev1.Secret, *corev1.SecretList],
+				scache *fake.MockCacheInterface[*corev1.Secret],
+				timer *MocktimeHandler,
+				hasher *MockhashHandler,
+				auth *MockauthHandler) {
+
+				timer.EXPECT().Now().Return("this is a fake now")
+
+				secrets.EXPECT().
+					Update(gomock.Any()).
+					Return(nil, apierrors.NewConflict(schema.GroupResource{Resource: "secrets"}, "bogus", errors.New("stale")))
+			},
+			err: apierrors.NewConflict(GVR.GroupResource(), "bogus", errors.New(registry.OptimisticLockErrorMsg)),
 		},
 		{
 			name:     "read back broken data after update",
@@ -2836,9 +3059,20 @@ func TestSystemStoreGet(t *testing.T) {
 			},
 			tokname: "bogus",
 			opts:    &metav1.GetOptions{},
-			err: apierrors.NewInternalError(fmt.Errorf("failed to retrieve token %s: %w", "bogus",
-				errSomeError)),
-			tok: nil,
+			err:     apierrors.NewInternalError(errors.New("error accessing backing object for token bogus")),
+			tok:     nil,
+		},
+		{
+			name: "forbidden secret keeps its status code",
+			storeSetup: func(secrets *fake.MockCacheInterface[*corev1.Secret]) {
+				secrets.EXPECT().
+					Get(TokenNamespace, "bogus").
+					Return(nil, apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "bogus", errors.New("denied")))
+			},
+			tokname: "bogus",
+			opts:    &metav1.GetOptions{},
+			err:     apierrors.NewForbidden(GVR.GroupResource(), "bogus", errors.New("backing store denied the request")),
+			tok:     nil,
 		},
 		{
 			name: "empty secret (not found)",

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -2503,7 +2503,35 @@ func TestAPIStatusOrInternalError(t *testing.T) {
 	assert.True(t, apierrors.IsBadRequest(got), "wrapped 400 must stay 400, got %v", got)
 	assert.IsType(t, &apierrors.StatusError{}, got)
 
+	// Any APIStatus implementation counts, not only *StatusError, since the
+	// apiserver matches on the interface.
+	custom := &customStatusError{code: 409}
+	assert.Same(t, custom, apiStatusOrInternalError(fmt.Errorf("wrapped: %w", custom)))
+
 	assert.True(t, apierrors.IsInternalError(apiStatusOrInternalError(errors.New("boom"))))
+}
+
+type customStatusError struct{ code int32 }
+
+func (e *customStatusError) Error() string { return "custom" }
+func (e *customStatusError) Status() metav1.Status {
+	return metav1.Status{Status: metav1.StatusFailure, Code: e.code, Reason: metav1.StatusReasonConflict}
+}
+
+func TestMapBackingErrorForbiddenCauseReachesMessage(t *testing.T) {
+	t.Parallel()
+
+	denied := apierrors.NewForbidden(schema.GroupResource{Resource: "secrets"}, "bogus", errors.New("denied"))
+	denied.ErrStatus.Details.Causes = []metav1.StatusCause{{Message: admissionDenialMessage}}
+
+	got := mapBackingError(denied, "bogus")
+	require.True(t, apierrors.IsForbidden(got))
+	assert.Contains(t, got.Error(), admissionDenialMessage)
+	assert.NotContains(t, got.Error(), "secret")
+	status, ok := got.(apierrors.APIStatus)
+	require.True(t, ok)
+	require.Len(t, status.Status().Details.Causes, 1)
+	assert.Equal(t, admissionDenialMessage, status.Status().Details.Causes[0].Message)
 }
 
 func TestSystemStoreAddLabel(t *testing.T) {

--- a/pkg/ext/stores/tokens/tokens_test.go
+++ b/pkg/ext/stores/tokens/tokens_test.go
@@ -500,6 +500,74 @@ func TestStoreUpdate(t *testing.T) {
 	})
 }
 
+func TestStoreValidationCallbackErrors(t *testing.T) {
+	t.Parallel()
+
+	wrappedForbidden := fmt.Errorf("admission: %w", apierrors.NewForbidden(GVR.GroupResource(), "bogus", errors.New("denied")))
+
+	newStore := func(t *testing.T, cachedSecret *corev1.Secret) *Store {
+		ctrl := gomock.NewController(t)
+		secrets := fake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+		scache := fake.NewMockCacheInterface[*corev1.Secret](ctrl)
+		users := fake.NewMockNonNamespacedControllerInterface[*v3.User, *v3.UserList](ctrl)
+		auth := NewMockauthHandler(ctrl)
+
+		auth.EXPECT().UserName(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(&mockUser{name: properUser}, true, true, nil).AnyTimes()
+		users.EXPECT().Cache().Return(nil)
+		secrets.EXPECT().Cache().Return(scache)
+		if cachedSecret != nil {
+			// Update reads through the cache, Delete bypasses it.
+			scache.EXPECT().Get(TokenNamespace, "bogus").Return(cachedSecret, nil).AnyTimes()
+			secrets.EXPECT().Get(TokenNamespace, "bogus", gomock.Any()).Return(cachedSecret, nil).AnyTimes()
+		}
+		return New(nil, nil, nil, secrets, users, nil, nil, nil, nil, auth)
+	}
+
+	t.Run("create keeps a wrapped status code", func(t *testing.T) {
+		store := newStore(t, nil)
+		validation := func(ctx context.Context, obj runtime.Object) error { return wrappedForbidden }
+
+		_, err := store.Create(context.TODO(), properToken.DeepCopy(), validation, &metav1.CreateOptions{})
+		assert.True(t, apierrors.IsForbidden(err), "wrapped 403 must stay 403, got %v", err)
+		assert.IsType(t, &apierrors.StatusError{}, err, "status error must be returned unwrapped")
+	})
+
+	t.Run("create turns a plain error into a bad request", func(t *testing.T) {
+		store := newStore(t, nil)
+		validation := func(ctx context.Context, obj runtime.Object) error { return errors.New("nope") }
+
+		_, err := store.Create(context.TODO(), properToken.DeepCopy(), validation, &metav1.CreateOptions{})
+		assert.True(t, apierrors.IsBadRequest(err), "plain validation error must be 400, got %v", err)
+	})
+
+	t.Run("delete keeps a wrapped status code", func(t *testing.T) {
+		store := newStore(t, properSecret.DeepCopy())
+		validation := func(ctx context.Context, obj runtime.Object) error { return wrappedForbidden }
+
+		_, _, err := store.Delete(context.TODO(), "bogus", validation, &metav1.DeleteOptions{})
+		assert.True(t, apierrors.IsForbidden(err), "wrapped 403 must stay 403, got %v", err)
+		assert.IsType(t, &apierrors.StatusError{}, err, "status error must be returned unwrapped")
+	})
+
+	t.Run("delete turns a plain error into a bad request", func(t *testing.T) {
+		store := newStore(t, properSecret.DeepCopy())
+		validation := func(ctx context.Context, obj runtime.Object) error { return errors.New("nope") }
+
+		_, _, err := store.Delete(context.TODO(), "bogus", validation, &metav1.DeleteOptions{})
+		assert.True(t, apierrors.IsBadRequest(err), "plain validation error must be 400, got %v", err)
+	})
+
+	t.Run("update keeps a wrapped status code", func(t *testing.T) {
+		store := newStore(t, properSecret.DeepCopy())
+		validation := func(ctx context.Context, obj, old runtime.Object) error { return wrappedForbidden }
+
+		_, _, err := store.Update(context.TODO(), "bogus", &fakeUpdatedObjectInfo{obj: properToken.DeepCopy()}, nil, validation, false, &metav1.UpdateOptions{})
+		assert.True(t, apierrors.IsForbidden(err), "wrapped 403 must stay 403, got %v", err)
+		assert.IsType(t, &apierrors.StatusError{}, err, "status error must be returned unwrapped")
+	})
+}
+
 func TestStoreDelete(t *testing.T) {
 	// The majority of the code is tested later, in Test_SystemStore_Delete
 	// Here we test the actions and checks done before delegation to the


### PR DESCRIPTION
## Issue: #57107 <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

The ext.Token store rewraps any error from the backing Secret other than NotFound as a 500 on create, get, update, and delete:

- A ValidatingAdmissionPolicy denying the Secret delete comes back as an internal error, both when the ext.Token is deleted directly and when an ext.Kubeconfig deletes the tokens it owns.
- A stale-resourceVersion conflict on update never surfaces as 409.
- Error messages name the Secret.
- Errors from applying a PATCH or from admission during update, and per-item errors during a collection delete, are also rewrapped as a 500.
- The update validation callback's error is always rewrapped as a 400. The create and delete callbacks return their error as-is, so a wrapped status error becomes a 500 at the apiserver and a plain error becomes a 500 instead of a 400.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Errors from the backing Secret are re-scoped to the ext.Token resource with their status code, reason, and causes preserved, in the same way the ext.Kubeconfig store handles its backing ConfigMap. Causes are folded into the message.
- Reads during update go through the same lookup as get and delete.
- Status errors from the update path, per-item deletes, and the create, update, and delete validation callbacks are unwrapped and returned with their code. Plain validation errors are 400.
- List and watch are unchanged.
 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests
