### PR TITLE
[v2.14] Register steve ownership filters for Tokens/Kubeconfigs in InstallStores

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -135,7 +135,7 @@ require (
 	github.com/rancher/remotedialer-proxy v0.7.5
 	github.com/rancher/rke v1.8.0
 	github.com/rancher/shepherd v0.0.0-20260804210509-d33eb553955c
-	github.com/rancher/steve v0.8.26
+	github.com/rancher/steve v0.8.27
 	github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260218133309-b0ff1f4c330d
 	github.com/rancher/wrangler v1.1.2
 	github.com/rancher/wrangler/v3 v3.6.0

--- a/go.sum
+++ b/go.sum
@@ -657,8 +657,8 @@ github.com/rancher/saml v0.4.14-rancher3 h1:2NN6cPqm9FJeiT25x8+gLHWGdulsEak33cHR
 github.com/rancher/saml v0.4.14-rancher3/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/rancher/shepherd v0.0.0-20260804210509-d33eb553955c h1:+VjKwaJZtZQsQSE0ZgezV/DHJPa89wS2LXZaNZU4ZDg=
 github.com/rancher/shepherd v0.0.0-20260804210509-d33eb553955c/go.mod h1:SJtW8Jqv0rphZzsGnvB965YdyR2FqFtB+TbbzVLt8F4=
-github.com/rancher/steve v0.8.26 h1:6rctR6/PnCir1vflk505jUTX88FFH9yB+KM4IqYh4wM=
-github.com/rancher/steve v0.8.26/go.mod h1:M1Wvm2sI+uRKuMjes3e6Jpgu/85LfyPoRKh2wEPoak4=
+github.com/rancher/steve v0.8.27 h1:Z09k0Asx7y4fpXmcNCEFrACQE7rVHxqdbVSHZt0Rcds=
+github.com/rancher/steve v0.8.27/go.mod h1:W331h9HffFV0Oam0ld89gJlxbJnfipL2LxGTyFu4WSg=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260218133309-b0ff1f4c330d h1:OfXAOEoBm4BYEFd4wWkF7c+Eu/OvaOpLb1a+ZBTfZps=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20260218133309-b0ff1f4c330d/go.mod h1:SUiQyIpckuP2ZGusrd+avYyt5WTQ9wuvhffw/ukbcrk=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/pkg/ext/stores/install.go
+++ b/pkg/ext/stores/install.go
@@ -13,6 +13,7 @@ import (
 	"github.com/rancher/rancher/pkg/features"
 	"github.com/rancher/rancher/pkg/wrangler"
 	steveext "github.com/rancher/steve/pkg/ext"
+	"github.com/rancher/steve/pkg/resources/ownership"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -44,14 +45,27 @@ func InstallStores(
 	}
 	logrus.Infof("Successfully installed %s store", tokens.SingularName)
 
+	// Tokens are stored in a single steve SQLite table shared by all users
+	// (populated by rancher's own service account, which is admin), but
+	// this store scopes list/get visibility to the requesting user via
+	// UserIDLabel. Register that scoping with steve so its /v1 list and
+	// /v1/count endpoints for tokens apply the same per-user filter this
+	// store applies -- see rancher/rancher#56849.
+	ownership.Register(tokens.GVK, ownership.NewUserIDLabelFilter(tokens.UserIDLabel))
+
+	kubeconfigGVK := extv1.SchemeGroupVersion.WithKind(kubeconfig.Kind)
 	if err := server.Install(
 		extv1.KubeconfigResourceName,
-		extv1.SchemeGroupVersion.WithKind(kubeconfig.Kind),
+		kubeconfigGVK,
 		kubeconfig.New(features.MCM.Enabled(), wranglerContext, server.GetAuthorizer()),
 	); err != nil {
 		return fmt.Errorf("unable to install %s store: %w", kubeconfig.Singular, err)
 	}
 	logrus.Infof("Successfully installed %s store", kubeconfig.Singular)
+
+	// See the Token registration above -- same per-user scoping applies to
+	// Kubeconfigs.
+	ownership.Register(kubeconfigGVK, ownership.NewUserIDLabelFilter(kubeconfig.UserIDLabel))
 
 	if err = server.Install(
 		extv1.PasswordChangeRequestResourceName,


### PR DESCRIPTION
Backport of https://github.com/rancher/rancher/issues/56849

# Issue https://github.com/rancher/rancher/issues/57105

With https://github.com/rancher/steve/pull/1290, we can register ownership filters for GVKs that need it. Those ownership filters used to be in steve directly but we're moving them to rancher/rancher now.

