### PR TITLE
Set local user passwords without depending on webhook

### DIFF
--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -9,18 +9,21 @@ import (
 	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/parse"
 	"github.com/rancher/norman/types"
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providerrefresh"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	exttokenstore "github.com/rancher/rancher/pkg/ext/stores/tokens"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	wranglerv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PasswordUpdater interface {
 	VerifyAndUpdatePassword(userId string, currentPassword, newPassword string) error
 	UpdatePassword(userId string, newPassword string) error
+	CreatePassword(user *apiv3.User, password string) error
 }
 
 func (h *Handler) UserFormatter(apiContext *types.APIContext, resource *types.RawResource) {
@@ -164,7 +167,19 @@ func (h *Handler) setPassword(request *types.APIContext) error {
 		return errors.New("failed to get userId")
 	}
 	if err := h.PwdChanger.UpdatePassword(userId, newPass); err != nil {
-		return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
+		if !apierrors.IsNotFound(err) {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
+		}
+
+		// The user has no password yet. This is the case for a user created
+		// through the public API, where the password is set separately.
+		user, err := h.UserClient.Get(userId, v1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		if err := h.PwdChanger.CreatePassword(user, newPass); err != nil {
+			return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
+		}
 	}
 
 	userData[client.UserFieldMustChangePassword] = false

--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -16,14 +16,12 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	wranglerv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type PasswordUpdater interface {
 	VerifyAndUpdatePassword(userId string, currentPassword, newPassword string) error
-	UpdatePassword(userId string, newPassword string) error
-	CreatePassword(user *apiv3.User, password string) error
+	SetPassword(user *apiv3.User, newPassword string) error
 }
 
 func (h *Handler) UserFormatter(apiContext *types.APIContext, resource *types.RawResource) {
@@ -166,20 +164,12 @@ func (h *Handler) setPassword(request *types.APIContext) error {
 	if !ok {
 		return errors.New("failed to get userId")
 	}
-	if err := h.PwdChanger.UpdatePassword(userId, newPass); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
-		}
-
-		// The user has no password yet. This is the case for a user created
-		// through the public API, where the password is set separately.
-		user, err := h.UserClient.Get(userId, v1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if err := h.PwdChanger.CreatePassword(user, newPass); err != nil {
-			return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
-		}
+	user, err := h.UserClient.Get(userId, v1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	if err := h.PwdChanger.SetPassword(user, newPass); err != nil {
+		return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())
 	}
 
 	userData[client.UserFieldMustChangePassword] = false

--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -17,6 +17,7 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/settings"
 	wranglerv1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -166,6 +167,9 @@ func (h *Handler) setPassword(request *types.APIContext) error {
 		return errors.New("failed to get userId")
 	}
 	user, err := h.UserClient.Get(userId, v1.GetOptions{})
+	if apierrors.IsNotFound(err) {
+		return httperror.NewAPIError(httperror.NotFound, fmt.Sprintf("user %s not found", userId))
+	}
 	if err != nil {
 		return fmt.Errorf("failed to get user %s: %w", userId, err)
 	}

--- a/pkg/auth/api/user/user_actions.go
+++ b/pkg/auth/api/user/user_actions.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"fmt"
 	"net/http"
 	"strings"
 	"unicode/utf8"
@@ -166,7 +167,7 @@ func (h *Handler) setPassword(request *types.APIContext) error {
 	}
 	user, err := h.UserClient.Get(userId, v1.GetOptions{})
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get user %s: %w", userId, err)
 	}
 	if err := h.PwdChanger.SetPassword(user, newPass); err != nil {
 		return httperror.NewAPIError(httperror.InvalidBodyContent, err.Error())

--- a/pkg/auth/api/user/user_actions_test.go
+++ b/pkg/auth/api/user/user_actions_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,9 +15,7 @@ import (
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestValidatePassword(t *testing.T) {
@@ -310,27 +307,19 @@ func (f *fakeAccessControl) FilterList(apiContext *types.APIContext, schema *typ
 }
 
 type fakePasswordUpdater struct {
-	updateErr   error
-	createErr   error
-	updatedUser string
-	createdUser *apiv3.User
-	password    string
+	err      error
+	user     *apiv3.User
+	password string
 }
 
 func (f *fakePasswordUpdater) VerifyAndUpdatePassword(string, string, string) error {
 	return nil
 }
 
-func (f *fakePasswordUpdater) UpdatePassword(userId string, newPassword string) error {
-	f.updatedUser = userId
+func (f *fakePasswordUpdater) SetPassword(user *apiv3.User, newPassword string) error {
+	f.user = user
 	f.password = newPassword
-	return f.updateErr
-}
-
-func (f *fakePasswordUpdater) CreatePassword(user *apiv3.User, password string) error {
-	f.createdUser = user
-	f.password = password
-	return f.createErr
+	return f.err
 }
 
 type fakeResponseWriter struct {
@@ -348,7 +337,6 @@ func TestSetPassword(t *testing.T) {
 
 	userID := "u-abc"
 	newPassword := "fake-new-password"
-	notFound := fmt.Errorf("failed to get password secret: %w", apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, userID))
 	user := &apiv3.User{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: userID,
@@ -358,34 +346,23 @@ func TestSetPassword(t *testing.T) {
 	}
 
 	tests := []struct {
-		name        string
-		pwdUpdater  *fakePasswordUpdater
-		userGetErr  error
-		wantErr     string
-		wantCreated bool
+		name       string
+		pwdUpdater *fakePasswordUpdater
+		userGetErr error
+		wantErr    string
 	}{
 		{
-			name:       "existing password is updated",
+			name:       "password is set",
 			pwdUpdater: &fakePasswordUpdater{},
 		},
 		{
-			name:        "missing password is created",
-			pwdUpdater:  &fakePasswordUpdater{updateErr: notFound},
-			wantCreated: true,
-		},
-		{
-			name:       "error updating password",
-			pwdUpdater: &fakePasswordUpdater{updateErr: errors.New("unexpected error")},
+			name:       "error setting password",
+			pwdUpdater: &fakePasswordUpdater{err: errors.New("unexpected error")},
 			wantErr:    "unexpected error",
 		},
 		{
-			name:       "error creating password",
-			pwdUpdater: &fakePasswordUpdater{updateErr: notFound, createErr: errors.New("unexpected error")},
-			wantErr:    "unexpected error",
-		},
-		{
-			name:       "error getting user for missing password",
-			pwdUpdater: &fakePasswordUpdater{updateErr: notFound},
+			name:       "error getting user",
+			pwdUpdater: &fakePasswordUpdater{},
 			userGetErr: errors.New("unexpected error"),
 			wantErr:    "unexpected error",
 		},
@@ -429,13 +406,8 @@ func TestSetPassword(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-			assert.Equal(t, userID, tt.pwdUpdater.updatedUser)
+			assert.Equal(t, user, tt.pwdUpdater.user)
 			assert.Equal(t, newPassword, tt.pwdUpdater.password)
-			if tt.wantCreated {
-				assert.Equal(t, user, tt.pwdUpdater.createdUser)
-			} else {
-				assert.Nil(t, tt.pwdUpdater.createdUser)
-			}
 			assert.Equal(t, false, store.updateData[client.UserFieldMustChangePassword])
 			assert.Equal(t, http.StatusOK, rw.code)
 		})

--- a/pkg/auth/api/user/user_actions_test.go
+++ b/pkg/auth/api/user/user_actions_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/rancher/norman/httperror"
 	"github.com/rancher/norman/types"
 	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
@@ -15,7 +16,9 @@ import (
 	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestValidatePassword(t *testing.T) {
@@ -346,11 +349,19 @@ func TestSetPassword(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		pwdUpdater *fakePasswordUpdater
-		userGetErr error
-		wantErr    string
+		name         string
+		pwdUpdater   *fakePasswordUpdater
+		userGetErr   error
+		wantErr      string
+		wantNotFound bool
 	}{
+		{
+			name:         "user not found",
+			pwdUpdater:   &fakePasswordUpdater{},
+			userGetErr:   apierrors.NewNotFound(schema.GroupResource{Resource: "users"}, userID),
+			wantErr:      "not found",
+			wantNotFound: true,
+		},
 		{
 			name:       "password is set",
 			pwdUpdater: &fakePasswordUpdater{},
@@ -403,6 +414,7 @@ func TestSetPassword(t *testing.T) {
 
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)
+				assert.Equal(t, tt.wantNotFound, httperror.IsNotFound(err))
 				return
 			}
 			require.NoError(t, err)

--- a/pkg/auth/api/user/user_actions_test.go
+++ b/pkg/auth/api/user/user_actions_test.go
@@ -1,12 +1,24 @@
 package user
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/rancher/norman/types"
+	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	client "github.com/rancher/rancher/pkg/client/generated/management/v3"
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
+	"github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3/fakes"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 func TestValidatePassword(t *testing.T) {
@@ -295,4 +307,137 @@ func (f *fakeAccessControl) Filter(apiContext *types.APIContext, schema *types.S
 
 func (f *fakeAccessControl) FilterList(apiContext *types.APIContext, schema *types.Schema, objs []map[string]interface{}, context map[string]string) []map[string]interface{} {
 	return objs
+}
+
+type fakePasswordUpdater struct {
+	updateErr   error
+	createErr   error
+	updatedUser string
+	createdUser *apiv3.User
+	password    string
+}
+
+func (f *fakePasswordUpdater) VerifyAndUpdatePassword(string, string, string) error {
+	return nil
+}
+
+func (f *fakePasswordUpdater) UpdatePassword(userId string, newPassword string) error {
+	f.updatedUser = userId
+	f.password = newPassword
+	return f.updateErr
+}
+
+func (f *fakePasswordUpdater) CreatePassword(user *apiv3.User, password string) error {
+	f.createdUser = user
+	f.password = password
+	return f.createErr
+}
+
+type fakeResponseWriter struct {
+	code int
+	obj  interface{}
+}
+
+func (f *fakeResponseWriter) Write(_ *types.APIContext, code int, obj interface{}) {
+	f.code = code
+	f.obj = obj
+}
+
+func TestSetPassword(t *testing.T) {
+	t.Parallel()
+
+	userID := "u-abc"
+	newPassword := "fake-new-password"
+	notFound := fmt.Errorf("failed to get password secret: %w", apierrors.NewNotFound(schema.GroupResource{Resource: "secrets"}, userID))
+	user := &apiv3.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userID,
+			UID:  "fake-uid",
+		},
+		Username: "fake-username",
+	}
+
+	tests := []struct {
+		name        string
+		pwdUpdater  *fakePasswordUpdater
+		userGetErr  error
+		wantErr     string
+		wantCreated bool
+	}{
+		{
+			name:       "existing password is updated",
+			pwdUpdater: &fakePasswordUpdater{},
+		},
+		{
+			name:        "missing password is created",
+			pwdUpdater:  &fakePasswordUpdater{updateErr: notFound},
+			wantCreated: true,
+		},
+		{
+			name:       "error updating password",
+			pwdUpdater: &fakePasswordUpdater{updateErr: errors.New("unexpected error")},
+			wantErr:    "unexpected error",
+		},
+		{
+			name:       "error creating password",
+			pwdUpdater: &fakePasswordUpdater{updateErr: notFound, createErr: errors.New("unexpected error")},
+			wantErr:    "unexpected error",
+		},
+		{
+			name:       "error getting user for missing password",
+			pwdUpdater: &fakePasswordUpdater{updateErr: notFound},
+			userGetErr: errors.New("unexpected error"),
+			wantErr:    "unexpected error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := &mockStore{
+				byIDResults: []map[string]interface{}{{
+					types.ResourceFieldID:    userID,
+					client.UserFieldUsername: user.Username,
+				}},
+			}
+			userClient := &fakes.UserInterfaceMock{
+				GetFunc: func(name string, _ metav1.GetOptions) (*apiv3.User, error) {
+					assert.Equal(t, userID, name)
+					return user, tt.userGetErr
+				},
+			}
+			h := &Handler{
+				UserClient: userClient,
+				PwdChanger: tt.pwdUpdater,
+			}
+
+			body, _ := json.Marshal(map[string]string{"newPassword": newPassword})
+			req := httptest.NewRequest("POST", "/v3/users/"+userID+"?action=setpassword", bytes.NewReader(body))
+			rw := &fakeResponseWriter{}
+			apiCtx := &types.APIContext{
+				Request:        req,
+				ResponseWriter: rw,
+				ID:             userID,
+				Schema:         &types.Schema{Store: store},
+			}
+
+			err := h.setPassword(apiCtx)
+
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, userID, tt.pwdUpdater.updatedUser)
+			assert.Equal(t, newPassword, tt.pwdUpdater.password)
+			if tt.wantCreated {
+				assert.Equal(t, user, tt.pwdUpdater.createdUser)
+			} else {
+				assert.Nil(t, tt.pwdUpdater.createdUser)
+			}
+			assert.Equal(t, false, store.updateData[client.UserFieldMustChangePassword])
+			assert.Equal(t, http.StatusOK, rw.code)
+		})
+	}
 }

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha3"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
@@ -120,11 +121,12 @@ type patchOp struct {
 }
 
 // updatePassword replaces the secret data with the hashed new password in a
-// single patch. A missing hash annotation is set, and when owner is not nil
-// and the secret has no owner reference to it, one is added.
+// single patch. The hash annotation is set when it does not name the algorithm
+// used, and when owner is not nil and the secret has no owner reference to it,
+// one is added.
 func (p *Pbkdf2) updatePassword(secret *corev1.Secret, newPassword string, owner *v3.User) error {
 	var value map[string][]byte
-	var ops []patchOp
+	var algorithm string
 	switch secret.Annotations[passwordHashAnnotation] {
 	case pbkdf2sha3512Hash, "":
 		salt, err := p.saltGenerator()
@@ -141,22 +143,7 @@ func (p *Pbkdf2) updatePassword(secret *corev1.Secret, newPassword string, owner
 			"password": hashedNewPassword,
 			"salt":     salt,
 		}
-
-		if _, ok := secret.Annotations[passwordHashAnnotation]; !ok {
-			if len(secret.Annotations) == 0 {
-				ops = append(ops, patchOp{
-					Op:    "add",
-					Path:  "/metadata/annotations",
-					Value: map[string]string{passwordHashAnnotation: pbkdf2sha3512Hash},
-				})
-			} else {
-				ops = append(ops, patchOp{
-					Op:    "add",
-					Path:  "/metadata/annotations/" + rfc6901PathEscape(passwordHashAnnotation),
-					Value: pbkdf2sha3512Hash,
-				})
-			}
-		}
+		algorithm = pbkdf2sha3512Hash
 	case bcryptHash:
 		hashedNewPassword, err := p.bcryptKey([]byte(newPassword), bcrypt.DefaultCost)
 		if err != nil {
@@ -166,25 +153,47 @@ func (p *Pbkdf2) updatePassword(secret *corev1.Secret, newPassword string, owner
 		value = map[string][]byte{
 			"password": hashedNewPassword,
 		}
+		algorithm = bcryptHash
 	default:
 		return fmt.Errorf("unsupported hashing algorithm %q", secret.Annotations[passwordHashAnnotation])
 	}
 
-	if owner != nil && !hasOwner(secret.OwnerReferences, owner) {
-		refs := make([]metav1.OwnerReference, 0, len(secret.OwnerReferences)+1)
-		refs = append(refs, secret.OwnerReferences...)
-		ops = append(ops, patchOp{
-			Op:    "add",
-			Path:  "/metadata/ownerReferences",
-			Value: append(refs, ownerReference(owner)),
-		})
-	}
-
-	patch, err := json.Marshal(append([]patchOp{{
+	ops := []patchOp{{
 		Op:    "replace",
 		Path:  "/data",
 		Value: value,
-	}}, ops...))
+	}}
+
+	if secret.Annotations[passwordHashAnnotation] != algorithm {
+		if len(secret.Annotations) == 0 {
+			ops = append(ops, patchOp{
+				Op:    "add",
+				Path:  "/metadata/annotations",
+				Value: map[string]string{passwordHashAnnotation: algorithm},
+			})
+		} else {
+			ops = append(ops, patchOp{
+				Op:    "add",
+				Path:  "/metadata/annotations/" + rfc6901PathEscape(passwordHashAnnotation),
+				Value: algorithm,
+			})
+		}
+	}
+
+	if owner != nil {
+		ownedByUser := func(ref metav1.OwnerReference) bool {
+			return ref.Kind == "User" && ref.Name == owner.Name
+		}
+		if !slices.ContainsFunc(secret.OwnerReferences, ownedByUser) {
+			ops = append(ops, patchOp{
+				Op:    "add",
+				Path:  "/metadata/ownerReferences",
+				Value: slices.Concat(secret.OwnerReferences, []metav1.OwnerReference{ownerReference(owner)}),
+			})
+		}
+	}
+
+	patch, err := json.Marshal(ops)
 	if err != nil {
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}
@@ -249,11 +258,7 @@ func (p *Pbkdf2) VerifyPassword(user *v3.User, password string) error {
 			return fmt.Errorf("failed to hash password: %w", err)
 		}
 
-		patch, err := json.Marshal([]struct {
-			Op    string `json:"op"`
-			Path  string `json:"path"`
-			Value any    `json:"value"`
-		}{
+		patch, err := json.Marshal([]patchOp{
 			{
 				Op:   "replace",
 				Path: "/data",
@@ -303,16 +308,6 @@ func ownerReference(user *v3.User) metav1.OwnerReference {
 		APIVersion: "management.cattle.io/v3",
 		Kind:       "User",
 	}
-}
-
-func hasOwner(refs []metav1.OwnerReference, user *v3.User) bool {
-	for _, ref := range refs {
-		if ref.Kind == "User" && ref.Name == user.Name {
-			return true
-		}
-	}
-
-	return false
 }
 
 func rfc6901PathEscape(s string) string {

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2.go
@@ -90,15 +90,27 @@ func (p *Pbkdf2) CreatePassword(user *v3.User, password string) error {
 // the password is changed. This happens when an admin changes the password for
 // a user which has not logged in since the upgrade, leaving its secret to
 // contain a BCRYPT hash.
+//
+// A secret without a hash annotation is treated as never hashed. This happens
+// when the secret was written as a plain Secret, not through a Rancher
+// password API, while the webhook that hashes such secrets was not running.
+// The new password is hashed with PBKDF2 and the annotation is set.
 func (p *Pbkdf2) UpdatePassword(userId string, newPassword string) error {
 	secret, err := p.secretLister.Get(LocalUserPasswordsNamespace, userId)
 	if err != nil {
 		return fmt.Errorf("failed to get password secret: %w", err)
 	}
 
+	type patchOp struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value any    `json:"value"`
+	}
+
 	var value map[string][]byte
+	var ops []patchOp
 	switch secret.Annotations[passwordHashAnnotation] {
-	case pbkdf2sha3512Hash:
+	case pbkdf2sha3512Hash, "":
 		salt, err := p.saltGenerator()
 		if err != nil {
 			return fmt.Errorf("failed to generate salt: %w", err)
@@ -113,6 +125,22 @@ func (p *Pbkdf2) UpdatePassword(userId string, newPassword string) error {
 			"password": hashedNewPassword,
 			"salt":     salt,
 		}
+
+		if _, ok := secret.Annotations[passwordHashAnnotation]; !ok {
+			if len(secret.Annotations) == 0 {
+				ops = append(ops, patchOp{
+					Op:    "add",
+					Path:  "/metadata/annotations",
+					Value: map[string]string{passwordHashAnnotation: pbkdf2sha3512Hash},
+				})
+			} else {
+				ops = append(ops, patchOp{
+					Op:    "add",
+					Path:  "/metadata/annotations/" + rfc6901PathEscape(passwordHashAnnotation),
+					Value: pbkdf2sha3512Hash,
+				})
+			}
+		}
 	case bcryptHash:
 		hashedNewPassword, err := p.bcryptKey([]byte(newPassword), bcrypt.DefaultCost)
 		if err != nil {
@@ -126,15 +154,11 @@ func (p *Pbkdf2) UpdatePassword(userId string, newPassword string) error {
 		return fmt.Errorf("unsupported hashing algorithm %q", secret.Annotations[passwordHashAnnotation])
 	}
 
-	patch, err := json.Marshal([]struct {
-		Op    string `json:"op"`
-		Path  string `json:"path"`
-		Value any    `json:"value"`
-	}{{
+	patch, err := json.Marshal(append([]patchOp{{
 		Op:    "replace",
 		Path:  "/data",
 		Value: value,
-	}})
+	}}, ops...))
 	if err != nil {
 		return fmt.Errorf("failed to marshal patch: %w", err)
 	}

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2.go
@@ -105,7 +105,12 @@ func (p *Pbkdf2) UpdatePassword(userId string, newPassword string) error {
 func (p *Pbkdf2) SetPassword(user *v3.User, newPassword string) error {
 	secret, err := p.secretLister.Get(LocalUserPasswordsNamespace, user.Name)
 	if apierrors.IsNotFound(err) {
-		return p.CreatePassword(user, newPassword)
+		err = p.CreatePassword(user, newPassword)
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
+		// The secret was created after the cache was read. Get it from the API.
+		secret, err = p.secretClient.Get(LocalUserPasswordsNamespace, user.Name, metav1.GetOptions{})
 	}
 	if err != nil {
 		return fmt.Errorf("failed to get password secret: %w", err)
@@ -181,14 +186,15 @@ func (p *Pbkdf2) updatePassword(secret *corev1.Secret, newPassword string, owner
 	}
 
 	if owner != nil {
+		want := ownerReference(owner)
 		ownedByUser := func(ref metav1.OwnerReference) bool {
-			return ref.Kind == "User" && ref.Name == owner.Name
+			return ref.APIVersion == want.APIVersion && ref.Kind == want.Kind && ref.Name == want.Name && ref.UID == want.UID
 		}
 		if !slices.ContainsFunc(secret.OwnerReferences, ownedByUser) {
 			ops = append(ops, patchOp{
 				Op:    "add",
 				Path:  "/metadata/ownerReferences",
-				Value: slices.Concat(secret.OwnerReferences, []metav1.OwnerReference{ownerReference(owner)}),
+				Value: slices.Concat(secret.OwnerReferences, []metav1.OwnerReference{want}),
 			})
 		}
 	}

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2.go
@@ -13,6 +13,7 @@ import (
 	v1 "github.com/rancher/wrangler/v3/pkg/generated/controllers/core/v1"
 	"golang.org/x/crypto/bcrypt"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -63,14 +64,7 @@ func (p *Pbkdf2) CreatePassword(user *v3.User, password string) error {
 			Annotations: map[string]string{
 				passwordHashAnnotation: pbkdf2sha3512Hash,
 			},
-			OwnerReferences: []metav1.OwnerReference{
-				{
-					Name:       user.Name,
-					UID:        user.UID,
-					APIVersion: "management.cattle.io/v3",
-					Kind:       "User",
-				},
-			},
+			OwnerReferences: []metav1.OwnerReference{ownerReference(user)},
 		},
 		Data: map[string][]byte{
 			"password": hashedPassword,
@@ -101,12 +95,34 @@ func (p *Pbkdf2) UpdatePassword(userId string, newPassword string) error {
 		return fmt.Errorf("failed to get password secret: %w", err)
 	}
 
-	type patchOp struct {
-		Op    string `json:"op"`
-		Path  string `json:"path"`
-		Value any    `json:"value"`
+	return p.updatePassword(secret, newPassword, nil)
+}
+
+// SetPassword stores the password for the user, creating the secret when it
+// does not exist. An existing secret is updated the same way UpdatePassword
+// does, and is made to be owned by the user so it is removed with the user.
+func (p *Pbkdf2) SetPassword(user *v3.User, newPassword string) error {
+	secret, err := p.secretLister.Get(LocalUserPasswordsNamespace, user.Name)
+	if apierrors.IsNotFound(err) {
+		return p.CreatePassword(user, newPassword)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to get password secret: %w", err)
 	}
 
+	return p.updatePassword(secret, newPassword, user)
+}
+
+type patchOp struct {
+	Op    string `json:"op"`
+	Path  string `json:"path"`
+	Value any    `json:"value"`
+}
+
+// updatePassword replaces the secret data with the hashed new password in a
+// single patch. A missing hash annotation is set, and when owner is not nil
+// and the secret has no owner reference to it, one is added.
+func (p *Pbkdf2) updatePassword(secret *corev1.Secret, newPassword string, owner *v3.User) error {
 	var value map[string][]byte
 	var ops []patchOp
 	switch secret.Annotations[passwordHashAnnotation] {
@@ -152,6 +168,16 @@ func (p *Pbkdf2) UpdatePassword(userId string, newPassword string) error {
 		}
 	default:
 		return fmt.Errorf("unsupported hashing algorithm %q", secret.Annotations[passwordHashAnnotation])
+	}
+
+	if owner != nil && !hasOwner(secret.OwnerReferences, owner) {
+		refs := make([]metav1.OwnerReference, 0, len(secret.OwnerReferences)+1)
+		refs = append(refs, secret.OwnerReferences...)
+		ops = append(ops, patchOp{
+			Op:    "add",
+			Path:  "/metadata/ownerReferences",
+			Value: append(refs, ownerReference(owner)),
+		})
 	}
 
 	patch, err := json.Marshal(append([]patchOp{{
@@ -268,6 +294,25 @@ func generateSalt() ([]byte, error) {
 	}
 
 	return salt, nil
+}
+
+func ownerReference(user *v3.User) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		Name:       user.Name,
+		UID:        user.UID,
+		APIVersion: "management.cattle.io/v3",
+		Kind:       "User",
+	}
+}
+
+func hasOwner(refs []metav1.OwnerReference, user *v3.User) bool {
+	for _, ref := range refs {
+		if ref.Kind == "User" && ref.Name == user.Name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func rfc6901PathEscape(s string) string {

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
@@ -284,6 +284,137 @@ func TestUpdatePassword(t *testing.T) {
 				return []byte(fakeNewPasswordSalt), nil
 			},
 		},
+		"a secret without a hash annotation is hashed with pbkdf2 and annotated": {
+			userID:   fakeUserID,
+			password: fakePassword,
+			mockHashKey: func(password string, salt []byte, iter, keyLength int) ([]byte, error) {
+				return []byte(fakeNewPasswordHash), nil
+			},
+			mockSecretCache: func() *fake.MockCacheInterface[*v1.Secret] {
+				mock := fake.NewMockCacheInterface[*v1.Secret](ctlr)
+				mock.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID).Return(&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fakeUserID,
+						Namespace: LocalUserPasswordsNamespace,
+					},
+					Data: map[string][]byte{
+						"password": []byte(fakePassword),
+					},
+				}, nil)
+
+				return mock
+			},
+			mockSecretClient: func() *fake.MockClientInterface[*v1.Secret, *v1.SecretList] {
+				mock := fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
+				patch, _ := json.Marshal([]struct {
+					Op    string `json:"op"`
+					Path  string `json:"path"`
+					Value any    `json:"value"`
+				}{
+					{
+						Op:   "replace",
+						Path: "/data",
+						Value: map[string][]byte{
+							"password": []byte(fakeNewPasswordHash),
+							"salt":     []byte(fakeNewPasswordSalt),
+						},
+					},
+					{
+						Op:   "add",
+						Path: "/metadata/annotations",
+						Value: map[string]string{
+							passwordHashAnnotation: pbkdf2sha3512Hash,
+						},
+					},
+				})
+				mock.EXPECT().Patch(LocalUserPasswordsNamespace, fakeUserID, types.JSONPatchType, patch).Return(nil, nil)
+
+				return mock
+			},
+			mockSaltGenerator: func() ([]byte, error) {
+				return []byte(fakeNewPasswordSalt), nil
+			},
+		},
+		"a secret with other annotations but no hash annotation keeps them and gets the hash annotation": {
+			userID:   fakeUserID,
+			password: fakePassword,
+			mockHashKey: func(password string, salt []byte, iter, keyLength int) ([]byte, error) {
+				return []byte(fakeNewPasswordHash), nil
+			},
+			mockSecretCache: func() *fake.MockCacheInterface[*v1.Secret] {
+				mock := fake.NewMockCacheInterface[*v1.Secret](ctlr)
+				mock.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID).Return(&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fakeUserID,
+						Namespace: LocalUserPasswordsNamespace,
+						Annotations: map[string]string{
+							"other": "value",
+						},
+					},
+					Data: map[string][]byte{
+						"password": []byte(fakePassword),
+					},
+				}, nil)
+
+				return mock
+			},
+			mockSecretClient: func() *fake.MockClientInterface[*v1.Secret, *v1.SecretList] {
+				mock := fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
+				patch, _ := json.Marshal([]struct {
+					Op    string `json:"op"`
+					Path  string `json:"path"`
+					Value any    `json:"value"`
+				}{
+					{
+						Op:   "replace",
+						Path: "/data",
+						Value: map[string][]byte{
+							"password": []byte(fakeNewPasswordHash),
+							"salt":     []byte(fakeNewPasswordSalt),
+						},
+					},
+					{
+						Op:    "add",
+						Path:  "/metadata/annotations/cattle.io~1password-hash",
+						Value: pbkdf2sha3512Hash,
+					},
+				})
+				mock.EXPECT().Patch(LocalUserPasswordsNamespace, fakeUserID, types.JSONPatchType, patch).Return(nil, nil)
+
+				return mock
+			},
+			mockSaltGenerator: func() ([]byte, error) {
+				return []byte(fakeNewPasswordSalt), nil
+			},
+		},
+		"error when the hash annotation has an unknown value": {
+			userID:   fakeUserID,
+			password: fakePassword,
+			mockSecretCache: func() *fake.MockCacheInterface[*v1.Secret] {
+				mock := fake.NewMockCacheInterface[*v1.Secret](ctlr)
+				mock.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID).Return(&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fakeUserID,
+						Namespace: LocalUserPasswordsNamespace,
+						Annotations: map[string]string{
+							passwordHashAnnotation: "argon2",
+						},
+					},
+					Data: map[string][]byte{
+						"password": []byte(fakePassword),
+					},
+				}, nil)
+
+				return mock
+			},
+			mockSecretClient: func() *fake.MockClientInterface[*v1.Secret, *v1.SecretList] {
+				return fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
+			},
+			mockSaltGenerator: func() ([]byte, error) {
+				return []byte(fakeNewPasswordSalt), nil
+			},
+			expectErrorMessage: `unsupported hashing algorithm "argon2"`,
+		},
 		"error when secret can't be fetched": {
 			userID:   fakeUserID,
 			password: fakePassword,

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
@@ -11,6 +11,7 @@ import (
 	"go.uber.org/mock/gomock"
 	"golang.org/x/crypto/bcrypt"
 	v1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -913,6 +914,171 @@ func TestVerifyPassword(t *testing.T) {
 				saltGenerator: test.mockSaltGenerator,
 			}
 			err := p.VerifyPassword(test.user, test.password)
+			if test.expectErrorMessage == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.EqualError(t, err, test.expectErrorMessage)
+			}
+		})
+	}
+}
+
+func TestSetPassword(t *testing.T) {
+	ctlr := gomock.NewController(t)
+	fakeUserID := "fake-user-id"
+	fakePassword := "fake-password"
+	fakeNewPasswordHash := "fake-new-password-hash"
+	fakeNewPasswordSalt := "fake-new-password-salt"
+	fakeNewPasswordBcryptHash := "fake-new-password-bcrypt-hash"
+	fakeUser := &v3.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: fakeUserID,
+			UID:  types.UID("fake-uuid"),
+		},
+	}
+	ownerRef := metav1.OwnerReference{
+		Name:       fakeUserID,
+		UID:        types.UID("fake-uuid"),
+		APIVersion: "management.cattle.io/v3",
+		Kind:       "User",
+	}
+	type patchOp struct {
+		Op    string `json:"op"`
+		Path  string `json:"path"`
+		Value any    `json:"value"`
+	}
+	replaceData := func(value map[string][]byte) patchOp {
+		return patchOp{Op: "replace", Path: "/data", Value: value}
+	}
+	pbkdf2Data := map[string][]byte{
+		"password": []byte(fakeNewPasswordHash),
+		"salt":     []byte(fakeNewPasswordSalt),
+	}
+	hashKey := func(password string, salt []byte, iter, keyLength int) ([]byte, error) {
+		return []byte(fakeNewPasswordHash), nil
+	}
+	saltGenerator := func() ([]byte, error) {
+		return []byte(fakeNewPasswordSalt), nil
+	}
+
+	tests := map[string]struct {
+		secret             *v1.Secret
+		secretErr          error
+		expectCreate       *v1.Secret
+		expectPatch        []patchOp
+		expectErrorMessage string
+	}{
+		"the secret is created when it does not exist": {
+			secretErr: apierrors.NewNotFound(v1.Resource("secrets"), fakeUserID),
+			expectCreate: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeUserID,
+					Namespace: LocalUserPasswordsNamespace,
+					Annotations: map[string]string{
+						passwordHashAnnotation: pbkdf2sha3512Hash,
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Data: pbkdf2Data,
+			},
+		},
+		"a secret without a hash annotation or owner is hashed, annotated and owned": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeUserID,
+					Namespace: LocalUserPasswordsNamespace,
+				},
+				Data: map[string][]byte{"password": []byte(fakePassword)},
+			},
+			expectPatch: []patchOp{
+				replaceData(pbkdf2Data),
+				{Op: "add", Path: "/metadata/annotations", Value: map[string]string{passwordHashAnnotation: pbkdf2sha3512Hash}},
+				{Op: "add", Path: "/metadata/ownerReferences", Value: []metav1.OwnerReference{ownerRef}},
+			},
+		},
+		"an owned pbkdf2 secret only gets its data replaced": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            fakeUserID,
+					Namespace:       LocalUserPasswordsNamespace,
+					Annotations:     map[string]string{passwordHashAnnotation: pbkdf2sha3512Hash},
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Data: map[string][]byte{"password": []byte("old"), "salt": []byte("old")},
+			},
+			expectPatch: []patchOp{replaceData(pbkdf2Data)},
+		},
+		"an owned bcrypt secret only gets its data replaced": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            fakeUserID,
+					Namespace:       LocalUserPasswordsNamespace,
+					Annotations:     map[string]string{passwordHashAnnotation: bcryptHash},
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Data: map[string][]byte{"password": []byte("old")},
+			},
+			expectPatch: []patchOp{replaceData(map[string][]byte{"password": []byte(fakeNewPasswordBcryptHash)})},
+		},
+		"an owner reference to the user is added next to existing owners": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        fakeUserID,
+					Namespace:   LocalUserPasswordsNamespace,
+					Annotations: map[string]string{passwordHashAnnotation: pbkdf2sha3512Hash},
+					OwnerReferences: []metav1.OwnerReference{
+						{Name: "other", UID: "other-uid", APIVersion: "v1", Kind: "ConfigMap"},
+					},
+				},
+				Data: map[string][]byte{"password": []byte("old"), "salt": []byte("old")},
+			},
+			expectPatch: []patchOp{
+				replaceData(pbkdf2Data),
+				{Op: "add", Path: "/metadata/ownerReferences", Value: []metav1.OwnerReference{
+					{Name: "other", UID: "other-uid", APIVersion: "v1", Kind: "ConfigMap"},
+					ownerRef,
+				}},
+			},
+		},
+		"error when the hash annotation has an unknown value": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        fakeUserID,
+					Namespace:   LocalUserPasswordsNamespace,
+					Annotations: map[string]string{passwordHashAnnotation: "argon2"},
+				},
+				Data: map[string][]byte{"password": []byte("old")},
+			},
+			expectErrorMessage: `unsupported hashing algorithm "argon2"`,
+		},
+		"error when secret can't be fetched": {
+			secretErr:          errors.New("unexpected error"),
+			expectErrorMessage: "failed to get password secret: unexpected error",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			secretCache := fake.NewMockCacheInterface[*v1.Secret](ctlr)
+			secretCache.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID).Return(test.secret, test.secretErr)
+			secretClient := fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
+			if test.expectCreate != nil {
+				secretClient.EXPECT().Create(test.expectCreate).Return(nil, nil)
+			}
+			if test.expectPatch != nil {
+				patch, err := json.Marshal(test.expectPatch)
+				assert.NoError(t, err)
+				secretClient.EXPECT().Patch(LocalUserPasswordsNamespace, fakeUserID, types.JSONPatchType, patch).Return(nil, nil)
+			}
+			p := Pbkdf2{
+				secretClient:  secretClient,
+				secretLister:  secretCache,
+				hashKey:       hashKey,
+				bcryptKey:     func(_ []byte, _ int) ([]byte, error) { return []byte(fakeNewPasswordBcryptHash), nil },
+				saltGenerator: saltGenerator,
+			}
+			err := p.SetPassword(fakeUser, fakePassword)
 			if test.expectErrorMessage == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
@@ -388,6 +388,58 @@ func TestUpdatePassword(t *testing.T) {
 				return []byte(fakeNewPasswordSalt), nil
 			},
 		},
+		"a secret with an empty hash annotation is hashed with pbkdf2 and annotated": {
+			userID:   fakeUserID,
+			password: fakePassword,
+			mockHashKey: func(password string, salt []byte, iter, keyLength int) ([]byte, error) {
+				return []byte(fakeNewPasswordHash), nil
+			},
+			mockSecretCache: func() *fake.MockCacheInterface[*v1.Secret] {
+				mock := fake.NewMockCacheInterface[*v1.Secret](ctlr)
+				mock.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID).Return(&v1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fakeUserID,
+						Namespace: LocalUserPasswordsNamespace,
+						Annotations: map[string]string{
+							passwordHashAnnotation: "",
+						},
+					},
+					Data: map[string][]byte{
+						"password": []byte(fakePassword),
+					},
+				}, nil)
+
+				return mock
+			},
+			mockSecretClient: func() *fake.MockClientInterface[*v1.Secret, *v1.SecretList] {
+				mock := fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
+				patch, _ := json.Marshal([]struct {
+					Op    string `json:"op"`
+					Path  string `json:"path"`
+					Value any    `json:"value"`
+				}{
+					{
+						Op:   "replace",
+						Path: "/data",
+						Value: map[string][]byte{
+							"password": []byte(fakeNewPasswordHash),
+							"salt":     []byte(fakeNewPasswordSalt),
+						},
+					},
+					{
+						Op:    "add",
+						Path:  "/metadata/annotations/cattle.io~1password-hash",
+						Value: pbkdf2sha3512Hash,
+					},
+				})
+				mock.EXPECT().Patch(LocalUserPasswordsNamespace, fakeUserID, types.JSONPatchType, patch).Return(nil, nil)
+
+				return mock
+			},
+			mockSaltGenerator: func() ([]byte, error) {
+				return []byte(fakeNewPasswordSalt), nil
+			},
+		},
 		"error when the hash annotation has an unknown value": {
 			userID:   fakeUserID,
 			password: fakePassword,

--- a/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
+++ b/pkg/auth/providers/local/pbkdf2/pbkdf2_test.go
@@ -1017,9 +1017,74 @@ func TestSetPassword(t *testing.T) {
 		secret             *v1.Secret
 		secretErr          error
 		expectCreate       *v1.Secret
+		createErr          error
+		liveSecret         *v1.Secret
+		liveErr            error
 		expectPatch        []patchOp
 		expectErrorMessage string
 	}{
+		"the secret is updated when creating it finds it already exists": {
+			secretErr: apierrors.NewNotFound(v1.Resource("secrets"), fakeUserID),
+			expectCreate: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeUserID,
+					Namespace: LocalUserPasswordsNamespace,
+					Annotations: map[string]string{
+						passwordHashAnnotation: pbkdf2sha3512Hash,
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Data: pbkdf2Data,
+			},
+			createErr: apierrors.NewAlreadyExists(v1.Resource("secrets"), fakeUserID),
+			liveSecret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            fakeUserID,
+					Namespace:       LocalUserPasswordsNamespace,
+					Annotations:     map[string]string{passwordHashAnnotation: pbkdf2sha3512Hash},
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Data: map[string][]byte{"password": []byte("old"), "salt": []byte("old")},
+			},
+			expectPatch: []patchOp{replaceData(pbkdf2Data)},
+		},
+		"error when the secret can't be fetched after creating it finds it already exists": {
+			secretErr: apierrors.NewNotFound(v1.Resource("secrets"), fakeUserID),
+			expectCreate: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      fakeUserID,
+					Namespace: LocalUserPasswordsNamespace,
+					Annotations: map[string]string{
+						passwordHashAnnotation: pbkdf2sha3512Hash,
+					},
+					OwnerReferences: []metav1.OwnerReference{ownerRef},
+				},
+				Data: pbkdf2Data,
+			},
+			createErr:          apierrors.NewAlreadyExists(v1.Resource("secrets"), fakeUserID),
+			liveErr:            errors.New("unexpected error"),
+			expectErrorMessage: "failed to get password secret: unexpected error",
+		},
+		"an owner reference to a user with a different uid does not count": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        fakeUserID,
+					Namespace:   LocalUserPasswordsNamespace,
+					Annotations: map[string]string{passwordHashAnnotation: pbkdf2sha3512Hash},
+					OwnerReferences: []metav1.OwnerReference{
+						{Name: fakeUserID, UID: "stale-uid", APIVersion: "management.cattle.io/v3", Kind: "User"},
+					},
+				},
+				Data: map[string][]byte{"password": []byte("old"), "salt": []byte("old")},
+			},
+			expectPatch: []patchOp{
+				replaceData(pbkdf2Data),
+				{Op: "add", Path: "/metadata/ownerReferences", Value: []metav1.OwnerReference{
+					{Name: fakeUserID, UID: "stale-uid", APIVersion: "management.cattle.io/v3", Kind: "User"},
+					ownerRef,
+				}},
+			},
+		},
 		"the secret is created when it does not exist": {
 			secretErr: apierrors.NewNotFound(v1.Resource("secrets"), fakeUserID),
 			expectCreate: &v1.Secret{
@@ -1116,7 +1181,10 @@ func TestSetPassword(t *testing.T) {
 			secretCache.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID).Return(test.secret, test.secretErr)
 			secretClient := fake.NewMockClientInterface[*v1.Secret, *v1.SecretList](ctlr)
 			if test.expectCreate != nil {
-				secretClient.EXPECT().Create(test.expectCreate).Return(nil, nil)
+				secretClient.EXPECT().Create(test.expectCreate).Return(nil, test.createErr)
+			}
+			if test.liveSecret != nil || test.liveErr != nil {
+				secretClient.EXPECT().Get(LocalUserPasswordsNamespace, fakeUserID, metav1.GetOptions{}).Return(test.liveSecret, test.liveErr)
 			}
 			if test.expectPatch != nil {
 				patch, err := json.Marshal(test.expectPatch)

--- a/pkg/data/management/resetpassword.go
+++ b/pkg/data/management/resetpassword.go
@@ -13,7 +13,6 @@ import (
 	v3 "github.com/rancher/rancher/pkg/generated/norman/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/wrangler"
 	"github.com/urfave/cli"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -83,14 +82,8 @@ func resetPassword() {
 			return fmt.Errorf("couldn't start wrangler cache for secrets %w", err)
 		}
 		pwdCreator := pbkdf2.New(wranglerContext.Core.Secret().Cache(), wranglerContext.Core.Secret())
-		if err := pwdCreator.UpdatePassword(admin.Name, string(pass)); err != nil {
-			if apierrors.IsNotFound(err) {
-				if err := pwdCreator.CreatePassword(&admin, string(pass)); err != nil {
-					return fmt.Errorf("couldn't create password %w", err)
-				}
-			} else {
-				return fmt.Errorf("couldn't update password %w", err)
-			}
+		if err := pwdCreator.SetPassword(&admin, string(pass)); err != nil {
+			return fmt.Errorf("couldn't set password %w", err)
 		}
 		fmt.Fprintf(os.Stdout, "New password for default admin user (%v):\n%s\n", admin.Name, pass)
 

--- a/pkg/ext/mocks/passwordupdater.go
+++ b/pkg/ext/mocks/passwordupdater.go
@@ -12,6 +12,7 @@ package mocks
 import (
 	reflect "reflect"
 
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	gomock "go.uber.org/mock/gomock"
 )
 
@@ -37,6 +38,20 @@ func NewMockPasswordUpdater(ctrl *gomock.Controller) *MockPasswordUpdater {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockPasswordUpdater) EXPECT() *MockPasswordUpdaterMockRecorder {
 	return m.recorder
+}
+
+// CreatePassword mocks base method.
+func (m *MockPasswordUpdater) CreatePassword(user *v3.User, password string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePassword", user, password)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreatePassword indicates an expected call of CreatePassword.
+func (mr *MockPasswordUpdaterMockRecorder) CreatePassword(user, password any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePassword", reflect.TypeOf((*MockPasswordUpdater)(nil).CreatePassword), user, password)
 }
 
 // UpdatePassword mocks base method.

--- a/pkg/ext/mocks/passwordupdater.go
+++ b/pkg/ext/mocks/passwordupdater.go
@@ -40,32 +40,18 @@ func (m *MockPasswordUpdater) EXPECT() *MockPasswordUpdaterMockRecorder {
 	return m.recorder
 }
 
-// CreatePassword mocks base method.
-func (m *MockPasswordUpdater) CreatePassword(user *v3.User, password string) error {
+// SetPassword mocks base method.
+func (m *MockPasswordUpdater) SetPassword(user *v3.User, newPassword string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePassword", user, password)
+	ret := m.ctrl.Call(m, "SetPassword", user, newPassword)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// CreatePassword indicates an expected call of CreatePassword.
-func (mr *MockPasswordUpdaterMockRecorder) CreatePassword(user, password any) *gomock.Call {
+// SetPassword indicates an expected call of SetPassword.
+func (mr *MockPasswordUpdaterMockRecorder) SetPassword(user, newPassword any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePassword", reflect.TypeOf((*MockPasswordUpdater)(nil).CreatePassword), user, password)
-}
-
-// UpdatePassword mocks base method.
-func (m *MockPasswordUpdater) UpdatePassword(userId, newPassword string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePassword", userId, newPassword)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdatePassword indicates an expected call of UpdatePassword.
-func (mr *MockPasswordUpdaterMockRecorder) UpdatePassword(userId, newPassword any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePassword", reflect.TypeOf((*MockPasswordUpdater)(nil).UpdatePassword), userId, newPassword)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetPassword", reflect.TypeOf((*MockPasswordUpdater)(nil).SetPassword), user, newPassword)
 }
 
 // VerifyAndUpdatePassword mocks base method.

--- a/pkg/ext/stores/passwordchangerequest/store.go
+++ b/pkg/ext/stores/passwordchangerequest/store.go
@@ -44,8 +44,7 @@ var GVK = ext.SchemeGroupVersion.WithKind(kind)
 
 type PasswordUpdater interface {
 	VerifyAndUpdatePassword(userId string, currentPassword, newPassword string) error
-	UpdatePassword(userId string, newPassword string) error
-	CreatePassword(user *v3.User, password string) error
+	SetPassword(user *v3.User, newPassword string) error
 }
 
 // +k8s:openapi-gen=false
@@ -163,13 +162,7 @@ func (s *Store) Create(
 	// Checking the current password is only required if the user doesn't have permissions on update on users and update
 	// secrets in the cattle-local-user-passwords namespace.
 	if canUpdateAnyPassword {
-		err := s.pwdUpdater.UpdatePassword(req.Spec.UserID, req.Spec.NewPassword)
-		if apierrors.IsNotFound(err) {
-			// The user has no password yet. This is the case for a user created
-			// through the public API, where the password is set separately.
-			err = s.pwdUpdater.CreatePassword(user, req.Spec.NewPassword)
-		}
-		if err != nil {
+		if err := s.pwdUpdater.SetPassword(user, req.Spec.NewPassword); err != nil {
 			return nil, apierrors.NewInternalError(fmt.Errorf("error updating password: %w", err))
 		}
 

--- a/pkg/ext/stores/passwordchangerequest/store.go
+++ b/pkg/ext/stores/passwordchangerequest/store.go
@@ -10,6 +10,7 @@ import (
 
 	ext "github.com/rancher/rancher/pkg/apis/ext.cattle.io/v1"
 	mgmt "github.com/rancher/rancher/pkg/apis/management.cattle.io"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/rancher/pkg/auth/providers/local/pbkdf2"
 	"github.com/rancher/rancher/pkg/controllers/status"
 	mgmtv3 "github.com/rancher/rancher/pkg/generated/controllers/management.cattle.io/v3"
@@ -44,6 +45,7 @@ var GVK = ext.SchemeGroupVersion.WithKind(kind)
 type PasswordUpdater interface {
 	VerifyAndUpdatePassword(userId string, currentPassword, newPassword string) error
 	UpdatePassword(userId string, newPassword string) error
+	CreatePassword(user *v3.User, password string) error
 }
 
 // +k8s:openapi-gen=false
@@ -134,7 +136,7 @@ func (s *Store) Create(
 		return nil, apierrors.NewBadRequest(fmt.Sprintf("password must be at least %d characters", minLength))
 	}
 
-	user, err := s.userCache.Get(req.Spec.UserID)
+	user, err := s.getUser(req.Spec.UserID)
 	if err != nil {
 		if apierrors.IsNotFound(err) {
 			return nil, apierrors.NewBadRequest(fmt.Sprintf("user %s not found", req.Spec.UserID))
@@ -162,8 +164,13 @@ func (s *Store) Create(
 	// secrets in the cattle-local-user-passwords namespace.
 	if canUpdateAnyPassword {
 		err := s.pwdUpdater.UpdatePassword(req.Spec.UserID, req.Spec.NewPassword)
+		if apierrors.IsNotFound(err) {
+			// The user has no password yet. This is the case for a user created
+			// through the public API, where the password is set separately.
+			err = s.pwdUpdater.CreatePassword(user, req.Spec.NewPassword)
+		}
 		if err != nil {
-			return nil, apierrors.NewUnauthorized(fmt.Sprintf("error checking permissions %s", err.Error()))
+			return nil, apierrors.NewInternalError(fmt.Errorf("error updating password: %w", err))
 		}
 
 		if user.MustChangePassword {
@@ -224,6 +231,18 @@ func (s *Store) Create(
 	}
 
 	return req, apierrors.NewUnauthorized("not authorized to update password")
+}
+
+// getUser returns the user from the cache, falling back to the API when the
+// cache does not have it yet. A password is often set right after the user is
+// created, before the cache has caught up.
+func (s *Store) getUser(name string) (*v3.User, error) {
+	user, err := s.userCache.Get(name)
+	if err == nil || !apierrors.IsNotFound(err) {
+		return user, err
+	}
+
+	return s.userClient.Get(name, metav1.GetOptions{})
 }
 
 // canUpdateAnyPassword verifies the user can update users and secrets in the cattle-local-user-passwords namespace.

--- a/pkg/ext/stores/passwordchangerequest/store.go
+++ b/pkg/ext/stores/passwordchangerequest/store.go
@@ -231,7 +231,7 @@ func (s *Store) Create(
 // created, before the cache has caught up.
 func (s *Store) getUser(name string) (*v3.User, error) {
 	user, err := s.userCache.Get(name)
-	if err == nil || !apierrors.IsNotFound(err) {
+	if !apierrors.IsNotFound(err) {
 		return user, err
 	}
 

--- a/pkg/ext/stores/passwordchangerequest/store.go
+++ b/pkg/ext/stores/passwordchangerequest/store.go
@@ -143,6 +143,12 @@ func (s *Store) Create(
 		return nil, apierrors.NewInternalError(fmt.Errorf("can't get user %s: %w", req.Spec.UserID, err))
 	}
 
+	// Local login resolves the user by username, so a password is only usable
+	// on a user that has one.
+	if user.Username == "" {
+		return nil, apierrors.NewBadRequest(fmt.Sprintf("user %s has no username and cannot log in locally", req.Spec.UserID))
+	}
+
 	// Password must not be the same as the username.
 	if req.Spec.NewPassword == user.Username {
 		return nil, apierrors.NewBadRequest("password cannot be the same as the username")

--- a/pkg/ext/stores/passwordchangerequest/store_test.go
+++ b/pkg/ext/stores/passwordchangerequest/store_test.go
@@ -210,6 +210,29 @@ func TestCreate(t *testing.T) {
 			wantErr:    "password cannot be the same as the username",
 		},
 		{
+			desc: "password is not set for a non-local user",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:      userID,
+					NewPassword: newPassword,
+				},
+			},
+			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: "another-user"}),
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			}),
+			pwdUpdater: pwdUpdater,
+			userCache: func() mgmtv3.UserCache {
+				cache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+				cache.EXPECT().Get(gomock.Any()).Return(&v3.User{
+					ObjectMeta:   metav1.ObjectMeta{Name: userID},
+					PrincipalIDs: []string{"okta_user://someone"},
+				}, nil)
+				return cache
+			},
+			wantErr: fmt.Sprintf("user %s has no username and cannot log in locally", userID),
+		},
+		{
 			desc: "user not found",
 			obj: &ext.PasswordChangeRequest{
 				Spec: ext.PasswordChangeRequestSpec{

--- a/pkg/ext/stores/passwordchangerequest/store_test.go
+++ b/pkg/ext/stores/passwordchangerequest/store_test.go
@@ -132,7 +132,12 @@ func TestCreate(t *testing.T) {
 			}),
 			pwdUpdater: func() PasswordUpdater {
 				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(nil)
+				mock.EXPECT().SetPassword(&v3.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: userID,
+					},
+					Username: username,
+				}, newPassword).Return(nil)
 
 				return mock
 			},
@@ -244,7 +249,12 @@ func TestCreate(t *testing.T) {
 			}),
 			pwdUpdater: func() PasswordUpdater {
 				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(nil)
+				mock.EXPECT().SetPassword(&v3.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: userID,
+					},
+					Username: username,
+				}, newPassword).Return(nil)
 
 				return mock
 			},
@@ -278,69 +288,6 @@ func TestCreate(t *testing.T) {
 					Summary: status.SummaryCompleted,
 				},
 			},
-		},
-		{
-			desc: "password secret is created when it does not exist for a different user",
-			obj: &ext.PasswordChangeRequest{
-				Spec: ext.PasswordChangeRequestSpec{
-					UserID:      userID,
-					NewPassword: newPassword,
-				},
-			},
-			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: "another-user"}),
-			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-				return authorizer.DecisionAllow, "", nil
-			}),
-			pwdUpdater: func() PasswordUpdater {
-				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(fmt.Errorf("failed to get password secret: %w", apierrors.NewNotFound(v3.Resource("secret"), userID)))
-				mock.EXPECT().CreatePassword(&v3.User{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: userID,
-					},
-					Username: username,
-				}, newPassword).Return(nil)
-
-				return mock
-			},
-			userCache: userCache,
-			wantObj: &ext.PasswordChangeRequest{
-				Spec: ext.PasswordChangeRequestSpec{
-					UserID:      userID,
-					NewPassword: newPassword,
-				},
-				Status: ext.PasswordChangeRequestStatus{
-					Conditions: []metav1.Condition{
-						{
-							Type:   "PasswordUpdated",
-							Status: "True",
-						},
-					},
-					Summary: status.SummaryCompleted,
-				},
-			},
-		},
-		{
-			desc: "error creating the password secret for a different user",
-			obj: &ext.PasswordChangeRequest{
-				Spec: ext.PasswordChangeRequestSpec{
-					UserID:      userID,
-					NewPassword: newPassword,
-				},
-			},
-			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: "another-user"}),
-			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
-				return authorizer.DecisionAllow, "", nil
-			}),
-			pwdUpdater: func() PasswordUpdater {
-				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(fmt.Errorf("failed to get password secret: %w", apierrors.NewNotFound(v3.Resource("secret"), userID)))
-				mock.EXPECT().CreatePassword(gomock.Any(), newPassword).Return(errors.New("unexpected error"))
-
-				return mock
-			},
-			userCache: userCache,
-			wantErr:   "unexpected error",
 		},
 		{
 			desc: "missing password secret is not created for the same user",
@@ -405,7 +352,12 @@ func TestCreate(t *testing.T) {
 			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: userID}),
 			pwdUpdater: func() PasswordUpdater {
 				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(errors.New("unexpected error"))
+				mock.EXPECT().SetPassword(&v3.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: userID,
+					},
+					Username: username,
+				}, newPassword).Return(errors.New("unexpected error"))
 
 				return mock
 			},
@@ -470,7 +422,7 @@ func TestCreate(t *testing.T) {
 			}),
 			pwdUpdater: func() PasswordUpdater {
 				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(nil)
+				mock.EXPECT().SetPassword(gomock.Any(), newPassword).Return(nil)
 
 				return mock
 			},
@@ -595,7 +547,12 @@ func TestCreateWithFirstLoginOff(t *testing.T) {
 			}),
 			pwdUpdater: func() PasswordUpdater {
 				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(nil)
+				mock.EXPECT().SetPassword(&v3.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: userID,
+					},
+					Username: username,
+				}, newPassword).Return(nil)
 
 				return mock
 			},
@@ -702,7 +659,12 @@ func TestCreateWithFirstLogin(t *testing.T) {
 			}),
 			pwdUpdater: func() PasswordUpdater {
 				mock := mocks.NewMockPasswordUpdater(ctrl)
-				mock.EXPECT().UpdatePassword(userID, newPassword).Return(nil)
+				mock.EXPECT().SetPassword(&v3.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: userID,
+					},
+					Username: username,
+				}, newPassword).Return(nil)
 
 				return mock
 			},

--- a/pkg/ext/stores/passwordchangerequest/store_test.go
+++ b/pkg/ext/stores/passwordchangerequest/store_test.go
@@ -223,7 +223,146 @@ func TestCreate(t *testing.T) {
 				cache.EXPECT().Get(gomock.Any()).Return(nil, apierrors.NewNotFound(v3.Resource("user"), ""))
 				return cache
 			},
+			userClient: func() mgmtv3.UserClient {
+				mock := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+				mock.EXPECT().Get(userID, metav1.GetOptions{}).Return(nil, apierrors.NewNotFound(v3.Resource("user"), ""))
+				return mock
+			},
 			wantErr: fmt.Sprintf("user %s not found", userID),
+		},
+		{
+			desc: "user is read from the API when not yet in the cache",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:      userID,
+					NewPassword: newPassword,
+				},
+			},
+			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: "another-user"}),
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			}),
+			pwdUpdater: func() PasswordUpdater {
+				mock := mocks.NewMockPasswordUpdater(ctrl)
+				mock.EXPECT().UpdatePassword(userID, newPassword).Return(nil)
+
+				return mock
+			},
+			userCache: func() mgmtv3.UserCache {
+				cache := fake.NewMockNonNamespacedCacheInterface[*v3.User](ctrl)
+				cache.EXPECT().Get(userID).Return(nil, apierrors.NewNotFound(v3.Resource("user"), ""))
+				return cache
+			},
+			userClient: func() mgmtv3.UserClient {
+				mock := fake.NewMockNonNamespacedClientInterface[*v3.User, *v3.UserList](ctrl)
+				mock.EXPECT().Get(userID, metav1.GetOptions{}).Return(&v3.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: userID,
+					},
+					Username: username,
+				}, nil)
+				return mock
+			},
+			wantObj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:      userID,
+					NewPassword: newPassword,
+				},
+				Status: ext.PasswordChangeRequestStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "PasswordUpdated",
+							Status: "True",
+						},
+					},
+					Summary: status.SummaryCompleted,
+				},
+			},
+		},
+		{
+			desc: "password secret is created when it does not exist for a different user",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:      userID,
+					NewPassword: newPassword,
+				},
+			},
+			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: "another-user"}),
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			}),
+			pwdUpdater: func() PasswordUpdater {
+				mock := mocks.NewMockPasswordUpdater(ctrl)
+				mock.EXPECT().UpdatePassword(userID, newPassword).Return(fmt.Errorf("failed to get password secret: %w", apierrors.NewNotFound(v3.Resource("secret"), userID)))
+				mock.EXPECT().CreatePassword(&v3.User{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: userID,
+					},
+					Username: username,
+				}, newPassword).Return(nil)
+
+				return mock
+			},
+			userCache: userCache,
+			wantObj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:      userID,
+					NewPassword: newPassword,
+				},
+				Status: ext.PasswordChangeRequestStatus{
+					Conditions: []metav1.Condition{
+						{
+							Type:   "PasswordUpdated",
+							Status: "True",
+						},
+					},
+					Summary: status.SummaryCompleted,
+				},
+			},
+		},
+		{
+			desc: "error creating the password secret for a different user",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:      userID,
+					NewPassword: newPassword,
+				},
+			},
+			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: "another-user"}),
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionAllow, "", nil
+			}),
+			pwdUpdater: func() PasswordUpdater {
+				mock := mocks.NewMockPasswordUpdater(ctrl)
+				mock.EXPECT().UpdatePassword(userID, newPassword).Return(fmt.Errorf("failed to get password secret: %w", apierrors.NewNotFound(v3.Resource("secret"), userID)))
+				mock.EXPECT().CreatePassword(gomock.Any(), newPassword).Return(errors.New("unexpected error"))
+
+				return mock
+			},
+			userCache: userCache,
+			wantErr:   "unexpected error",
+		},
+		{
+			desc: "missing password secret is not created for the same user",
+			obj: &ext.PasswordChangeRequest{
+				Spec: ext.PasswordChangeRequestSpec{
+					UserID:          userID,
+					CurrentPassword: oldPassword,
+					NewPassword:     newPassword,
+				},
+			},
+			ctx: request.WithUser(context.Background(), &user.DefaultInfo{Name: userID}),
+			authorizer: authorizer.AuthorizerFunc(func(ctx context.Context, a authorizer.Attributes) (authorizer.Decision, string, error) {
+				return authorizer.DecisionDeny, "", nil
+			}),
+			pwdUpdater: func() PasswordUpdater {
+				mock := mocks.NewMockPasswordUpdater(ctrl)
+				mock.EXPECT().VerifyAndUpdatePassword(userID, oldPassword, newPassword).Return(fmt.Errorf("failed to get password secret: %w", apierrors.NewNotFound(v3.Resource("secret"), userID)))
+
+				return mock
+			},
+			userCache: userCache,
+			wantErr:   "failed to get password secret",
 		},
 		{
 			desc: "dry run",


### PR DESCRIPTION
## Issue: #57258<!-- link the issue or issues this PR resolves here -->
<!-- If your PR depends on changes from another pr link them here and describe why they are needed on your solution section. -->
 
## Problem
<!-- Describe the root cause of the issue you are resolving. This may include what behavior is observed and why it is not desirable. If this is a new feature describe why we need this feature and how it will be used. -->

A local user created through the UI shortly after Rancher starts cannot log in, and an admin cannot set a new password for that user. The UI reports `unsupported hashing algorithm ""`. On a fresh install the window lasts until rancher-webhook is running, roughly two minutes, and it reopens on every Rancher restart or upgrade.

Since 2.14 the UI creates a local user in two steps: it creates the User, then writes the plaintext password into a Secret in `cattle-local-user-passwords`. Hashing that value is left to a rancher-webhook mutator. Rancher installs the webhook asynchronously and serves the UI before it is running, so a Secret written in that window is stored as plaintext with no hash annotation. Login and password change both require the annotation and reject a Secret without one. A user created without a Secret at all cannot be given a password through either API.

Every other path that sets a local password hashes it inside Rancher. The UI create flow is the only one that depends on the webhook.

## Solution
<!-- Describe what you changed to fix the issue. Relate your changes back to the original issue / feature and explain why this addresses the issue. -->

Rancher's User Public API now work without the webhook, so the UI can create a user and set its password through `PasswordChangeRequest` instead of writing the Secret itself.

- Updating a password treats a Secret with no hash annotation as never hashed. The new password is hashed with PBKDF2 and the annotation is set.
- `PasswordChangeRequest` and the Norman `setpassword` action create the Secret when it does not exist.
- `PasswordChangeRequest` reads the User from the API when the cache does not have it yet, since the password is usually set right after the user is created.
- A failed password update is reported as an internal error instead of a permission error.

`PasswordChangeRequest`, the Norman `setpassword` action and `reset-password` each handled a missing Secret on their own. They now share one method that creates the Secret when missing and otherwise updates it, adding an owner reference to the User when there is none so the Secret is removed with the user.

Users already affected recover when an admin sets a new password for them. The webhook mutator stays as a safety net for Secrets written directly with kubectl.

 
## Testing
<!-- Note: Confirm if the repro steps in the GitHub issue are valid, if not, please update the issue with accurate repro steps. -->

- Unit-tests