### PR TITLE
Load global Renovate managers

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,9 @@
   "ignoreDeps": [
     "go.qase.io/client"
   ],
+  "extends": [
+    "github>rancher/renovate-config//default#main"
+  ],
   "prHourlyLimit": 6,
   "prConcurrentLimit": 20,
   "packageRules": [


### PR DESCRIPTION
Load the shared default preset at root level so custom managers and datasources are available on main and release branches. Preserve branch-specific Rancher restrictions while enabling Dockerfile, checksum, and development-version updates.