### PR TITLE
modified okta ldap setup to immediately save password into a secret

### DIFF
--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -343,7 +343,7 @@ func (s *Provider) saveSamlConfig(config *apiv3.SamlConfig) error {
 	if s.hasLdapGroupSearch() {
 		combinedConfig, err := s.combineSamlAndLdapConfig(config)
 		if err != nil {
-			logrus.Warnf("problem combining saml and ldap config, saving partial configuration %s", err.Error())
+			return err
 		}
 		_, err = s.authConfigs.ObjectClient().Update(config.ObjectMeta.Name, combinedConfig)
 		if err != nil {

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -61,6 +61,7 @@ type Provider struct {
 }
 
 var SamlProviders = make(map[string]*Provider)
+var getLDAPConfig = ldap.GetLDAPConfig
 
 func Configure(ctx context.Context, mgmtCtx *config.ScaledContext, userMGR user.Manager, tokenMGR *tokens.Manager, name string) common.AuthProvider {
 	provider := &Provider{
@@ -509,7 +510,7 @@ func splitPrincipalID(principalID string) (string, string) {
 
 func (s *Provider) combineSamlAndLdapConfig(config *apiv3.SamlConfig) (runtime.Object, error) {
 	// if errors we might not want to turn on ldap
-	ldapConfig, _, err := ldap.GetLDAPConfig(s.ldapProvider)
+	ldapConfig, _, err := getLDAPConfig(s.ldapProvider)
 
 	// can be misconfigured but still want it saved
 	if err != nil {

--- a/pkg/auth/providers/saml/saml_provider.go
+++ b/pkg/auth/providers/saml/saml_provider.go
@@ -550,6 +550,19 @@ func (s *Provider) combineSamlAndLdapConfig(config *apiv3.SamlConfig) (runtime.O
 			OpenLdapConfig: ldapConfig.LdapFields,
 		}
 	case OKTAName:
+		secretName, err := common.SavePasswordSecret(
+			s.secrets,
+			ldapConfig.LdapFields.ServiceAccountPassword,
+			client.LdapConfigFieldServiceAccountPassword,
+			samlConfig.Type,
+		)
+		if err != nil {
+			return config, fmt.Errorf("unable to save ldap service account password: %w", err)
+		}
+
+		ldapConfig.LdapFields.ServiceAccountPassword = secretName
+		// Set the status for OKTA password migration to True so it doesn't get re-migrated
+		apiv3.AuthConfigOKTAPasswordMigrated.SetStatus(&samlConfig, "True")
 		fullConfig = &apiv3.OKTAConfig{
 			SamlConfig:     samlConfig,
 			OpenLdapConfig: ldapConfig.LdapFields,

--- a/pkg/auth/providers/saml/saml_provider_test.go
+++ b/pkg/auth/providers/saml/saml_provider_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/crewjam/saml"
+	"github.com/rancher/norman/objectclient"
 	"github.com/rancher/norman/types"
 	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -159,6 +160,50 @@ func TestCombineSamlAndLdapConfigStoresLDAPPasswordInSecret(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSaveSamlConfigReturnsErrorWhenLDAPPasswordSecretSaveFails(t *testing.T) {
+	originalGetLDAPConfig := getLDAPConfig
+	t.Cleanup(func() {
+		getLDAPConfig = originalGetLDAPConfig
+	})
+
+	getLDAPConfig = func(common.AuthProvider) (*apiv3.LdapConfig, *x509.CertPool, error) {
+		return &apiv3.LdapConfig{
+			LdapFields: apiv3.LdapFields{
+				ServiceAccountPassword: "test-password",
+			},
+		}, nil, nil
+	}
+
+	ctrl := gomock.NewController(t)
+	secretController := wranglerfake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+	secretCache := wranglerfake.NewMockCacheInterface[*corev1.Secret](ctrl)
+	secretController.EXPECT().Cache().Return(secretCache)
+	secretCache.EXPECT().Get(common.SecretsNamespace, "oktaconfig-serviceaccountpassword").Return(nil, assert.AnError)
+
+	provider := &Provider{
+		name:         OKTAName,
+		secrets:      secretController,
+		ldapProvider: &mockLdapProvider{providerName: OKTAName},
+		authConfigs: &fakes.AuthConfigInterfaceMock{
+			ObjectClientFunc: func() *objectclient.ObjectClient {
+				t.Fatal("auth config update should not be attempted when saving the LDAP password secret fails")
+				return nil
+			},
+		},
+		getSamlConfig: func() (*apiv3.SamlConfig, error) {
+			return &apiv3.SamlConfig{
+				AuthConfig: apiv3.AuthConfig{
+					ObjectMeta: metav1.ObjectMeta{Name: "okta"},
+				},
+			}, nil
+		},
+	}
+
+	err := provider.saveSamlConfig(&apiv3.SamlConfig{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unable to save ldap service account password")
 }
 
 func TestSearchPrincipals(t *testing.T) {

--- a/pkg/auth/providers/saml/saml_provider_test.go
+++ b/pkg/auth/providers/saml/saml_provider_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -26,10 +27,15 @@ import (
 	"github.com/rancher/rancher/pkg/types/config"
 	"github.com/rancher/rancher/pkg/user"
 	"github.com/rancher/rancher/pkg/wrangler"
+	wranglerfake "github.com/rancher/wrangler/v3/pkg/generic/fake"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/rest"
 )
@@ -73,6 +79,86 @@ func TestConfiguredGenericSAMLProviderHasNoLdap(t *testing.T) {
 
 	assert.False(t, provider.hasLdapGroupSearch(), "Generic SAML provider must not have LDAP group search")
 	assert.Nil(t, provider.ldapProvider, "Generic SAML provider must not receive a child LDAP provider")
+}
+
+func TestCombineSamlAndLdapConfigStoresLDAPPasswordInSecret(t *testing.T) {
+	originalGetLDAPConfig := getLDAPConfig
+	t.Cleanup(func() {
+		getLDAPConfig = originalGetLDAPConfig
+	})
+
+	getLDAPConfig = func(common.AuthProvider) (*apiv3.LdapConfig, *x509.CertPool, error) {
+		return &apiv3.LdapConfig{
+			LdapFields: apiv3.LdapFields{
+				ServiceAccountPassword: "test-password",
+			},
+		}, nil, nil
+	}
+
+	tests := []struct {
+		name           string
+		providerName   string
+		configType     string
+		wantSecretName string
+	}{
+		{
+			name:           "okta",
+			providerName:   OKTAName,
+			configType:     client.OKTAConfigType,
+			wantSecretName: "oktaconfig-serviceaccountpassword",
+		},
+		{
+			name:           "shibboleth",
+			providerName:   ShibbolethName,
+			configType:     client.ShibbolethConfigType,
+			wantSecretName: "shibbolethconfig-serviceaccountpassword",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			secretController := wranglerfake.NewMockControllerInterface[*corev1.Secret, *corev1.SecretList](ctrl)
+			secretCache := wranglerfake.NewMockCacheInterface[*corev1.Secret](ctrl)
+			secretController.EXPECT().Cache().Return(secretCache)
+			secretCache.EXPECT().Get(common.SecretsNamespace, tt.wantSecretName).Return(nil, apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, tt.wantSecretName))
+			secretController.EXPECT().Create(gomock.Any()).DoAndReturn(func(secret *corev1.Secret) (*corev1.Secret, error) {
+				assert.Equal(t, tt.wantSecretName, secret.Name)
+				assert.Equal(t, common.SecretsNamespace, secret.Namespace)
+				assert.Equal(t, map[string]string{
+					"serviceaccountpassword": "test-password",
+				}, secret.StringData)
+
+				return secret, nil
+			})
+
+			provider := &Provider{
+				name:         tt.providerName,
+				secrets:      secretController,
+				ldapProvider: &mockLdapProvider{providerName: tt.providerName},
+			}
+
+			config, err := provider.combineSamlAndLdapConfig(&apiv3.SamlConfig{
+				AuthConfig: apiv3.AuthConfig{
+					Type: tt.configType,
+				},
+			})
+			require.NoError(t, err)
+
+			wantSecretRef := common.SecretsNamespace + ":" + tt.wantSecretName
+
+			switch typedConfig := config.(type) {
+			case *apiv3.OKTAConfig:
+				assert.Equal(t, wantSecretRef, typedConfig.OpenLdapConfig.ServiceAccountPassword)
+				assert.True(t, apiv3.AuthConfigOKTAPasswordMigrated.IsTrue(&typedConfig.SamlConfig))
+			case *apiv3.ShibbolethConfig:
+				assert.Equal(t, wantSecretRef, typedConfig.OpenLdapConfig.ServiceAccountPassword)
+				assert.True(t, apiv3.AuthConfigConditionSecretsMigrated.IsTrue(&typedConfig.SamlConfig))
+			default:
+				t.Fatalf("unexpected config type %T", config)
+			}
+		})
+	}
 }
 
 func TestSearchPrincipals(t *testing.T) {


### PR DESCRIPTION
## Issue: <!-- link the issue or issues this PR resolves here -->

Issue #57095 
 
## Problem

The LDAP setup of the OKTA provider does not save the password immediately into a secret, like Shibboleth does.
 
Note https://github.com/rancher/rancher/pull/57021/files/ca882d064045a6c0f3f7fea28adece6409364911#diff-f15a5e17c6575557554ecc152a1737527aa690cda3390e453564d266b319fd22 for the initial report.

## Solution

Added saving to secret to the OKTA LDAP setup.

## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->

### Automated Testing
<!-- Ensure there are unit/integration/validation tests added (if possible); describe what cases they cover and do not cover. -->
* Test types added/modified:
    * Unit
    * Integration (Go Framework)
    * Integration (v2prov Framework)
    * Validation (Go Framework)
    * Other - Explain: _EXPLAIN_
    * None
    * _REMOVE NOT APPLICABLE BULLET POINTS ABOVE_
* If "None" - Reason: _EXPLAIN THE REASON_
  <!-- 
  Non-exhaustive list of reasons:
    - Lack of the framework capable of testing this fix/change
    - Tight deadlines / critical priority to get fix/change in - !ensure GH issue is logged to add tests!
    - No application logic is modified by this change, e.g. refactoring/cosmetic/non-code/test change
    - Tests implemented in another PR elsewhere - !ensure GH PR link is added!
    - Other (explain)
  Note: Outside of the exceptions above, the "existing tests cover the changes" is very unlikely to be an acceptable reason as the existing tests generally don't cover the logic changes implemented by this PR 
  -->
* If "None" - GH Issue/PR: _LINK TO GH ISSUE/PR TO ADD TESTS_

Summary: _TODO_

## QA Testing Considerations
<!-- Highlight areas or (additional) cases that QA should test w.r.t a fresh install as well as the upgrade scenarios -->
 
### Regressions Considerations
<!-- Dedicated section to specifically call out any areas that with higher chance of regressions caused by this change, include estimation of probability of regressions -->
_TODO_

Existing / newly added automated tests that provide evidence there are no regressions:
* _TODO_