### PR TITLE
Update Renovate workflow reference to use caching

### DIFF
--- a/.github/workflows/renovate-vault.yml
+++ b/.github/workflows/renovate-vault.yml
@@ -48,7 +48,7 @@ jobs:
       contents: read
       id-token: write # Required for Vault OIDC authentication.
     # https://github.com/rancher/renovate-config/releases
-    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@a1a645d20a4c3d46bc5d1a00f45b87362fce5abc # v1.0.9
+    uses: rancher/renovate-config/.github/workflows/renovate-vault.yml@dea92a08bcb3b0c0943e6ae3dc6b2cc68f93fc17 # Improve Renovate run time
     # Note: github.event.inputs.<name> with '||' fallbacks is used across all inputs
     # so that scheduled cron runs (where github.event.inputs is null) safely default.
     with:


### PR DESCRIPTION
A Renovate run previously took more than one hour, causing the GitHub App token to expire before the run completed. Adding a persistent cache among other [optimizations](https://github.com/rancher/renovate-config/pull/888).