### PR TITLE
[v2.15] Register steve ownership filters for Tokens/Kubeconfigs in InstallStores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/rancher/remotedialer v0.6.1
 	github.com/rancher/remotedialer-proxy v0.8.0
 	github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a
-	github.com/rancher/steve v0.9.20
+	github.com/rancher/steve v0.9.21
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260803054930-c6c76ca75822
 	github.com/rancher/wrangler/v3 v3.7.1
 	github.com/robfig/cron v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -665,8 +665,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a h1://lhZJ7E6znLttBO9b2+V/Xl51iw3bDspjiH8W5MxMk=
 github.com/rancher/shepherd v0.0.0-20260610155525-6d926c75d49a/go.mod h1:OxexRIlEGlPaWS9YeFVfYD5ANH/8Yqb+hMyPuUiCp2o=
-github.com/rancher/steve v0.9.20 h1:c5y6WQoTWj1dhuLWz7zDo90dI9P3wYLdLCBSXnKFYy0=
-github.com/rancher/steve v0.9.20/go.mod h1:mI09E2xobibiO6ADBYMUa0p6+/77x8M/A9xUoXJXvGE=
+github.com/rancher/steve v0.9.21 h1:h4yaH2qaVuN2lWgxRYFsdfUSIfJiUqEpGIWMbuQYmUM=
+github.com/rancher/steve v0.9.21/go.mod h1:D6BH+GH4ZyUmFXHX2CEs0l2JRquTemPUpBv+y1gXvHM=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260803054930-c6c76ca75822 h1:PS5UzNmlTMeBhm0Df48pHjiy5MWkHzqHDr4On7kYpDc=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260803054930-c6c76ca75822/go.mod h1:vMTQo88CdIoDMJCX9azje1ckE93d0B82TyMgFroWTcI=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/pkg/ext/stores/install.go
+++ b/pkg/ext/stores/install.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/wrangler"
 	steveext "github.com/rancher/steve/pkg/ext"
+	"github.com/rancher/steve/pkg/resources/ownership"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -44,14 +45,27 @@ func InstallStores(
 	}
 	logrus.Infof("Successfully installed %s store", tokens.SingularName)
 
+	// Tokens are stored in a single steve SQLite table shared by all users
+	// (populated by rancher's own service account, which is admin), but
+	// this store scopes list/get visibility to the requesting user via
+	// UserIDLabel. Register that scoping with steve so its /v1 list and
+	// /v1/count endpoints for tokens apply the same per-user filter this
+	// store applies -- see rancher/rancher#56849.
+	ownership.Register(tokens.GVK, ownership.NewUserIDLabelFilter(tokens.UserIDLabel))
+
+	kubeconfigGVK := extv1.SchemeGroupVersion.WithKind(kubeconfig.Kind)
 	if err := server.Install(
 		extv1.KubeconfigResourceName,
-		extv1.SchemeGroupVersion.WithKind(kubeconfig.Kind),
+		kubeconfigGVK,
 		kubeconfig.New(features.MCM.Enabled(), wranglerContext, server.GetAuthorizer()),
 	); err != nil {
 		return fmt.Errorf("unable to install %s store: %w", kubeconfig.Singular, err)
 	}
 	logrus.Infof("Successfully installed %s store", kubeconfig.Singular)
+
+	// See the Token registration above -- same per-user scoping applies to
+	// Kubeconfigs.
+	ownership.Register(kubeconfigGVK, ownership.NewUserIDLabelFilter(kubeconfig.UserIDLabel))
 
 	if err = server.Install(
 		extv1.PasswordChangeRequestResourceName,


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/issues/56849

# Issue https://github.com/rancher/rancher/issues/56932

With https://github.com/rancher/steve/pull/1290, we can register ownership filters for GVKs that need it. Those ownership filters used to be in steve directly but we're moving them to rancher/rancher now.

