### PR TITLE
Bump kube-api-auth to v0.16.0-rc.1

### DIFF
--- a/pkg/apis/management.cattle.io/v3/tools_system_images.go
+++ b/pkg/apis/management.cattle.io/v3/tools_system_images.go
@@ -5,7 +5,7 @@ var (
 		AuthSystemImages AuthSystemImages
 	}{
 		AuthSystemImages: AuthSystemImages{
-			KubeAPIAuth: "rancher/kube-api-auth:v0.15.0",
+			KubeAPIAuth: "rancher/kube-api-auth:v0.16.0-rc.1",
 		},
 	}
 )


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->
 
## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

- Bump kube-api-auth to [v0.16.0-rc.1](https://github.com/rancher/kube-api-auth/releases/tag/v0.16.0-rc.1)
