### PR TITLE
Preserve explicit nulls in chartValues on the RKEControlPlane

### DIFF
--- a/pkg/controllers/provisioningv2/provisioningcluster/controller.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/controller.go
@@ -79,6 +79,7 @@ func Register(ctx context.Context, clients *wrangler.CAPIContext) {
 		clients.Apply.
 			// Because capi wants to own objects we don't set ownerreference with apply
 			WithDynamicLookup().
+			WithNullSafePatch(rkev1.SchemeGroupVersion.WithKind("RKEControlPlane")).
 			WithCacheTypes(
 				clients.CAPI.Cluster(),
 				clients.CAPI.MachineDeployment(),

--- a/pkg/controllers/provisioningv2/provisioningcluster/template_test.go
+++ b/pkg/controllers/provisioningv2/provisioningcluster/template_test.go
@@ -1,10 +1,14 @@
 package provisioningcluster
 
 import (
+	"encoding/json"
 	"testing"
 
 	provv1 "github.com/rancher/rancher/pkg/apis/provisioning.cattle.io/v1"
+	rkev1 "github.com/rancher/rancher/pkg/apis/rke.cattle.io/v1"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPopulateHostnameLengthLimitAnnotation(t *testing.T) {
@@ -91,6 +95,76 @@ func TestPopulateHostnameLengthLimitAnnotation(t *testing.T) {
 			}}}, annotations)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, annotations)
+		})
+	}
+}
+
+// TestRKEControlPlaneChartValuesNulls asserts that the RKEControlPlane template
+// carries chart values through verbatim, including an explicit null.
+//
+// A null is how a user removes a chart default, and it used to be lost on the
+// way to the generated HelmChartConfig (#56335). The loss was in the merge patch
+// apply sends, not here -- this pins the hop before it, so that a regression in
+// the template is not mistaken for the patching bug the apply side now fixes
+// with WithNullSafePatch.
+func TestRKEControlPlaneChartValuesNulls(t *testing.T) {
+	tests := []struct {
+		name        string
+		chartValues map[string]any
+		expected    string
+	}{
+		{
+			name:        "nil chart values",
+			chartValues: nil,
+			expected:    `null`,
+		},
+		{
+			name:        "empty chart values",
+			chartValues: map[string]any{},
+			expected:    `{}`,
+		},
+		{
+			name: "chart values are carried",
+			chartValues: map[string]any{
+				"rke2-coredns": map[string]any{"replicas": 2},
+			},
+			expected: `{"rke2-coredns":{"replicas":2}}`,
+		},
+		{
+			name: "an explicit null is carried",
+			chartValues: map[string]any{
+				"rke2-coredns": map[string]any{
+					"resources": map[string]any{
+						"limits": map[string]any{"cpu": nil, "memory": "130Mi"},
+					},
+				},
+			},
+			expected: `{"rke2-coredns":{"resources":{"limits":{"cpu":null,"memory":"130Mi"}}}}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cluster := &provv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-cluster", Namespace: "fleet-default"},
+				Spec: provv1.ClusterSpec{
+					RKEConfig: &provv1.RKEConfig{
+						ClusterConfiguration: rkev1.ClusterConfiguration{
+							ChartValues: rkev1.GenericMap{Data: tt.chartValues},
+						},
+					},
+				},
+			}
+
+			cp, err := rkeControlPlane(cluster)
+			require.NoError(t, err)
+
+			// Marshalled rather than compared as a map, because that is the form
+			// the value reaches apply in, and a null member and an absent one are
+			// both nil once decoded.
+			got, err := json.Marshal(cp.Spec.ChartValues.Data)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, string(got))
 		})
 	}
 }


### PR DESCRIPTION
## Issue

Fixes [#56335](https://github.com/rancher/rancher/issues/56335). Supersedes #56569.

Depends on `rancher/wrangler#741`, which adds the `WithNullSafePatch` API this PR calls,
and on the `go.mod` bump to the wrangler release containing it.

## Problem

Setting a Helm value to `null` is the documented way to remove a chart default. It works
when the user writes a `HelmChartConfig` directly, but not when the same value is
expressed in `spec.rkeConfig.chartValues` on a `cluster.provisioning.cattle.io`. The null
is accepted and persisted on the `Cluster`, but is gone by the time the `RKEControlPlane`
is written, so the generated `HelmChartConfig` at
`/var/lib/rancher/rke2/server/manifests/rancher/managed-chart-config.yaml` never removes
the default. No error, event, or condition is surfaced.

`Cluster` → `RKEControlPlane` is produced by a wrangler generating handler
(`pkg/controllers/provisioningv2/provisioningcluster/controller.go`). For an existing
object wrangler updates via a patch, and `patch.GetMergeStyle` selects
`types.MergePatchType` for any GVK absent from the client-go scheme — which is every CRD,
including `rke.cattle.io/v1`. RFC 7386 defines a `null` member in a merge patch as an
instruction to **remove** the key, not as a value, so the null is dropped at patch
generation time.

This also explains why the bug only appears when `chartValues` is edited on an **existing**
cluster: a create is a full-body POST with no patch involved, so the null survives that
path.

Components ruled out:

- **The kube-apiserver.** `chartValues` is `x-kubernetes-preserve-unknown-fields: true`.
  In `PruneNonNullableNullsWithoutDefaults`, `getSchemaForField` returns `nil` for keys
  with no structural schema and `isNonNullableNonDefaultableNull` requires `s != nil`, so
  nested nulls under such a subtree are never pruned. Confirmed on a live cluster.
- **steve / the dashboard.** The reproduction uses `kubectl --type=json`.
- **`GenericMap`, `convert.ToObj`, `convert.ToMapInterface`** and the `json.Marshal` in
  `addChartConfigs` are all null-preserving. They simply never receive the null.
- **rke2.** `managed-chart-config.yaml` is written by `pkg/capr/planner/config.go`, and
  helm-controller honours nulls correctly — which is why the `HelmChartConfig`-via-
  Additional-Manifests workaround works. No rke2 change required.

## Solution

Opt the `RKEControlPlane` GVK into wrangler's new null-safe patch mode — one line at
`pkg/controllers/provisioningv2/provisioningcluster/controller.go`:

```go
clients.Apply.
    WithDynamicLookup().
    WithNullSafePatch(rkev1.SchemeGroupVersion.WithKind("RKEControlPlane")).
    WithCacheTypes(...)
```

Wrangler then translates the merge patch it would have sent into an equivalent RFC 6902
JSON Patch, which is the only format Kubernetes accepts that distinguishes
`{"op":"remove"}` from `{"op":"add","value":null}`. Nulls the user asked for are assigned;
keys genuinely removed are still removed. See the companion wrangler PR for the
translation rules.

No Rancher-side logic changes. `template.go` already carries chart values through
verbatim, and `addChartConfigs` already emits `"cpu":null` once it receives one — they
were never the problem.

## Testing

The repro steps in #56335 are valid:

```bash
kubectl -n fleet-default patch clusters.provisioning.cattle.io <cluster> --type=json \
  -p '[{"op":"add","path":"/spec/rkeConfig/chartValues/rke2-coredns",
        "value":{"resources":{"limits":{"cpu":null,"memory":"130Mi"}}}}]'
```


## Engineering Testing
### Manual Testing
<!-- Describe what manual testing you did (if no testing was done, explain why). -->
```bash
# A. the Cluster CR -- null present (already true before the fix)
kubectl -n fleet-default get clusters.provisioning.cattle.io <cluster> -o json | jq '.spec.rkeConfig.chartValues'

# B. the RKEControlPlane -- null must now be present
kubectl -n fleet-default get rkecontrolplanes.rke.cattle.io <cluster> -o json | jq '.spec.chartValues'

# C. the rendered plan
kubectl -n fleet-default get secret <machine>-machine-plan -o jsonpath='{.data.plan}' | base64 -d \
  | jq -r '.files[] | select(.path|test("managed-chart-config")) | .content' | base64 -d
```

Expected at C:

```yaml
valuesContent: '{"global":{"cattle":{"clusterId":"..."}},"resources":{"limits":{"cpu":null,"memory":"130Mi"}}}'
```

and the chart default gone downstream:

```bash
kubectl -n kube-system get deploy rke2-coredns-rke2-coredns -o yaml | grep -A10 resources
```

Also exercise, because these are the risky paths rather than the happy one:

- a cluster with **no** nulls in `chartValues` — must be byte-for-byte the old behaviour;
- removing a chart from `chartValues` entirely — deletion must still delete, not null;
- editing a non-`chartValues` field alongside a null in one edit;
- an etcd snapshot restore, which exercises `ClusterSpecAnnotation` on the same object.

### Automated Testing

* Test types added/modified:
    * Unit
* Summary: `template_test.go` — `TestRKEControlPlaneChartValuesNulls` asserts
  `rkeControlPlane()` carries chart values through verbatim, including an explicit null,
  across nil / empty / populated / null-bearing inputs. It compares the **marshalled**
  form, because a null member and an absent one are indistinguishable once decoded into a
  map. This pins the hop before the one that was broken, so a future template regression
  is not mistaken for the patching bug.

  The patch-translation logic itself is covered by unit tests in the wrangler PR.

  Not covered by unit tests: that the apiserver preserves a null written via
  `JSONPatchType` into a preserve-unknown-fields subtree. That needs the manual testing
  above.

## QA Testing Considerations

- **Fresh install** — the first write of an `RKEControlPlane` is a create (full-body
  POST), which was never affected. The bug and the fix only appear on **subsequent
  edits**, so QA must edit `chartValues` on an already-provisioned cluster.
- **Upgrade** — clusters provisioned before this change have an `RKEControlPlane` missing
  any null the user previously tried to set. Confirm the next reconcile converges it, and
  that clusters with no nulls do not churn.
- Cover UI-managed charts (CNI, ingress) specifically — those have no workaround
  available, and are the reason this is customer-impacting.

### Regressions Considerations

The blast radius is narrow by construction: the opt-in is per GVK, so only
`RKEControlPlane` writes take the new path and every other consumer of the shared
`clients.Apply` is untouched. Within that GVK, the translated JSON Patch is intended to be
equivalent to the merge patch for objects containing no nulls.

Higher-risk areas, roughly in order:

1. **`RKEControlPlane` writes generally.** The translation applies to the whole object,
   not just `chartValues`, so a bug in it affects the entire spec. *Low probability, high
   impact.* Mitigated by the wrangler unit tests and by the no-nulls equivalence case.
2. **Deletion turning into assignment.** The translation has to read a null in the merge
   patch as a removal when the key is absent from the desired object. Getting that
   backwards would leave removed keys behind as explicit nulls. *Low probability, moderate
   impact.* Covered by the "null for a key absent from modified is a removal" test.
3. **`DryRun` divergence.** `createPlan` short-circuits on `"[]"` as well as `"{}"` now,
   but plan output for this GVK is a JSON Patch rather than a merge patch — anything
   parsing it must cope. *Certain, low impact.*

Existing / newly added automated tests that provide evidence there are no regressions:
* `pkg/controllers/provisioningv2/provisioningcluster/template_test.go` —
  `TestRKEControlPlaneChartValuesNulls`
* wrangler `pkg/patch/jsonpatch_test.go`, `pkg/apply/desiredset_compare_test.go` —
  `TestApplyPatchNullSafe`, `TestSanitizePatchJSONPatch`

## Workaround for affected users

Define the `HelmChartConfig` directly via Additional Manifests instead of
`spec.rkeConfig.chartValues`. Not applicable to UI-managed charts such as the CNI or
ingress controller.