### PR TITLE
fix(auth): reject current password reuse in self-service changes

### DIFF
--- a/pkg/ext/stores/passwordchangerequest/store.go
+++ b/pkg/ext/stores/passwordchangerequest/store.go
@@ -147,6 +147,11 @@ func (s *Store) Create(
 		return nil, apierrors.NewBadRequest("password cannot be the same as the username")
 	}
 
+	// A user changing their own password must choose a different password.
+	if userInfo.GetName() == req.Spec.UserID && req.Spec.NewPassword == req.Spec.CurrentPassword {
+		return nil, apierrors.NewBadRequest("new password must not be the same as the current password")
+	}
+
 	dryRun := options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll
 
 	if dryRun {

--- a/pkg/ext/stores/passwordchangerequest/store_test.go
+++ b/pkg/ext/stores/passwordchangerequest/store_test.go
@@ -205,6 +205,57 @@ func TestCreate(t *testing.T) {
 			wantErr:    "password cannot be the same as the username",
 		},
 		{
+			desc: "same user cannot reuse current password",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:          userID,
+					CurrentPassword: oldPassword,
+					NewPassword:     oldPassword,
+				},
+			},
+			ctx:        request.WithUser(context.Background(), &user.DefaultInfo{Name: userID}),
+			pwdUpdater: pwdUpdater,
+			userCache:  userCache,
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionDeny, "", nil
+			}),
+			wantErr: "new password must not be the same as the current password",
+		},
+		{
+			desc: "same user with mustChangePassword cannot reuse current password",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:          userID,
+					CurrentPassword: oldPassword,
+					NewPassword:     oldPassword,
+				},
+			},
+			ctx:        request.WithUser(context.Background(), &user.DefaultInfo{Name: userID}),
+			pwdUpdater: pwdUpdater,
+			userCache:  userWithMustChangePasswordCache,
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionDeny, "", nil
+			}),
+			wantErr: "new password must not be the same as the current password",
+		},
+		{
+			desc: "privileged user cannot reuse current password for self",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:          userID,
+					CurrentPassword: oldPassword,
+					NewPassword:     oldPassword,
+				},
+			},
+			ctx:        request.WithUser(context.Background(), &user.DefaultInfo{Name: userID}),
+			pwdUpdater: pwdUpdater,
+			userCache:  userCache,
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			}),
+			wantErr: "new password must not be the same as the current password",
+		},
+		{
 			desc: "user not found",
 			obj: &ext.PasswordChangeRequest{
 				Spec: ext.PasswordChangeRequestSpec{

--- a/pkg/ext/stores/passwordchangerequest/store_test.go
+++ b/pkg/ext/stores/passwordchangerequest/store_test.go
@@ -69,16 +69,17 @@ func TestCreate(t *testing.T) {
 	}
 
 	tests := []struct {
-		desc       string
-		obj        *ext.PasswordChangeRequest
-		ctx        context.Context
-		options    *metav1.CreateOptions
-		authorizer authorizer.Authorizer
-		pwdUpdater func() PasswordUpdater
-		userCache  func() mgmtv3.UserCache
-		userClient func() mgmtv3.UserClient
-		wantObj    *ext.PasswordChangeRequest
-		wantErr    string
+		desc           string
+		obj            *ext.PasswordChangeRequest
+		ctx            context.Context
+		options        *metav1.CreateOptions
+		authorizer     authorizer.Authorizer
+		pwdUpdater     func() PasswordUpdater
+		userCache      func() mgmtv3.UserCache
+		userClient     func() mgmtv3.UserClient
+		wantObj        *ext.PasswordChangeRequest
+		wantErr        string
+		wantBadRequest bool
 	}{
 		{
 			desc: "password changed for the same user",
@@ -219,7 +220,8 @@ func TestCreate(t *testing.T) {
 			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				return authorizer.DecisionDeny, "", nil
 			}),
-			wantErr: "new password must not be the same as the current password",
+			wantErr:        "new password must not be the same as the current password",
+			wantBadRequest: true,
 		},
 		{
 			desc: "same user with mustChangePassword cannot reuse current password",
@@ -236,7 +238,8 @@ func TestCreate(t *testing.T) {
 			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				return authorizer.DecisionDeny, "", nil
 			}),
-			wantErr: "new password must not be the same as the current password",
+			wantErr:        "new password must not be the same as the current password",
+			wantBadRequest: true,
 		},
 		{
 			desc: "privileged user cannot reuse current password for self",
@@ -253,7 +256,61 @@ func TestCreate(t *testing.T) {
 			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
 				return authorizer.DecisionAllow, "", nil
 			}),
-			wantErr: "new password must not be the same as the current password",
+			wantErr:        "new password must not be the same as the current password",
+			wantBadRequest: true,
+		},
+		{
+			desc: "same user cannot reuse current password in a dry run",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:          userID,
+					CurrentPassword: oldPassword,
+					NewPassword:     oldPassword,
+				},
+			},
+			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: userID}),
+			options: &metav1.CreateOptions{
+				DryRun: []string{metav1.DryRunAll},
+			},
+			pwdUpdater:     pwdUpdater,
+			userCache:      userCache,
+			wantErr:        "new password must not be the same as the current password",
+			wantBadRequest: true,
+		},
+		{
+			desc: "privileged user can reset another user with the same current and new password",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:          userID,
+					CurrentPassword: oldPassword,
+					NewPassword:     oldPassword,
+				},
+			},
+			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: "another-user"}),
+			pwdUpdater: func() PasswordUpdater {
+				mock := mocks.NewMockPasswordUpdater(ctrl)
+				mock.EXPECT().UpdatePassword(userID, oldPassword).Return(nil)
+
+				return mock
+			},
+			userCache: userCache,
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			}),
+			wantObj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:          userID,
+					CurrentPassword: oldPassword,
+					NewPassword:     oldPassword,
+				},
+				Status: ext.PasswordChangeRequestStatus{
+					Conditions: []metav1.Condition{{
+						Type:   "PasswordUpdated",
+						Status: "True",
+					}},
+					Summary: status.SummaryCompleted,
+				},
+			},
 		},
 		{
 			desc: "user not found",
@@ -432,6 +489,9 @@ func TestCreate(t *testing.T) {
 
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
+				if tt.wantBadRequest {
+					assert.True(t, apierrors.IsBadRequest(err))
+				}
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tt.wantObj, obj)


### PR DESCRIPTION
## Issue: Fixes #57235

## Problem
The `PasswordChangeRequest` API does not reject a user's new password when it is identical to their current password. This is particularly problematic for users with `mustChangePassword=true`: the user can submit the administrator-assigned temporary password as both `currentPassword` and `newPassword`, and the request succeeds while clearing `mustChangePassword`.

The legacy Norman password-change API already rejects this condition, so the two password-change APIs behave inconsistently.

## Solution
Add validation to `PasswordChangeRequest` when the authenticated user is changing their own password. If `newPassword` equals `currentPassword`, the request is rejected before dry-run handling, authorization-based password updates, or `mustChangePassword` state changes.

The validation is intentionally limited to self-service password changes. Administrator password resets for other users retain their existing behavior.

This change intentionally does not implement password history or prevent reuse of previously used passwords.

## Testing
The issue reproduction steps describe the affected Dashboard setup flow and direct `PasswordChangeRequest` API path. Manual execution of the reproducer was not performed.

## Engineering Testing
### Manual Testing
Not performed. The targeted backend unit test covers the affected API path.

### Automated Testing
* Test types added/modified:
    * Unit

Summary: Added unit coverage verifying that:
* a regular user cannot reuse their current password when changing their own password;
* reuse is rejected when `mustChangePassword=true`;
* a privileged user changing their own password is subject to the same validation;
* reuse is rejected before dry-run processing and returns a `BadRequest`;
* administrator password resets for another user remain unaffected.

Command:
`go test ./pkg/ext/stores/passwordchangerequest -count=1`

## QA Testing Considerations
QA should verify ordinary local-user password changes and forced password changes after an administrator assigns a temporary password. Administrator password resets for another user should continue to work as before.

Password history is outside the scope of this change. A user may still change to a previously used password, provided it is not their current password.

### Regressions Considerations
Regression risk is low. The new validation only applies when the authenticated user is changing their own password and `newPassword` is identical to `currentPassword`. Password changes to a different value and administrator resets of other users are unaffected.

Existing / newly added automated tests that provide evidence there are no regressions:
* `pkg/ext/stores/passwordchangerequest/store_test.go`
