### PR TITLE
[main] Fix v2 prov test log streaming

### DIFF
--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -141,19 +141,28 @@ jobs:
         run: |
           set -eo pipefail
           ./scripts/container-run provisioning-tests | tee provtest_output.txt
-      - name: Move plaintext test results for upload
+      - name: Move test results for upload
         if: always()
         id: test_output
         run: |
           export TESTSUITE="$(echo "${V2PROV_TEST_RUN_REGEX}" | sed 's/Test//' | tr -d '()|_^.*$')"
           echo "suite=${TESTSUITE}" >> $GITHUB_OUTPUT
-          mv ./build/out.txt "/tmp/report-${V2PROV_TEST_DIST}-${TESTSUITE}.txt"
-      - name: Upload Plain Text Test Results
+          # out.txt is the plaintext `go test -v` rendering, out.json is the raw
+          # `go test -json` event stream, which is what the JUnit conversion parses.
+          for ext in txt json; do
+            if [ -f "./build/out.${ext}" ]; then
+              mv "./build/out.${ext}" "/tmp/report-${V2PROV_TEST_DIST}-${TESTSUITE}.${ext}"
+            else
+              echo "warning: ./build/out.${ext} not found"
+            fi
+          done
+      - name: Upload Test Results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: "Test Results ${{ matrix.V2PROV_TEST_DIST }} ${{ steps.test_output.outputs.suite }}"
           path: "/tmp/report-${{ matrix.V2PROV_TEST_DIST }}-${{ steps.test_output.outputs.suite }}.*"
+          if-no-files-found: warn
       - name: Upload logdump artifact if we had some tests failures
         if: failure()
         uses: rancherlabs/cowboy@61de86d99456805424f9af0dadfcf362413cd745 # v0.0.2
@@ -193,25 +202,31 @@ jobs:
   convert-to-xml:
     name: Convert test report to xml
     needs: [provisioning_tests]
+    if: ${{ needs.provisioning_tests.result != 'skipped' }}
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     container: ghcr.io/rancher/ci-image/go1.26@sha256:34d6500cf7fda045e047ac054f42fa65a2c0c291658ddc021c61d2179def46a5 # go1.26
     steps:
-      - name: Fetch plaintext test output
+      - name: Fetch test output
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
+          # Only pull the artifacts we need to convert
+          pattern: "Test Results *"
           merge-multiple: true
           path: /tmp/test-results/
       - name: Convert test results to XML
         run: |
-          for file in $(ls /tmp/test-results/report-*.txt); do
-             echo "Processing $file..."
-             go run github.com/jstemmer/go-junit-report/v2@14d61e6e75e3f3c74551d757ad936e8e88014464 < $file > $(sed 's/txt/xml/g' <<<$file)
+          set -eo pipefail
+          # Parse the raw `go test -json` stream rather than the plaintext report.
+          for file in /tmp/test-results/report-*.json; do
+            [ -f "$file" ] || continue
+            go run github.com/jstemmer/go-junit-report/v2@14d61e6e75e3f3c74551d757ad936e8e88014464 -parser gojson < "$file" > "${file%.json}.xml"
           done
       - name: Upload XML Test Results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: XML Results
           path: "/tmp/test-results/report-*.xml"
+          if-no-files-found: warn
 
   event-file:
     name: Upload event file

--- a/.github/workflows/provisioning-tests.yml
+++ b/.github/workflows/provisioning-tests.yml
@@ -202,7 +202,7 @@ jobs:
   convert-to-xml:
     name: Convert test report to xml
     needs: [provisioning_tests]
-    if: ${{ needs.provisioning_tests.result != 'skipped' }}
+    if: always()
     runs-on: org-${{ github.repository_owner_id }}-amd64-k8s
     container: ghcr.io/rancher/ci-image/go1.26@sha256:34d6500cf7fda045e047ac054f42fa65a2c0c291658ddc021c61d2179def46a5 # go1.26
     steps:

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -367,10 +367,11 @@ render_test_json() {
     '. as $line | try ($line | fromjson | select(.Action == "output" or .Action == "build-output") | .Output) catch ($line + "\n")'
 }
 
-go test -run "${V2PROV_TEST_RUN_REGEX}" -json -failfast -timeout 60m -p 3 -parallel "${V2PROV_TEST_PARALLELISM}" ./tests/v2prov/tests/... 2>&1 \
+go test -run "${V2PROV_TEST_RUN_REGEX}" -json -v -failfast -timeout 60m -p 3 -parallel "${V2PROV_TEST_PARALLELISM}" ./tests/v2prov/tests/... \
+  2> >(tee -a /tmp/out.txt >&2) \
   | tee /tmp/out.json \
   | render_test_json \
-  | tee /tmp/out.txt || {
+  | tee -a /tmp/out.txt || {
      dump_rancher_logs
      exit 1
 }

--- a/scripts/provisioning-tests
+++ b/scripts/provisioning-tests
@@ -349,7 +349,28 @@ if [ -z "${V2PROV_TEST_PARALLELISM}" ]; then
 fi
 
 export KUBECONFIG=/etc/rancher/k3s/k3s.yaml
-go test -run "${V2PROV_TEST_RUN_REGEX}" -v -failfast -timeout 60m -p 3 -parallel "${V2PROV_TEST_PARALLELISM}" ./tests/v2prov/tests/... 2>&1 | tee /tmp/out.txt || {
+
+# `go test -v` buffers each package's output and only releases it once that
+# package finishes, in package-list order. With 7 packages and `-p 3`
+# nothing reaches the log until the whole run is basically over.
+# `-json` skips that buffering. The raw events are stored in out.json
+# (and the JUnit conversion uses `-parser gojson`), and they're rendered
+# back into the plaintext that `go test -v` produces for the live log and out.txt.
+#
+# The jq filter:
+#   -j            no extra newline; .Output already carries its own
+#   --unbuffered  flush every event instead of writing 64KB blocks
+#   try/catch     print lines that aren't JSON
+#   build-output  compiler errors arrive under this action, not "output"
+render_test_json() {
+  jq -j -R --unbuffered \
+    '. as $line | try ($line | fromjson | select(.Action == "output" or .Action == "build-output") | .Output) catch ($line + "\n")'
+}
+
+go test -run "${V2PROV_TEST_RUN_REGEX}" -json -failfast -timeout 60m -p 3 -parallel "${V2PROV_TEST_PARALLELISM}" ./tests/v2prov/tests/... 2>&1 \
+  | tee /tmp/out.json \
+  | render_test_json \
+  | tee /tmp/out.txt || {
      dump_rancher_logs
      exit 1
 }

--- a/tests/v2prov/tests/autoscaler/autoscaling_provisioning_test.go
+++ b/tests/v2prov/tests/autoscaler/autoscaling_provisioning_test.go
@@ -225,7 +225,7 @@ func deployLoadPods(t *testing.T, kc *kubernetes.Clientset) {
 	}
 
 	err := retry.OnError(defaults.DownstreamRetry, func(err error) bool {
-		logrus.Warnf("[deployLoadPods] failed to get '%s' deployment in default workspace, will retry: %v", deploy.Name, err)
+		logrus.Warnf("[deployLoadPods] failed to create '%s' deployment in default workspace, will retry: %v", deploy.Name, err)
 		return true
 	}, func() error {
 		_, err := kc.AppsV1().Deployments("default").Create(context.TODO(), deploy, metav1.CreateOptions{})


### PR DESCRIPTION
## Issue:  https://github.com/rancher/rancher/issues/55231
 
## Problem
Recent refactoring to the `go test` call in `scripts/provisioning-tests` broke log streaming. Right now you can only see the v2 test output after all tests have completed, which is frustrating.
 
## Solution
The root cause is the reduced `-p` flag value, which causes the standard text output flush much less frequently than when it was implicitly set to `16`.  The `-json` flag gets around this, but requires in a bit of finagling to make sure that the junit reports still process the output correctly. It's important to note that since we are still using package level concurrency there may be some interleaving between test logs in the GH UI output. 

## Testing
I've tested this on a debug branch and found that the fix for log streaming works, it can also be validated by looking at the CI of this PR as it runs.

## Engineering Testing
### Manual Testing
Tested in a different PR

