### PR TITLE
Op pause conditions

### DIFF
--- a/pkg/controllers/operations/encryptionkeyrotation/controller.go
+++ b/pkg/controllers/operations/encryptionkeyrotation/controller.go
@@ -99,22 +99,16 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 }
 
 func (h *handler) OnChange(op *opv1alpha1.EncryptionKeyRotation, status opv1alpha1.EncryptionKeyRotationStatus) (opv1alpha1.EncryptionKeyRotationStatus, error) {
-	if op == nil {
-		return status, nil
-	}
-	if op.DeletionTimestamp != nil {
-		return status, nil
-	}
-	if ops.IsPaused(&op.Spec.OperationSpec) {
-		logrus.Debugf("[encryptionkeyrotation] %s/%s: skipping paused operation", op.Namespace, op.Name)
-		return status, nil
-	}
-
 	status, err := h.onChange(op, status)
 	if err != nil {
 		return status, err
 	}
 	status = updateStatus(op, status)
+
+	// Paused operations resume on a spec change; skip TTL cleanup and polling until then.
+	if ops.IsPaused(&op.Spec.OperationSpec) {
+		return status, nil
+	}
 
 	if equality.Semantic.DeepEqual(op.Status, status) {
 		// handle after normal processing to allow for proper phase-related cleanup (freeing beacon)
@@ -139,6 +133,17 @@ func (h *handler) OnChange(op *opv1alpha1.EncryptionKeyRotation, status opv1alph
 }
 
 func (h *handler) onChange(op *opv1alpha1.EncryptionKeyRotation, status opv1alpha1.EncryptionKeyRotationStatus) (opv1alpha1.EncryptionKeyRotationStatus, error) {
+	if op == nil {
+		return status, nil
+	}
+	if op.DeletionTimestamp != nil {
+		return status, nil
+	}
+	if ops.IsPaused(&op.Spec.OperationSpec) {
+		logrus.Debugf("[encryptionkeyrotation] %s/%s: skipping paused operation", op.Namespace, op.Name)
+		return status, nil
+	}
+
 	if status.Phase == "" {
 		status.Phase = opv1alpha1.OperationPhasePending
 		status.LastUpdated = metav1.Now()
@@ -911,6 +916,15 @@ func updateStatus(op *opv1alpha1.EncryptionKeyRotation, status opv1alpha1.Encryp
 	logrus.Tracef("[encryptionkeyrotation] %s/%s: updating conditions", op.Namespace, op.Name)
 
 	status.ObservedGeneration = op.Generation
+	if op.Spec.Paused {
+		opv1alpha1.PausedCondition.True(&status)
+		opv1alpha1.PausedCondition.Reason(&status, opv1alpha1.PausedReason)
+		opv1alpha1.PausedCondition.Message(&status, "Operation is paused")
+	} else {
+		opv1alpha1.PausedCondition.False(&status)
+		opv1alpha1.PausedCondition.Reason(&status, opv1alpha1.NotPausedReason)
+		opv1alpha1.PausedCondition.Message(&status, "")
+	}
 
 	if status.Phase == opv1alpha1.OperationPhasePending {
 		opv1alpha1.PendingCondition.True(&status)

--- a/pkg/controllers/operations/encryptionkeyrotation/controller_test.go
+++ b/pkg/controllers/operations/encryptionkeyrotation/controller_test.go
@@ -897,3 +897,125 @@ func TestReclaimStaleBeaconOwnerIfNeeded(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateStatusPausedCondition(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		paused          bool
+		initiallyPaused bool
+		expectedStatus  string
+		expectedReason  string
+		expectedMessage string
+	}{
+		{
+			name:            "paused",
+			paused:          true,
+			initiallyPaused: false,
+			expectedStatus:  "True",
+			expectedReason:  opv1alpha1.PausedReason,
+			expectedMessage: "Operation is paused",
+		},
+		{
+			name:            "resumed",
+			paused:          false,
+			initiallyPaused: true,
+			expectedStatus:  "False",
+			expectedReason:  opv1alpha1.NotPausedReason,
+			expectedMessage: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := newOp()
+			op.Spec.Paused = tc.paused
+			op.Generation = 7
+
+			initialStatus := opv1alpha1.EncryptionKeyRotationStatus{
+				OperationStatus: opv1alpha1.OperationStatus{
+					Phase: opv1alpha1.OperationPhaseInProgress,
+				},
+				Step: opv1alpha1.EncryptionKeyRotationStepRotate,
+			}
+
+			if tc.initiallyPaused {
+				opv1alpha1.PausedCondition.True(&initialStatus)
+				opv1alpha1.PausedCondition.Reason(&initialStatus, opv1alpha1.PausedReason)
+				opv1alpha1.PausedCondition.Message(&initialStatus, "Operation is paused")
+			}
+
+			status := updateStatus(op, initialStatus)
+
+			if status.ObservedGeneration != int64(7) {
+				t.Errorf("ObservedGeneration = %d, want 7", status.ObservedGeneration)
+			}
+			if got := opv1alpha1.PausedCondition.GetStatus(&status); got != tc.expectedStatus {
+				t.Errorf("PausedCondition status = %q, want %q", got, tc.expectedStatus)
+			}
+			if got := opv1alpha1.PausedCondition.GetReason(&status); got != tc.expectedReason {
+				t.Errorf("PausedCondition reason = %q, want %q", got, tc.expectedReason)
+			}
+			if got := opv1alpha1.PausedCondition.GetMessage(&status); got != tc.expectedMessage {
+				t.Errorf("PausedCondition message = %q, want %q", got, tc.expectedMessage)
+			}
+
+			// Verify phase and step are unchanged
+			if status.Phase != initialStatus.Phase {
+				t.Errorf("Phase = %q, want %q (unchanged)", status.Phase, initialStatus.Phase)
+			}
+			if status.Step != initialStatus.Step {
+				t.Errorf("Step = %q, want %q (unchanged)", status.Step, initialStatus.Step)
+			}
+		})
+	}
+}
+
+func TestOnChange_Paused(t *testing.T) {
+	t.Parallel()
+
+	op := newOp()
+	op.Spec.Paused = true
+	op.Generation = 7
+
+	initialStatus := opv1alpha1.EncryptionKeyRotationStatus{
+		OperationStatus: opv1alpha1.OperationStatus{
+			Phase: opv1alpha1.OperationPhaseInProgress,
+		},
+		Step: opv1alpha1.EncryptionKeyRotationStepRotate,
+	}
+
+	op.Status = initialStatus
+
+	h := &handler{}
+	status, err := h.OnChange(op, op.Status)
+
+	if err != nil {
+		t.Fatalf("OnChange returned error: %v", err)
+	}
+
+	// Verify PausedCondition is set to True
+	if got := opv1alpha1.PausedCondition.GetStatus(&status); got != "True" {
+		t.Errorf("PausedCondition status = %q, want %q", got, "True")
+	}
+	if got := opv1alpha1.PausedCondition.GetReason(&status); got != opv1alpha1.PausedReason {
+		t.Errorf("PausedCondition reason = %q, want %q", got, opv1alpha1.PausedReason)
+	}
+	if got := opv1alpha1.PausedCondition.GetMessage(&status); got != "Operation is paused" {
+		t.Errorf("PausedCondition message = %q, want %q", got, "Operation is paused")
+	}
+
+	// Verify ObservedGeneration is updated
+	if status.ObservedGeneration != int64(7) {
+		t.Errorf("ObservedGeneration = %d, want 7", status.ObservedGeneration)
+	}
+
+	// Verify phase and step are preserved
+	if status.Phase != initialStatus.Phase {
+		t.Errorf("Phase = %q, want %q (unchanged)", status.Phase, initialStatus.Phase)
+	}
+	if status.Step != initialStatus.Step {
+		t.Errorf("Step = %q, want %q (unchanged)", status.Step, initialStatus.Step)
+	}
+}

--- a/pkg/controllers/operations/encryptionkeyrotation/controller_test.go
+++ b/pkg/controllers/operations/encryptionkeyrotation/controller_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"testing"
+	"time"
 
 	opv1alpha1 "github.com/rancher/rancher/pkg/apis/operation.cattle.io/v1alpha1"
 	rkeplan "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
@@ -15,6 +16,7 @@ import (
 	planv1alpha1 "github.com/rancher/rancher/pkg/plan/api/plan.cattle.io/v1alpha1"
 	plancontrollers "github.com/rancher/rancher/pkg/plan/generated/controllers/plan.cattle.io/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -165,7 +167,9 @@ func newScope(op *opv1alpha1.EncryptionKeyRotation, beacon *planv1alpha1.Beacon,
 
 type fakeEncryptionKeyRotationController struct {
 	operationcontrollers.EncryptionKeyRotationController
-	getFn func(namespace, name string, opts metav1.GetOptions) (*opv1alpha1.EncryptionKeyRotation, error)
+	getFn        func(namespace, name string, opts metav1.GetOptions) (*opv1alpha1.EncryptionKeyRotation, error)
+	enqueueCalls int
+	deleteCalls  int
 }
 
 func (f *fakeEncryptionKeyRotationController) Get(namespace, name string, opts metav1.GetOptions) (*opv1alpha1.EncryptionKeyRotation, error) {
@@ -173,6 +177,15 @@ func (f *fakeEncryptionKeyRotationController) Get(namespace, name string, opts m
 		return nil, nil
 	}
 	return f.getFn(namespace, name, opts)
+}
+
+func (f *fakeEncryptionKeyRotationController) EnqueueAfter(_, _ string, _ time.Duration) {
+	f.enqueueCalls++
+}
+
+func (f *fakeEncryptionKeyRotationController) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	f.deleteCalls++
+	return nil
 }
 
 type fakeBeaconClient struct {
@@ -1017,5 +1030,86 @@ func TestOnChange_Paused(t *testing.T) {
 	}
 	if status.Step != initialStatus.Step {
 		t.Errorf("Step = %q, want %q (unchanged)", status.Step, initialStatus.Step)
+	}
+}
+
+func TestOnChange_StablePausedOperation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		phase       opv1alpha1.OperationPhase
+		step        opv1alpha1.EncryptionKeyRotationStep
+		ttl         int64
+		lastUpdated metav1.Time
+	}{
+		{
+			name:        "stable in-progress paused operation",
+			phase:       opv1alpha1.OperationPhaseInProgress,
+			step:        opv1alpha1.EncryptionKeyRotationStepRotate,
+			ttl:         300,
+			lastUpdated: metav1.Now(),
+		},
+		{
+			name:        "stable terminal expired paused operation",
+			phase:       opv1alpha1.OperationPhaseSucceeded,
+			step:        opv1alpha1.EncryptionKeyRotationStepRotate,
+			ttl:         0,
+			lastUpdated: metav1.NewTime(metav1.Now().Add(-10 * time.Minute)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := newOp()
+			op.Spec.Paused = true
+			op.Spec.TTL = tc.ttl
+			op.Generation = 7
+
+			initialStatus := opv1alpha1.EncryptionKeyRotationStatus{
+				OperationStatus: opv1alpha1.OperationStatus{
+					Phase:       tc.phase,
+					LastUpdated: tc.lastUpdated,
+				},
+				Step: tc.step,
+			}
+
+			// Pre-compute the expected status with paused condition
+			currentStatus := updateStatus(op, initialStatus)
+			op.Status = currentStatus
+
+			controller := &fakeEncryptionKeyRotationController{}
+			h := &handler{
+				encryptionkeyrotations: controller,
+			}
+
+			returnedStatus, err := h.OnChange(op, op.Status)
+			if err != nil {
+				t.Fatalf("OnChange returned error: %v", err)
+			}
+
+			// Verify status unchanged
+			if !equality.Semantic.DeepEqual(returnedStatus, currentStatus) {
+				t.Errorf("returnedStatus differs from currentStatus")
+			}
+
+			// Verify phase and step preserved
+			if returnedStatus.Phase != tc.phase {
+				t.Errorf("Phase = %q, want %q", returnedStatus.Phase, tc.phase)
+			}
+			if returnedStatus.Step != tc.step {
+				t.Errorf("Step = %q, want %q", returnedStatus.Step, tc.step)
+			}
+
+			// Verify no delete occurred
+			if controller.deleteCalls != 0 {
+				t.Errorf("Delete called %d times, want 0", controller.deleteCalls)
+			}
+
+			// Verify no enqueue occurred
+			if controller.enqueueCalls != 0 {
+				t.Errorf("EnqueueAfter called %d times, want 0", controller.enqueueCalls)
+			}
+		})
 	}
 }

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller.go
@@ -219,6 +219,11 @@ func (h *handler) OnChange(op *opv1alpha1.ETCDSnapshotRestore, status opv1alpha1
 	}
 	status = updateStatus(op, status)
 
+	// Paused operations resume on a spec change; skip TTL cleanup and polling until then.
+	if ops.IsPaused(&op.Spec.OperationSpec) {
+		return status, nil
+	}
+
 	if reflect.DeepEqual(op.Status, status) {
 		// handle after normal processing to allow for proper phase-related cleanup (freeing beacon)
 		//
@@ -1739,6 +1744,15 @@ func updateStatus(op *opv1alpha1.ETCDSnapshotRestore, status opv1alpha1.ETCDSnap
 	logrus.Tracef("[etcdsnapshotrestore] %s/%s: updating conditions", op.Namespace, op.Name)
 
 	status.ObservedGeneration = op.Generation
+	if op.Spec.Paused {
+		opv1alpha1.PausedCondition.True(&status)
+		opv1alpha1.PausedCondition.Reason(&status, opv1alpha1.PausedReason)
+		opv1alpha1.PausedCondition.Message(&status, "Operation is paused")
+	} else {
+		opv1alpha1.PausedCondition.False(&status)
+		opv1alpha1.PausedCondition.Reason(&status, opv1alpha1.NotPausedReason)
+		opv1alpha1.PausedCondition.Message(&status, "")
+	}
 
 	if status.Phase == opv1alpha1.OperationPhasePending {
 		opv1alpha1.PendingCondition.True(&status)

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
@@ -404,3 +404,91 @@ func TestAssignedPlansAreOperationScoped(t *testing.T) {
 		})
 	}
 }
+
+func newOp() *opv1alpha1.ETCDSnapshotRestore {
+	return &opv1alpha1.ETCDSnapshotRestore{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "restore-1",
+			Namespace:  "fleet-default",
+			UID:        types.UID("restore-uid"),
+			Generation: 1,
+		},
+		Spec: opv1alpha1.ETCDSnapshotRestoreSpec{
+			OperationSpec: opv1alpha1.OperationSpec{},
+		},
+	}
+}
+
+func TestUpdateStatusPausedCondition(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name            string
+		paused          bool
+		initiallyPaused bool
+		expectedStatus  string
+		expectedReason  string
+		expectedMessage string
+	}{
+		{
+			name:            "paused",
+			paused:          true,
+			initiallyPaused: false,
+			expectedStatus:  "True",
+			expectedReason:  opv1alpha1.PausedReason,
+			expectedMessage: "Operation is paused",
+		},
+		{
+			name:            "resumed",
+			paused:          false,
+			initiallyPaused: true,
+			expectedStatus:  "False",
+			expectedReason:  opv1alpha1.NotPausedReason,
+			expectedMessage: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := newOp()
+			op.Spec.Paused = tc.paused
+			op.Generation = 7
+
+			initialStatus := opv1alpha1.ETCDSnapshotRestoreStatus{
+				OperationStatus: opv1alpha1.OperationStatus{
+					Phase: opv1alpha1.OperationPhaseInProgress,
+				},
+				Step: opv1alpha1.ETCDSnapshotRestoreStepRestore,
+			}
+
+			if tc.initiallyPaused {
+				opv1alpha1.PausedCondition.True(&initialStatus)
+				opv1alpha1.PausedCondition.Reason(&initialStatus, opv1alpha1.PausedReason)
+				opv1alpha1.PausedCondition.Message(&initialStatus, "Operation is paused")
+			}
+
+			status := updateStatus(op, initialStatus)
+
+			if status.ObservedGeneration != int64(7) {
+				t.Errorf("ObservedGeneration = %d, want 7", status.ObservedGeneration)
+			}
+			if got := opv1alpha1.PausedCondition.GetStatus(&status); got != tc.expectedStatus {
+				t.Errorf("PausedCondition status = %q, want %q", got, tc.expectedStatus)
+			}
+			if got := opv1alpha1.PausedCondition.GetReason(&status); got != tc.expectedReason {
+				t.Errorf("PausedCondition reason = %q, want %q", got, tc.expectedReason)
+			}
+			if got := opv1alpha1.PausedCondition.GetMessage(&status); got != tc.expectedMessage {
+				t.Errorf("PausedCondition message = %q, want %q", got, tc.expectedMessage)
+			}
+
+			// Verify phase and step are unchanged
+			if status.Phase != initialStatus.Phase {
+				t.Errorf("Phase = %q, want %q (unchanged)", status.Phase, initialStatus.Phase)
+			}
+			if status.Step != initialStatus.Step {
+				t.Errorf("Step = %q, want %q (unchanged)", status.Step, initialStatus.Step)
+			}
+		})
+	}
+}

--- a/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotrestore/controller_test.go
@@ -5,12 +5,15 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	opv1alpha1 "github.com/rancher/rancher/pkg/apis/operation.cattle.io/v1alpha1"
 	rkeplan "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/capr"
+	operationcontrollers "github.com/rancher/rancher/pkg/generated/controllers/operation.cattle.io/v1alpha1"
 	ops "github.com/rancher/rancher/pkg/operations"
 	planapi "github.com/rancher/rancher/pkg/plan"
 	corev1 "k8s.io/api/core/v1"
@@ -120,6 +123,21 @@ func makePlanSecret(name, nodeName string, labels map[string]string) *corev1.Sec
 			UID:       types.UID(name + "-uid"),
 		},
 	}
+}
+
+type fakeETCDSnapshotRestoreController struct {
+	operationcontrollers.ETCDSnapshotRestoreController
+	enqueueCalls int
+	deleteCalls  int
+}
+
+func (f *fakeETCDSnapshotRestoreController) EnqueueAfter(_, _ string, _ time.Duration) {
+	f.enqueueCalls++
+}
+
+func (f *fakeETCDSnapshotRestoreController) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	f.deleteCalls++
+	return nil
 }
 
 func TestBuildPostRestoreNodeCleanupPlan(t *testing.T) {
@@ -490,5 +508,128 @@ func TestUpdateStatusPausedCondition(t *testing.T) {
 				t.Errorf("Step = %q, want %q (unchanged)", status.Step, initialStatus.Step)
 			}
 		})
+	}
+}
+
+func TestOnChange_StablePausedOperation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		phase       opv1alpha1.OperationPhase
+		step        opv1alpha1.ETCDSnapshotRestoreStep
+		ttl         int64
+		lastUpdated metav1.Time
+	}{
+		{
+			name:        "stable in-progress paused operation",
+			phase:       opv1alpha1.OperationPhaseInProgress,
+			step:        opv1alpha1.ETCDSnapshotRestoreStepRestore,
+			ttl:         300,
+			lastUpdated: metav1.Now(),
+		},
+		{
+			name:        "stable terminal expired paused operation",
+			phase:       opv1alpha1.OperationPhaseSucceeded,
+			step:        opv1alpha1.ETCDSnapshotRestoreStepRestore,
+			ttl:         0,
+			lastUpdated: metav1.NewTime(metav1.Now().Add(-10 * time.Minute)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := newOp()
+			op.Spec.Paused = true
+			op.Spec.TTL = tc.ttl
+			op.Generation = 7
+
+			initialStatus := opv1alpha1.ETCDSnapshotRestoreStatus{
+				OperationStatus: opv1alpha1.OperationStatus{
+					Phase:       tc.phase,
+					LastUpdated: tc.lastUpdated,
+				},
+				Step: tc.step,
+			}
+
+			// Pre-compute the expected status with paused condition
+			currentStatus := updateStatus(op, initialStatus)
+			op.Status = currentStatus
+
+			controller := &fakeETCDSnapshotRestoreController{}
+			h := &handler{
+				etcdsnapshotrestores: controller,
+			}
+
+			returnedStatus, err := h.OnChange(op, op.Status)
+			if err != nil {
+				t.Fatalf("OnChange returned error: %v", err)
+			}
+
+			// Verify status unchanged
+			if !reflect.DeepEqual(returnedStatus, currentStatus) {
+				t.Errorf("returnedStatus differs from currentStatus")
+			}
+
+			// Verify phase and step preserved
+			if returnedStatus.Phase != tc.phase {
+				t.Errorf("Phase = %q, want %q", returnedStatus.Phase, tc.phase)
+			}
+			if returnedStatus.Step != tc.step {
+				t.Errorf("Step = %q, want %q", returnedStatus.Step, tc.step)
+			}
+
+			// Verify no delete occurred
+			if controller.deleteCalls != 0 {
+				t.Errorf("Delete called %d times, want 0", controller.deleteCalls)
+			}
+
+			// Verify no enqueue occurred
+			if controller.enqueueCalls != 0 {
+				t.Errorf("EnqueueAfter called %d times, want 0", controller.enqueueCalls)
+			}
+		})
+	}
+}
+
+func TestOnChange_Paused(t *testing.T) {
+	t.Parallel()
+
+	op := newOp()
+	op.Spec.Paused = true
+	op.Generation = 7
+
+	initialStatus := opv1alpha1.ETCDSnapshotRestoreStatus{
+		OperationStatus: opv1alpha1.OperationStatus{
+			Phase: opv1alpha1.OperationPhaseInProgress,
+		},
+		Step: opv1alpha1.ETCDSnapshotRestoreStepRestore,
+	}
+
+	op.Status = initialStatus
+
+	h := &handler{}
+	status, err := h.OnChange(op, op.Status)
+
+	if err != nil {
+		t.Fatalf("OnChange returned error: %v", err)
+	}
+	if got := opv1alpha1.PausedCondition.GetStatus(&status); got != "True" {
+		t.Errorf("PausedCondition status = %q, want %q", got, "True")
+	}
+	if got := opv1alpha1.PausedCondition.GetReason(&status); got != opv1alpha1.PausedReason {
+		t.Errorf("PausedCondition reason = %q, want %q", got, opv1alpha1.PausedReason)
+	}
+	if got := opv1alpha1.PausedCondition.GetMessage(&status); got != "Operation is paused" {
+		t.Errorf("PausedCondition message = %q, want %q", got, "Operation is paused")
+	}
+	if status.ObservedGeneration != int64(7) {
+		t.Errorf("ObservedGeneration = %d, want 7", status.ObservedGeneration)
+	}
+	if status.Phase != initialStatus.Phase {
+		t.Errorf("Phase = %q, want %q (unchanged)", status.Phase, initialStatus.Phase)
+	}
+	if status.Step != initialStatus.Step {
+		t.Errorf("Step = %q, want %q (unchanged)", status.Step, initialStatus.Step)
 	}
 }

--- a/pkg/controllers/operations/etcdsnapshotsave/controller.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller.go
@@ -118,6 +118,11 @@ func (h *handler) OnChange(op *opv1alpha1.ETCDSnapshotSave, status opv1alpha1.ET
 	}
 	status = updateStatus(op, status)
 
+	// Paused operations resume on a spec change; skip TTL cleanup and polling until then.
+	if ops.IsPaused(&op.Spec.OperationSpec) {
+		return status, nil
+	}
+
 	if equality.Semantic.DeepEqual(op.Status, status) {
 		// handle after normal processing to allow for proper phase-related cleanup (freeing beacon)
 		//

--- a/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
@@ -274,18 +274,68 @@ func (f *fakeBeaconClient) UpdateStatus(b *planv1alpha1.Beacon) (*planv1alpha1.B
 	return b, nil
 }
 
-func TestUpdateStatusPaused(t *testing.T) {
+// --- updateStatus ---------------------------------------------------------------------------
+
+func TestUpdateStatusPausedCondition(t *testing.T) {
 	t.Parallel()
 
-	op := newOp()
-	op.Spec.Paused = true
-	op.Generation = 7
+	cases := []struct {
+		name            string
+		paused          bool
+		initiallyPaused bool
+		expectedStatus  string
+		expectedReason  string
+		expectedMessage string
+	}{
+		{
+			name:            "paused",
+			paused:          true,
+			initiallyPaused: false,
+			expectedStatus:  "True",
+			expectedReason:  opv1alpha1.PausedReason,
+			expectedMessage: "Operation is paused",
+		},
+		{
+			name:            "resumed",
+			paused:          false,
+			initiallyPaused: true,
+			expectedStatus:  "False",
+			expectedReason:  opv1alpha1.NotPausedReason,
+			expectedMessage: "",
+		},
+	}
 
-	status := updateStatus(op, opv1alpha1.ETCDSnapshotSaveStatus{})
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := newOp()
+			op.Spec.Paused = tc.paused
+			op.Generation = 7
 
-	assert.Equal(t, int64(7), status.ObservedGeneration, "ObservedGeneration must be copied from the op")
-	assert.Equal(t, "True", opv1alpha1.PausedCondition.GetStatus(&status))
-	assert.Equal(t, opv1alpha1.PausedReason, opv1alpha1.PausedCondition.GetReason(&status))
+			initialStatus := opv1alpha1.ETCDSnapshotSaveStatus{
+				OperationStatus: opv1alpha1.OperationStatus{
+					Phase: opv1alpha1.OperationPhaseInProgress,
+				},
+				Step: opv1alpha1.ETCDSnapshotSaveStepSave,
+			}
+
+			if tc.initiallyPaused {
+				opv1alpha1.PausedCondition.True(&initialStatus)
+				opv1alpha1.PausedCondition.Reason(&initialStatus, opv1alpha1.PausedReason)
+				opv1alpha1.PausedCondition.Message(&initialStatus, "Operation is paused")
+			}
+
+			status := updateStatus(op, initialStatus)
+
+			assert.Equal(t, int64(7), status.ObservedGeneration, "ObservedGeneration must be copied from the op")
+			assert.Equal(t, tc.expectedStatus, opv1alpha1.PausedCondition.GetStatus(&status))
+			assert.Equal(t, tc.expectedReason, opv1alpha1.PausedCondition.GetReason(&status))
+			assert.Equal(t, tc.expectedMessage, opv1alpha1.PausedCondition.GetMessage(&status))
+
+			// Verify phase and step are unchanged
+			assert.Equal(t, initialStatus.Phase, status.Phase, "Phase should be unchanged")
+			assert.Equal(t, initialStatus.Step, status.Step, "Step should be unchanged")
+		})
+	}
 }
 
 func TestUpdateStatusByPhase(t *testing.T) {

--- a/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
+++ b/pkg/controllers/operations/etcdsnapshotsave/controller_test.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"reflect"
 	"testing"
+	"time"
 
 	opv1alpha1 "github.com/rancher/rancher/pkg/apis/operation.cattle.io/v1alpha1"
 	rkeplan "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1/plan"
 	"github.com/rancher/rancher/pkg/capr"
+	operationcontrollers "github.com/rancher/rancher/pkg/generated/controllers/operation.cattle.io/v1alpha1"
 	ops "github.com/rancher/rancher/pkg/operations"
 	planapi "github.com/rancher/rancher/pkg/plan"
 	planv1alpha1 "github.com/rancher/rancher/pkg/plan/api/plan.cattle.io/v1alpha1"
@@ -17,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -272,6 +275,21 @@ func (f *fakeBeaconClient) Update(b *planv1alpha1.Beacon) (*planv1alpha1.Beacon,
 func (f *fakeBeaconClient) UpdateStatus(b *planv1alpha1.Beacon) (*planv1alpha1.Beacon, error) {
 	f.statusUpdates = append(f.statusUpdates, b.DeepCopy())
 	return b, nil
+}
+
+type fakeETCDSnapshotSaveController struct {
+	operationcontrollers.ETCDSnapshotSaveController
+	enqueueCalls int
+	deleteCalls  int
+}
+
+func (f *fakeETCDSnapshotSaveController) EnqueueAfter(_, _ string, _ time.Duration) {
+	f.enqueueCalls++
+}
+
+func (f *fakeETCDSnapshotSaveController) Delete(_, _ string, _ *metav1.DeleteOptions) error {
+	f.deleteCalls++
+	return nil
 }
 
 // --- updateStatus ---------------------------------------------------------------------------
@@ -824,5 +842,120 @@ func TestAssignedPlansAreOperationScoped(t *testing.T) {
 			assert.Equal(t, marshal("save-uid-1"), marshal("save-uid-1"),
 				"plans for one operation must serialize identically across reconciles")
 		})
+	}
+}
+
+func TestOnChange_StablePausedOperation(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		phase       opv1alpha1.OperationPhase
+		step        opv1alpha1.ETCDSnapshotSaveStep
+		ttl         int64
+		lastUpdated metav1.Time
+	}{
+		{
+			name:        "stable in-progress paused operation",
+			phase:       opv1alpha1.OperationPhaseInProgress,
+			step:        opv1alpha1.ETCDSnapshotSaveStepSave,
+			ttl:         300,
+			lastUpdated: metav1.Now(),
+		},
+		{
+			name:        "stable terminal expired paused operation",
+			phase:       opv1alpha1.OperationPhaseSucceeded,
+			step:        opv1alpha1.ETCDSnapshotSaveStepSave,
+			ttl:         0,
+			lastUpdated: metav1.NewTime(metav1.Now().Add(-10 * time.Minute)),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			op := newOp()
+			op.Spec.Paused = true
+			op.Spec.TTL = tc.ttl
+			op.Generation = 7
+
+			initialStatus := opv1alpha1.ETCDSnapshotSaveStatus{
+				OperationStatus: opv1alpha1.OperationStatus{
+					Phase:       tc.phase,
+					LastUpdated: tc.lastUpdated,
+				},
+				Step: tc.step,
+			}
+
+			// Pre-compute the expected status with paused condition
+			currentStatus := updateStatus(op, initialStatus)
+			op.Status = currentStatus
+
+			controller := &fakeETCDSnapshotSaveController{}
+			h := &handler{
+				etcdsnapshotsaves: controller,
+			}
+
+			returnedStatus, err := h.OnChange(op, op.Status)
+			if err != nil {
+				t.Fatalf("OnChange returned error: %v", err)
+			}
+
+			// Verify status unchanged
+			if !equality.Semantic.DeepEqual(returnedStatus, currentStatus) {
+				t.Errorf("returnedStatus differs from currentStatus")
+			}
+
+			// Verify phase and step preserved
+			assert.Equal(t, tc.phase, returnedStatus.Phase)
+			assert.Equal(t, tc.step, returnedStatus.Step)
+
+			// Verify no delete occurred
+			assert.Zero(t, controller.deleteCalls, "Delete should not be called")
+
+			// Verify no enqueue occurred
+			assert.Zero(t, controller.enqueueCalls, "EnqueueAfter should not be called")
+		})
+	}
+}
+
+func TestOnChange_Paused(t *testing.T) {
+	t.Parallel()
+
+	op := newOp()
+	op.Spec.Paused = true
+	op.Generation = 7
+
+	initialStatus := opv1alpha1.ETCDSnapshotSaveStatus{
+		OperationStatus: opv1alpha1.OperationStatus{
+			Phase: opv1alpha1.OperationPhaseInProgress,
+		},
+		Step: opv1alpha1.ETCDSnapshotSaveStepSave,
+	}
+
+	op.Status = initialStatus
+
+	h := &handler{}
+	status, err := h.OnChange(op, op.Status)
+
+	if err != nil {
+		t.Fatalf("OnChange returned error: %v", err)
+	}
+	if got := opv1alpha1.PausedCondition.GetStatus(&status); got != "True" {
+		t.Errorf("PausedCondition status = %q, want %q", got, "True")
+	}
+	if got := opv1alpha1.PausedCondition.GetReason(&status); got != opv1alpha1.PausedReason {
+		t.Errorf("PausedCondition reason = %q, want %q", got, opv1alpha1.PausedReason)
+	}
+	if got := opv1alpha1.PausedCondition.GetMessage(&status); got != "Operation is paused" {
+		t.Errorf("PausedCondition message = %q, want %q", got, "Operation is paused")
+	}
+	if status.ObservedGeneration != int64(7) {
+		t.Errorf("ObservedGeneration = %d, want 7", status.ObservedGeneration)
+	}
+	if status.Phase != initialStatus.Phase {
+		t.Errorf("Phase = %q, want %q (unchanged)", status.Phase, initialStatus.Phase)
+	}
+	if status.Step != initialStatus.Step {
+		t.Errorf("Step = %q, want %q (unchanged)", status.Step, initialStatus.Step)
 	}
 }


### PR DESCRIPTION
## Issue
 #56332

## Problem

Paused ETCDSnapshotRestore and EncryptionKeyRotation operations did not publish a Paused condition, leaving the UI showing Pending or In Progress.

## Solution

Match ETCDSnapshotSave’s pause condition handling in Restore and EKR. Skip TTL cleanup and polling while paused in all three controllers.

## Testing

Added unit coverage for pause/resume conditions, observed generation, phase/step preservation, and skipping deletion and requeue while paused. All three controller unit-test suites passed.
 
